### PR TITLE
docs: fix a command to work properly

### DIFF
--- a/runtime/manual/tools/script_installer.md
+++ b/runtime/manual/tools/script_installer.md
@@ -56,7 +56,7 @@ You must specify permissions that will be used to run the script at installation
 time.
 
 ```shell
-deno install --allow-net --allow-read https://deno.land/std/http/file_server.ts -p 8080
+deno install --allow-net --allow-read https://deno.land/std/http/file_server.ts -- -p 8080
 ```
 
 The above command creates an executable called `file_server` that runs with


### PR DESCRIPTION
I just fixed the sample command to work properly.

The prior command:
```bash
deno install --allow-net --allow-read https://deno.land/std/http/file_server.ts -f -p 8080
error: unexpected argument '-p' found

  tip: to pass '-p' as a value, use '-- -p'

Usage: deno install [OPTIONS] <cmd>...

For more information, try '--help'.
```

The updated command:
```bash
deno install --allow-net --allow-read https://deno.land/std/http/file_server.ts -f -- -p 8080
✅ Successfully installed file_server
/Users/motoyakondo/.deno/bin/file_server
```