### PR TITLE
Add manual commit history

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,9 @@
 MIT License
 
-Copyright 2023 the Deno Authors
+Copyright (c) 2018-2023 the Deno authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the “Software”), to deal in
+this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to
 use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 the Software, and to permit persons to whom the Software is furnished to do so,
@@ -12,7 +12,7 @@ subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
 FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER

--- a/README.md
+++ b/README.md
@@ -199,6 +199,18 @@ succeeds without error before submitting a pull request. This will ensure that
 there are no broken links or invalid MDX syntax in the content you have
 authored.
 
+## Special thanks for historical contributions
+
+This repository was created using content from the
+[Deno Manual](https://github.com/denoland/manual), a project contributed to by
+hundreds of developers since 2018. You can view a list of historical
+contributors to the Deno documentation in this repository and the manual with
+this command:
+
+```
+git shortlog -s -n
+```
+
 ## Deployment
 
 The `docs.deno.com` site is updated with every push to the `main` branch, which


### PR DESCRIPTION
This should integrate git history from the original Deno manual to the repository. Running:

```
git shortlog -s -n
```

Should now correctly list historical contributors.