### PR TITLE
fix(example): update twind to 1.1.3

### DIFF
--- a/runtime/manual/advanced/jsx_dom/twind.md
+++ b/runtime/manual/advanced/jsx_dom/twind.md
@@ -1,6 +1,6 @@
 # Using Twind with Deno
 
-[Twind](https://twind.dev/) is a _tailwind-in-js_ solution for using
+[Twind](https://twind.style/) is a _tailwind-in-js_ solution for using
 [Tailwind](https://tailwindcss.com/). Twind is particularly useful in Deno's
 server context, where Tailwind and CSS can be easily server side rendered,
 generating dynamic, performant and efficient CSS while having the usability of
@@ -9,54 +9,54 @@ styling with Tailwind.
 ## Basic example
 
 In the following example, we will use twind to server side render an HTML page
-and log it to the console. It demonstrates using the `tw` function to specify
-grouped tailwind classes and have it rendered using only the styles specified in
-the document and no client side JavaScript to accomplish the _tailwind-in-js_:
+and log it to the console. It demonstrates using grouped tailwind classes and
+have it rendered using only the styles specified in the document and no client
+side JavaScript to accomplish the _tailwind-in-js_:
 
 ```ts
-import { setup, tw } from "https://esm.sh/twind@0.16.16";
-import { getStyleTag, virtualSheet } from "https://esm.sh/twind@0.16.16/sheets";
+import { extract, install } from "https://esm.sh/@twind/core@1.1.3";
+import presetTailwind from "https://esm.sh/@twind/preset-tailwind@1.1.4";
 
-const sheet = virtualSheet();
-
-setup({
-  theme: {
-    fontFamily: {
-      sans: ["Helvetica", "sans-serif"],
-      serif: ["Times", "serif"],
+install({
+  presets: [
+    presetTailwind(),
+    {
+      theme: {
+        fontFamily: {
+          sans: ["Helvetica", "sans-serif"],
+          serif: ["Times", "serif"],
+        },
+      },
     },
-  },
-  sheet,
+  ],
 });
 
 function renderBody() {
-  return `
-    <h1 class="${tw`text(3xl blue-500)`}">Hello from Deno</h1>
-    <form>
-      <input name="user">
-      <button class="${tw`text(2xl red-500)`}">
-        Submit
-      </button>
-    </form>
-  `;
-}
-
-function ssr() {
-  sheet.reset();
-  const body = renderBody();
-  const styleTag = getStyleTag(sheet);
-
   return `<!DOCTYPE html>
     <html lang="en">
       <head>
         <title>Hello from Deno</title>
-        ${styleTag}
       </head>
-      <body>
-        ${body}
+      <body class="font-sans">
+        <h1 class="text(3xl blue-500)">Hello from Deno</h1>
+        <form>
+          <input name="user">
+          <button class="text(2xl red-500)">
+            Submit
+          </button>
+        </form>
       </body>
-    </html>`;
+    </html>
+  `;
+}
+
+function ssr() {
+  const body = renderBody();
+  const { html, css } = extract(body);
+  return html.replace("</head>", `<style data-twind>${css}</style></head>`);
 }
 
 console.log(ssr());
 ```
+
+https://twind.style/packages/@twind/core#extract


### PR DESCRIPTION
Closes #89 

This PR updates twind version to `1.1.3`.

The example code is based on [extract function in @twind/core](https://twind.style/packages/@twind/core#extract).
I adjusted the code so that the HTML looks the same as before.

<img width="317" alt="image" src="https://github.com/denoland/deno-docs/assets/3132889/e9f30a55-3b49-458b-ae48-c30badd1b4e7">
