### PR TITLE
Remove `npm:` prefix on unstable-byonm example

### DIFF
--- a/runtime/manual/tools/unstable_flags.md
+++ b/runtime/manual/tools/unstable_flags.md
@@ -98,7 +98,7 @@ npm install
 Afterward, you could write code in a Deno program that looks like this:
 
 ```ts title="example.ts"
-import cowsay from "npm:cowsay";
+import cowsay from "cowsay";
 
 console.log(cowsay.say({
   text: "Hello from Deno using BYONM!",


### PR DESCRIPTION
It being there might give the impression it's required, but it can work exactly like as in Node.