### PR TITLE
fix: update broken fair use policy link

### DIFF
--- a/deploy/manual/pricing-and-limits.md
+++ b/deploy/manual/pricing-and-limits.md
@@ -6,14 +6,14 @@ exceeds any of these limits, [please reach out](mailto:deploy@deno.com).
 
 No uptime guarantees are provided during the initial public beta for Deno
 Deploy. Access to the service will be controlled by
-[our fair use policy](https://www.deno.com/deploy/fair-use-policy). Any user we
-deem to be in violation of this policy, runs the risk of having their account
-terminated.
+[our fair use policy](https://docs.deno.com/deploy/manual/fair-use-policy). Any
+user we deem to be in violation of this policy, runs the risk of having their
+account terminated.
 
 ## Maximum size for deployments
 
 When uploading assets to a deployment, the total size of all files within the
-deployment (source files and static files) __should not exceed 1 gigabyte__.
+deployment (source files and static files) **should not exceed 1 gigabyte**.
 
 ## TLS proxying
 


### PR DESCRIPTION
Make https://docs.deno.com/deploy/manual/pricing-and-limits link to https://docs.deno.com/deploy/manual/fair-use-policy. 
