### PR TITLE
Customize docs breadcrumbs

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -99,11 +99,6 @@ h3 {
   padding: 60px 0;
 }
 
-/* Hide breadcrumbs */
-.theme-doc-breadcrumbs {
-  display: none;
-}
-
 .theme-doc-sidebar-container {
   position: relative;
 }
@@ -309,4 +304,21 @@ h3 {
     margin-inline: calc(var(--ifm-global-spacing) * -1);
     padding-inline: var(--ifm-global-spacing);
   }
+}
+
+.breadcrumbs__item:first-child > a {
+	padding-left: 0;
+}
+
+.breadcrumbs__item a {
+	text-decoration: underline;
+}
+
+.breadcrumbs__item:not(:last-child):after {
+	margin-inline: 0;
+}
+
+.breadcrumbs__item--active .breadcrumbs__link {
+	background: transparent;
+	color: inherit;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -314,6 +314,10 @@ h3 {
 	text-decoration: underline;
 }
 
+.breadcrumbs__link {
+	background-color: transparent !important;
+}
+
 .breadcrumbs__item:not(:last-child):after {
 	margin-inline: 0;
 }

--- a/src/theme/DocBreadcrumbs/Items/Home/index.js
+++ b/src/theme/DocBreadcrumbs/Items/Home/index.js
@@ -8,17 +8,17 @@ export default function HomeBreadcrumbItem() {
   const getDocsLocation = () => {
     if (currentPath.startsWith("/deploy")) {
       return {
-        href: "/deploy",
+        href: "/deploy/manual",
         name: "Deploy",
       }
     } else if (currentPath.startsWith("/kv")) {
       return {
-        href: "/kv",
+        href: "/kv/manual",
         name: "KV",
       }
     } else if (currentPath.startsWith("/runtime")) {
       return {
-        href: "/runtime",
+        href: "/runtime/manual",
         name: "Runtime",
       }
     }
@@ -26,7 +26,7 @@ export default function HomeBreadcrumbItem() {
       href: "/",
       name: "All docs"
     }
-  }
+  };
 
   const {href, name} = getDocsLocation()
   return (

--- a/src/theme/DocBreadcrumbs/Items/Home/index.js
+++ b/src/theme/DocBreadcrumbs/Items/Home/index.js
@@ -1,0 +1,43 @@
+import React from "react";
+import Link from "@docusaurus/Link";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import {translate} from "@docusaurus/Translate";
+import {useLocation} from "@docusaurus/router";
+
+export default function HomeBreadcrumbItem() {
+  const homeHref = useBaseUrl("/");
+
+  const getDocsLocation = () => {
+    if (useLocation().pathname.startsWith("/deploy")) {
+      return {
+        href: "/deploy",
+        name: "Deploy",
+      }
+    } else if (useLocation().pathname.startsWith("/kv")) {
+      return {
+        href: "/kv",
+        name: "KV",
+      }
+    }
+    return {
+      href: "/runtime",
+      name: "Runtime",
+    }
+  }
+
+	const {href, name} = getDocsLocation()
+  return (
+    <li className="breadcrumbs__item">
+      <Link
+        aria-label={translate({
+          id: 'theme.docs.breadcrumbs.home',
+          message: 'Home page',
+          description: 'The ARIA label for the home page in the breadcrumbs',
+        })}
+        className="breadcrumbs__link"
+        href={href}>
+        {name}
+      </Link>
+    </li>
+  );
+}

--- a/src/theme/DocBreadcrumbs/Items/Home/index.js
+++ b/src/theme/DocBreadcrumbs/Items/Home/index.js
@@ -1,31 +1,34 @@
 import React from "react";
 import Link from "@docusaurus/Link";
-import useBaseUrl from "@docusaurus/useBaseUrl";
 import {translate} from "@docusaurus/Translate";
 import {useLocation} from "@docusaurus/router";
 
 export default function HomeBreadcrumbItem() {
-  const homeHref = useBaseUrl("/");
-
+  const currentPath = useLocation().pathname
   const getDocsLocation = () => {
-    if (useLocation().pathname.startsWith("/deploy")) {
+    if (currentPath.startsWith("/deploy")) {
       return {
         href: "/deploy",
         name: "Deploy",
       }
-    } else if (useLocation().pathname.startsWith("/kv")) {
+    } else if (currentPath.startsWith("/kv")) {
       return {
         href: "/kv",
         name: "KV",
       }
+    } else if (currentPath.startsWith("/runtime")) {
+      return {
+        href: "/runtime",
+        name: "Runtime",
+      }
     }
     return {
-      href: "/runtime",
-      name: "Runtime",
+      href: "/",
+      name: "All docs"
     }
   }
 
-	const {href, name} = getDocsLocation()
+  const {href, name} = getDocsLocation()
   return (
     <li className="breadcrumbs__item">
       <Link

--- a/src/theme/DocBreadcrumbs/index.js
+++ b/src/theme/DocBreadcrumbs/index.js
@@ -1,0 +1,93 @@
+import React from "react";
+import clsx from "clsx";
+import {ThemeClassNames} from "@docusaurus/theme-common";
+
+
+import {
+  useSidebarBreadcrumbs,
+  useHomePageRoute,
+} from "@docusaurus/theme-common/internal";
+import Link from "@docusaurus/Link";
+import {translate} from "@docusaurus/Translate";
+import HomeBreadcrumbItem from "@theme/DocBreadcrumbs/Items/Home";
+import styles from "./styles.module.css";
+// TODO move to design system folder
+function BreadcrumbsItemLink({children, href, isLast}) {
+  const className = "breadcrumbs__link";
+  if (isLast) {
+    return (
+      <span className={className} itemProp="name">
+        {children}
+      </span>
+    );
+  }
+  return href ? (
+    <Link className={className} href={href} itemProp="item">
+      <span itemProp="name">{children}link</span>
+    </Link>
+  ) : (
+    // TODO Google search console doesn't like breadcrumb items without href.
+    // The schema doesn't seem to require `id` for each `item`, although Google
+    // insist to infer one, even if it's invalid. Removing `itemProp="item
+    // name"` for now, since I don't know how to properly fix it.
+    // See https://github.com/facebook/docusaurus/issues/7241
+    <span className={className}itemProp="itemname">{children}</span>
+  );
+}
+// TODO move to design system folder
+function BreadcrumbsItem({children, active, index, addMicrodata}) {
+  return (
+    <li
+      {...(addMicrodata && {
+        itemScope: true,
+        itemProp: "itemListElement",
+        itemType: "https://schema.org/ListItem",
+      })}
+      className={clsx("breadcrumbs__item", {
+        "breadcrumbs__item--active": active,
+      })}>
+      {children}
+      <meta itemProp="position" content={String(index + 1)} />
+    </li>
+  );
+}
+export default function DocBreadcrumbs() {
+  const breadcrumbs = useSidebarBreadcrumbs();
+  const homePageRoute = useHomePageRoute();
+  if (!breadcrumbs?.length) {
+    return null;
+  }
+  return (
+    <nav
+      className={clsx(
+        ThemeClassNames.docs.docBreadcrumbs,
+        styles.breadcrumbsContainer,
+      )}
+      aria-label={translate({
+        id: "theme.docs.breadcrumbs.navAriaLabel",
+        message: "Breadcrumbs",
+        description: "The ARIA label for the breadcrumbs",
+      })}>
+      <ul
+        className="breadcrumbs"
+        itemScope
+        itemType="https://schema.org/BreadcrumbList">
+        {homePageRoute && <HomeBreadcrumbItem />}
+        {breadcrumbs.map((item, idx) => {
+          const isLast = idx === breadcrumbs.length - 1;
+          return (
+            <BreadcrumbsItem
+              key={idx}
+              active={isLast}
+              index={idx}
+              addMicrodata={!!item.href}>
+              <BreadcrumbsItemLink href={item.href} isLast={isLast}>
+                {item.label}
+              </BreadcrumbsItemLink>
+            </BreadcrumbsItem>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/theme/DocBreadcrumbs/index.js
+++ b/src/theme/DocBreadcrumbs/index.js
@@ -1,8 +1,6 @@
 import React from "react";
 import clsx from "clsx";
 import {ThemeClassNames} from "@docusaurus/theme-common";
-
-
 import {
   useSidebarBreadcrumbs,
   useHomePageRoute,

--- a/src/theme/DocBreadcrumbs/styles.module.css
+++ b/src/theme/DocBreadcrumbs/styles.module.css
@@ -1,0 +1,5 @@
+/* This file is required by the theme */
+.breadcrumbsContainer {
+  --ifm-breadcrumb-size-multiplier: 0.8;
+  margin-bottom: 0.8rem;
+}


### PR DESCRIPTION
- Shows breadcrumbs at all times (unless the user is on a landing page and hasn't begun to navigate any deeper yet)
- Changes the "home" link in the docs to go to the current section's home (`/kv`, `/runtime`, or `/deploy`, as the case may be)
- Slightly modifies styling of breadcrumbs

<img width="1015" alt="image" src="https://github.com/denoland/deno-docs/assets/22334764/e918699f-5799-4f36-af00-cd56f7dc3637">

<img width="412" alt="CleanShot 2023-09-29 at 10 58 03@2x" src="https://github.com/denoland/deno-docs/assets/22334764/19ecfa6a-2ec5-4505-9770-ef5a05111b3f">

