### PR TITLE
update: workers now work in compiled executables

### DIFF
--- a/runtime/manual/runtime/workers.md
+++ b/runtime/manual/runtime/workers.md
@@ -9,8 +9,6 @@ is run on a separate thread, dedicated only to that worker.
 Currently Deno supports only `module` type workers; thus it's essential to pass
 the `type: "module"` option when creating a new worker.
 
-Workers currently do not work in [compiled executables](../tools/compiler.md).
-
 Use of relative module specifiers in the main worker are only supported with
 `--location <href>` passed on the CLI. This is not recommended for portability.
 You can instead use the `URL` constructor and `import.meta.url` to easily create


### PR DESCRIPTION
https://discord.com/channels/684898665143206084/1151939558548709486/1151943237339197450
> Andreu Botella (they/them)
 — 
14/09/2023 15:11
it used to be that you couldn't use workers, but now you can if you pass the `--include` flag with the worker scripts you will use
I guess the documentation is stale on that