### PR TITLE
Fix import statement in dynamodb tutorial

### DIFF
--- a/deploy/tutorials/tutorial-dynamodb.md
+++ b/deploy/tutorials/tutorial-dynamodb.md
@@ -94,7 +94,7 @@ import {
   DynamoDBClient,
   GetItemCommand,
   PutItemCommand,
-} from "https://cdn.skypack.dev/@aws-sdk/client-dynamodb?dts";
+} from "https://esm.sh/@aws-sdk/client-dynamodb";
 
 // Create a client instance by providing your region information.
 // The credentials are obtained from environment variables which


### PR DESCRIPTION
The dynamodb client served via skypack [has issues](https://github.com/denoland/deploy_feedback/issues/116). By updating the import to use the client served on esm.sh, the issues are resolved.