### PR TITLE
Add link to install necessary tools for contributing

### DIFF
--- a/runtime/manual/references/contributing/index.md
+++ b/runtime/manual/references/contributing/index.md
@@ -32,6 +32,9 @@ While iterating on such modules it is recommended to include
 development mode where the JS/TS sources are not included in the binary but read
 at runtime, meaning the binary will not have to be rebuilt if they are changed.
 
+> To use the commands below, you need to first install the necessary tools on
+> your system as described [here](building_from_source).
+
 ```sh
 # cargo build
 cargo build --features __runtime_js_sources
@@ -149,6 +152,9 @@ Examples of bad PR title:
 ## Submitting a PR to [`deno`](https://github.com/denoland/deno)
 
 In addition to the above make sure that:
+
+> To use the commands below, you need to first install the necessary tools on
+> your system as described [here](building_from_source).
 
 1. `cargo test` passes - this will run full test suite for `deno` including unit
    tests, integration tests and Web Platform Tests


### PR DESCRIPTION
As a beginner, I didn't even know I needed `--recurse-submodules` to clone project and to install many tools before running `cargo test`. This prompt can prevent beginners like me from feeling discouraged right from the start.

This may related to issue: https://github.com/denoland/deno/issues/21652