### PR TITLE
Add installation instructions using winget for Windows

### DIFF
--- a/runtime/manual/getting_started/installation.md
+++ b/runtime/manual/getting_started/installation.md
@@ -23,10 +23,10 @@ Using PowerShell (Windows):
 irm https://deno.land/install.ps1 | iex
 ```
 
-Using [Winget](https://winget.run) (Windows):
+Using [Winget](https://github.com/microsoft/winget-cli) (Windows):
 
 ```shell
-winget install --id DenoLand.Deno -e
+winget install deno
 ```
 
 Using [Scoop](https://scoop.sh/) (Windows):
@@ -104,10 +104,10 @@ To update a previously installed version of Deno, you can run:
 deno upgrade
 ```
 
-Or using [Winget](https://winget.run) (Windows):
+Or using [Winget](https://github.com/microsoft/winget-cli) (Windows):
 
 ```shell
-winget upgrade --id DenoLand.Deno -e
+winget upgrade deno
 ```
 
 This will fetch the latest release from

--- a/runtime/manual/getting_started/installation.md
+++ b/runtime/manual/getting_started/installation.md
@@ -23,6 +23,12 @@ Using PowerShell (Windows):
 irm https://deno.land/install.ps1 | iex
 ```
 
+Using [Winget](https://winget.run) (Windows):
+
+```shell
+winget install --id DenoLand.Deno -e
+```
+
 Using [Scoop](https://scoop.sh/) (Windows):
 
 ```shell
@@ -96,6 +102,12 @@ To update a previously installed version of Deno, you can run:
 
 ```shell
 deno upgrade
+```
+
+Or using [Winget](https://winget.run) (Windows):
+
+```shell
+winget upgrade --id DenoLand.Deno -e
 ```
 
 This will fetch the latest release from


### PR DESCRIPTION
- Reverts #63.
- https://winget.run does not seem to be involved with Microsoft or the [`winget` cli](https://github.com/microsoft/winget-cli).
- [winget's deno versions are current](https://github.com/microsoft/winget-pkgs/tree/master/manifests/d/DenoLand/Deno)
<img width="400" alt="image" src="https://github.com/denoland/deno-docs/assets/69170106/ece32a52-88d3-4213-8fc2-27a3e77e3eb7">
<img width="696" alt="image" src="https://github.com/denoland/deno-docs/assets/69170106/08d2b71e-8f94-4c01-bd33-75565804e853">