### PR TITLE
Update building_from_source.md

### DIFF
--- a/runtime/manual/references/contributing/building_from_source.md
+++ b/runtime/manual/references/contributing/building_from_source.md
@@ -48,10 +48,12 @@ cargo -V
 > Many components of Deno require a native compiler to build optimized native
 > functions.
 
-**Linux**:
-
-```sh
-apt install --install-recommends -y clang-16 lld-16 cmake libglib2.0-dev
+**Linus/WSL**
+```shell
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+./llvm.sh 16
+apt install --install-recommends -y cmake libglib2.0-dev
 ```
 
 **Mac**:
@@ -76,13 +78,6 @@ brew install llvm
 # Add /opt/homebrew/opt/llvm/bin/ to $PATH
 ```
 
-**WSL**
-```shell
-wget https://apt.llvm.org/llvm.sh
-chmod +x llvm.sh
-./llvm.sh 16
-apt install --install-recommends -y cmake libglib2.0-dev
-```
 
 **Windows**:
 

--- a/runtime/manual/references/contributing/building_from_source.md
+++ b/runtime/manual/references/contributing/building_from_source.md
@@ -48,7 +48,7 @@ cargo -V
 > Many components of Deno require a native compiler to build optimized native
 > functions.
 
-**Linus/WSL**
+**Linux/WSL**
 ```shell
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh

--- a/runtime/manual/references/contributing/building_from_source.md
+++ b/runtime/manual/references/contributing/building_from_source.md
@@ -10,7 +10,7 @@ chapter).
 > Deno uses submodules, so you must remember to clone using
 > `--recurse-submodules`.
 
-**Linux**/**Mac**/**WSL**:
+**Linux(Debian)**/**Mac**/**WSL**:
 
 ```shell
 git clone --recurse-submodules https://github.com/denoland/deno.git
@@ -48,7 +48,7 @@ cargo -V
 > Many components of Deno require a native compiler to build optimized native
 > functions.
 
-**Linux/WSL**
+**Linux(Debian)/WSL**
 ```shell
 wget https://apt.llvm.org/llvm.sh
 chmod +x llvm.sh
@@ -108,7 +108,7 @@ brew install llvm
 > Building Deno requires the
 > [Protocol Buffers compiler](https://grpc.io/docs/protoc-installation/).
 
-**Linux**/**WSL**:
+**Linux(Debian)**/**WSL**:
 
 ```sh
 apt install -y protobuf-compiler


### PR DESCRIPTION
 clang-16 lld-16 is not found in Ubuntu 22.04 which is latest LTS version.
 Similar commands like WSL section works