### PR TITLE
fix: wrong `dgram` compatibility info

### DIFF
--- a/runtime/manual/node/compatibility.mdx
+++ b/runtime/manual/node/compatibility.mdx
@@ -144,7 +144,8 @@ which modules you need by
     </div>
   </summary>
   <p>
-    Missing <code>dgram.Socket</code> instance methods:
+    Much of the dgram module internals is yet to be implemented.
+    Some <code>dgram.Socket</code> instance methods is non-functional stubs:
     <ul>
         <li><code>addMembership</code></li>
         <li><code>addSourceSpecificMembership</code></li>

--- a/runtime/manual/node/compatibility.mdx
+++ b/runtime/manual/node/compatibility.mdx
@@ -140,11 +140,24 @@ which modules you need by
   <summary>
     <code>node:dgram</code>
     <div style={{ float: "right" }}>
-      <span>✅</span>
+      <span>ℹ️</span>
     </div>
   </summary>
   <p>
-    Fully supported.
+    Missing <code>dgram.Socket</code> instance methods:
+    <ul>
+        <li><code>addMembership</code></li>
+        <li><code>addSourceSpecificMembership</code></li>
+        <li><code>dropMembership</code></li>
+        <li><code>dropSourceSpecificMembership</code></li>
+        <li><code>setBroadcast</code></li>
+        <li><code>setMulticastInterface</code></li>
+        <li><code>setMulticastLoopback</code></li>
+        <li><code>setMulticastTtl</code></li>
+        <li><code>setTtl</code></li>
+        <li><code>ref</code></li>
+        <li><code>unref</code></li>
+    </ul>
   </p>
   <p>
     <a href="https://nodejs.org/api/dgram.html">Node.js docs</a>

--- a/runtime/manual/node/compatibility.mdx
+++ b/runtime/manual/node/compatibility.mdx
@@ -144,8 +144,7 @@ which modules you need by
     </div>
   </summary>
   <p>
-    Much of the dgram module internals is yet to be implemented.
-    Some <code>dgram.Socket</code> instance methods is non-functional stubs:
+    Some <code>dgram.Socket</code> instance methods are non-functional stubs:
     <ul>
         <li><code>addMembership</code></li>
         <li><code>addSourceSpecificMembership</code></li>


### PR DESCRIPTION
That PR fix wrong compatibility info about `node:dgram`. In fact, the realization is quite partial and most popular libraries using `dgram` not working in Deno.
Proof: https://github.com/denoland/deno/issues/18324#issuecomment-1478034481
Some issues with `dgram`: https://github.com/denoland/deno/issues?q=dgram