### PR TITLE
Revert "Remove winget - out of date (#63)"

### DIFF
--- a/runtime/manual/getting_started/installation.md
+++ b/runtime/manual/getting_started/installation.md
@@ -23,6 +23,12 @@ Using PowerShell (Windows):
 irm https://deno.land/install.ps1 | iex
 ```
 
+Using [Winget](https://winget.run) (Windows):
+
+```shell
+winget install --id DenoLand.Deno -e
+```
+
 Using [Scoop](https://scoop.sh/) (Windows):
 
 ```shell
@@ -96,6 +102,12 @@ To update a previously installed version of Deno, you can run:
 
 ```shell
 deno upgrade
+```
+
+Or using [Winget](https://winget.run) (Windows):
+
+```shell
+winget upgrade --id DenoLand.Deno -e
 ```
 
 This will fetch the latest release from


### PR DESCRIPTION
WinGet Deno package looks up to date. See https://github.com/microsoft/winget-pkgs/pulls?q=is%3Apr+deno or https://winstall.app/apps/DenoLand.Deno.

Note: The page https://winget.run/pkg/DenoLand/Deno is a 3rd party registry viewer, which apparently has bug or some issue on updating the package versions.