### PR TITLE
add trackjs integration for client-side errors

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,6 +15,11 @@ const config = {
     defaultLocale: "en",
     locales: ["en"],
   },
+
+  clientModules: [
+    "./src/client_plugins/trackjs.js",
+  ],
+
   presets: [
     [
       "classic",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,10 +16,6 @@ const config = {
     locales: ["en"],
   },
 
-  clientModules: [
-    "./src/client_plugins/trackjs.js",
-  ],
-
   presets: [
     [
       "classic",

--- a/src/client_plugins/trackjs.js
+++ b/src/client_plugins/trackjs.js
@@ -1,8 +1,0 @@
-const init = setInterval(() => {
-  if (window.TrackJS) {
-    TrackJS.install({
-      token: "abb73baafbd94b74878a59fc03e5ac1b",
-    });
-    clearInterval(init);
-  }
-}, 100);

--- a/src/client_plugins/trackjs.js
+++ b/src/client_plugins/trackjs.js
@@ -1,0 +1,8 @@
+const init = setInterval(() => {
+  if (window.TrackJS) {
+    TrackJS.install({
+      token: "abb73baafbd94b74878a59fc03e5ac1b",
+    });
+    clearInterval(init);
+  }
+}, 100);

--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -25,10 +25,6 @@ export default function Layout(props) {
   } = props;
   useKeyboardNavigation();
 
-  window.TrackJS && TrackJS.install({ 
-    token: "abb73baafbd94b74878a59fc03e5ac1b"
-  });
-
   return (
     <LayoutProvider>
       <Head>

--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -11,7 +11,6 @@ import {useKeyboardNavigation} from '@docusaurus/theme-common/internal';
 import SkipToContent from '@theme/SkipToContent';
 import AnnouncementBar from '@theme/AnnouncementBar';
 import Navbar from '@theme/Navbar';
-import Footer from '@theme/Footer';
 import LayoutProvider from '@theme/Layout/Provider';
 import ErrorPageContent from '@theme/ErrorPageContent';
 import styles from './styles.module.css';
@@ -25,6 +24,11 @@ export default function Layout(props) {
     description,
   } = props;
   useKeyboardNavigation();
+
+  window.TrackJS && TrackJS.install({ 
+    token: "abb73baafbd94b74878a59fc03e5ac1b"
+  });
+
   return (
     <LayoutProvider>
       <Head>
@@ -44,6 +48,7 @@ export default function Layout(props) {
         />
         <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
         <link rel="stylesheet" href="/fonts/inter.css" />
+        <script src="https://cdn.trackjs.com/agent/v3/latest/t.js"></script>
       </Head>
       <PageMetadata title={title} description={description} />
 

--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -24,7 +24,6 @@ export default function Layout(props) {
     description,
   } = props;
   useKeyboardNavigation();
-
   return (
     <LayoutProvider>
       <Head>
@@ -43,9 +42,11 @@ export default function Layout(props) {
           crossOrigin="true"
         />
         <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
+        <script src="/trackjs.js"></script>
+        <script src="https://cdn.trackjs.com/releases/current/tracker.js"></script>
         <link rel="stylesheet" href="/fonts/inter.css" />
-        <script src="https://cdn.trackjs.com/agent/v3/latest/t.js"></script>
       </Head>
+
       <PageMetadata title={title} description={description} />
 
       <SkipToContent />

--- a/static/trackjs.js
+++ b/static/trackjs.js
@@ -1,0 +1,3 @@
+window._trackJs = {
+  token: "abb73baafbd94b74878a59fc03e5ac1b",
+};


### PR DESCRIPTION
Add client side error tracking - primary target right now is to isolate the errors with syntax highlighting that are happening intermittently.