### PR TITLE
Extend code blocks to edge of mobile viewport

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -297,3 +297,10 @@ h3 {
   word-break: break-all;
   word-wrap: break-word;
 }
+
+@media (max-width: 36rem) {
+	.markdown > div[class*="codeBlockContainer"] {
+		margin-inline: -1rem;
+		border-radius: 0;
+	}
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -299,8 +299,8 @@ h3 {
 }
 
 @media (max-width: 36rem) {
-	.markdown > div[class*="codeBlockContainer"] {
-		margin-inline: -1rem;
-		border-radius: 0;
-	}
+  .markdown > div[class*="codeBlockContainer"] {
+    margin-inline: calc(var(--ifm-global-spacing) * -1);
+    border-radius: 0;
+  }
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -299,8 +299,14 @@ h3 {
 }
 
 @media (max-width: 36rem) {
-  .markdown > div[class*="codeBlockContainer"] {
+  .markdown > div[class*="codeBlockContainer"],
+  .markdown > .tabs-container div[class*="codeBlockContainer"] {
     margin-inline: calc(var(--ifm-global-spacing) * -1);
     border-radius: 0;
+  }
+
+  .markdown > .tabs-container {
+    margin-inline: calc(var(--ifm-global-spacing) * -1);
+    padding-inline: var(--ifm-global-spacing);
   }
 }


### PR DESCRIPTION
Closes https://github.com/denoland/deno-docs/issues/28

A quick and simple fix to make code blocks extend to the edge of mobile viewports. (Also removes the rounded corners on mobile, since it looks weird to round into the edges.)


<img width="389" alt="CleanShot 2023-09-26 at 14 53 26@2x" src="https://github.com/denoland/deno-docs/assets/22334764/a138cb79-28f6-4c1a-a899-c819eee40268">

<img width="706" alt="CleanShot 2023-09-26 at 14 52 55@2x" src="https://github.com/denoland/deno-docs/assets/22334764/207e1910-567f-44a8-af15-d97bb2639c87">

