### PR TITLE
Unstyle search bar and make main docs button more clearly a back button

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,7 +7,7 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
+html:root {
   /* These variables mainly pulled from dotcom */
   --white: #ffffff;
   --black: #0b0d11;
@@ -71,6 +71,7 @@
   --ifm-tabs-padding-vertical: 0.5rem;
   --ifm-list-item-margin: 0.5em;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+  --docsearch-muted-color: var(--gray-1);
   --ifm-font-family-base: Inter, ui-sans-serif, system-ui, -apple-system,
     "system-ui", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans",
     sans-serif;
@@ -109,6 +110,14 @@ html[data-theme="dark"][data-theme="dark"] {
   --ifm-menu-color-background-active: var(--runtime-dark);
   --ifm-code-background: #282a36;
   --ifm-menu-color: var(--gray-0);
+  --docsearch-footer-background: var(--runtime-dark);
+  --docsearch-muted-color: var(--gray-0);
+}
+
+html[data-theme="dark"] kbd.DocSearch-Button-Key,
+html[data-theme="dark"] kbd.DocSearch-Commands-Key {
+  box-shadow: none;
+  color: var(--gray-0);
 }
 
 html,
@@ -163,6 +172,11 @@ h4 {
 
   text-wrap: balance;
   letter-spacing: -0.025em;
+}
+
+button,
+kbd {
+  font: inherit;
 }
 
 code {
@@ -459,4 +473,20 @@ nav.menu.thin-scrollbar.menu_node_modules-\@docusaurus-theme-classic-lib-theme-D
 .footer__copyright {
   font-size: 0.75rem;
   margin-top: 2rem;
+}
+
+.DocSearch-Button .DocSearch-Search-Icon {
+  width: 1rem;
+}
+
+kbd.DocSearch-Button-Key,
+kbd.DocSearch-Commands-Key {
+  box-shadow: none;
+  padding: 0;
+  border: 1px solid;
+  top: 0;
+  font-size: 0.8rem;
+  line-height: 1;
+  margin-right: 0.375em;
+  background: transparent;
 }

--- a/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.js
+++ b/src/theme/Navbar/MobileSidebar/SecondaryMenu/index.js
@@ -9,8 +9,9 @@ function SecondaryMenuBackButton(props) {
     <button
       type="button"
       {...props}
-      className="secondary-menu__product__button"
+      className="secondary-menu__product__button [font:inherit]"
     >
+			<span aria-hidden="true" className="inline-block transform rotate-180 [font-family:inherit]">&ensp;-&gt; </span>
       All docs
     </button>
   );


### PR DESCRIPTION
Let's get rid of this cheesy web 2.0 skeuomorphism stuff.

<img width="259" alt="image" src="https://github.com/denoland/deno-docs/assets/22334764/0f49bbe9-d71c-40e8-8a7f-974b39d38f54">

<img width="244" alt="image" src="https://github.com/denoland/deno-docs/assets/22334764/98811e0c-aa41-4995-8d0b-915f61a0c765">

<img width="1539" alt="image" src="https://github.com/denoland/deno-docs/assets/22334764/880f0527-b334-4099-a3f5-e54e9fb0235d">
<img width="1539" alt="image" src="https://github.com/denoland/deno-docs/assets/22334764/0d592d36-e92a-4607-8879-7880d8e5bc06">

Let's also add a back arrow to the "all docs" button.

![CleanShot 2024-01-12 at 14 22 18@2x](https://github.com/denoland/deno-docs/assets/22334764/b7475469-9037-402e-a5b7-8254cee107fe)
