### PR TITLE
Update node:util compatibility info

### DIFF
--- a/runtime/manual/node/compatibility.mdx
+++ b/runtime/manual/node/compatibility.mdx
@@ -594,11 +594,11 @@ which modules you need by
   <summary>
     <code>node:util</code>
     <div style={{ float: "right" }}>
-      <span>✅</span>
+      <span>ℹ️</span>
     </div>
   </summary>
   <p>
-    Fully supported.
+    Missing <code>aborted</code>, <code>transferableAbortSignal</code>, <code>transferableAbortController</code>, <code>MIMEParams</code>, <code>MIMEType</code>, <code>getSystemErrorMap</code>, and <code>debug</code>.
   </p>
   <p>
     <a href="https://nodejs.org/api/util.html">Node.js docs</a>


### PR DESCRIPTION
I compared the latest Node.js docs and the latest Deno runtime, and these APIs seemed still missing.

I opened the corresponding issue in Deno CLI repo. https://github.com/denoland/deno/issues/21378

closes #205 