### PR TITLE
Use shortened URL for install.sh

### DIFF
--- a/deploy/manual/index.mdx
+++ b/deploy/manual/index.mdx
@@ -53,7 +53,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
   <TabItem value="mac" label="macOS" default>
 
 ```sh
-curl -fsSL https://deno.land/x/install/install.sh | sh
+curl -fsSL https://deno.land/install.sh | sh
 ```
 
 </TabItem>
@@ -67,7 +67,7 @@ irm https://deno.land/install.ps1 | iex
   <TabItem value="linux" label="Linux">
 
 ```sh
-curl -fsSL https://deno.land/x/install/install.sh | sh
+curl -fsSL https://deno.land/install.sh | sh
 ```
 
 </TabItem>

--- a/runtime/manual/getting_started/installation.md
+++ b/runtime/manual/getting_started/installation.md
@@ -17,7 +17,7 @@ import Tabs from '@theme/Tabs'; import TabItem from '@theme/TabItem';
 Using Shell:
 
 ```shell
-curl -fsSL https://deno.land/x/install/install.sh | sh
+curl -fsSL https://deno.land/install.sh | sh
 ```
 
 Using [Homebrew](https://formulae.brew.sh/formula/deno):
@@ -83,7 +83,7 @@ winget install deno
 Using Shell:
 
 ```shell
-curl -fsSL https://deno.land/x/install/install.sh | sh
+curl -fsSL https://deno.land/install.sh | sh
 ```
 
 Using [Nix](https://nixos.org/download.html):

--- a/runtime/manual/index.md
+++ b/runtime/manual/index.md
@@ -27,7 +27,7 @@ below.
   <TabItem value="mac" label="macOS" default>
 
 ```sh
-curl -fsSL https://deno.land/x/install/install.sh | sh
+curl -fsSL https://deno.land/install.sh | sh
 ```
 
 </TabItem>
@@ -41,7 +41,7 @@ irm https://deno.land/install.ps1 | iex
   <TabItem value="linux" label="Linux">
 
 ```sh
-curl -fsSL https://deno.land/x/install/install.sh | sh
+curl -fsSL https://deno.land/install.sh | sh
 ```
 
 </TabItem>


### PR DESCRIPTION
The URL of installation uses `https://deno.land/install.ps1` for `.ps1` and `https://deno.land/x/install/install.sh` for `.sh`.
I think it's better if both URLs are of the same type.