### PR TITLE
docs: fix link to Chromium inclusive code guide

### DIFF
--- a/runtime/manual/references/contributing/style_guide.md
+++ b/runtime/manual/references/contributing/style_guide.md
@@ -45,7 +45,7 @@ the vast majority of cases it does not.
 ## Inclusive code
 
 Please follow the guidelines for inclusive code outlined at
-https://chromium.googlesource.com/chromium/src/+/master/stylemanual/inclusive_code.md.
+https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/inclusive_code.md.
 
 ## Rust
 


### PR DESCRIPTION
The current link returns a `404`.