### PR TITLE
`--unstable-kv` description incorrectly links to deno.cron

### DIFF
--- a/runtime/manual/tools/unstable_flags.md
+++ b/runtime/manual/tools/unstable_flags.md
@@ -205,7 +205,7 @@ on the `Deno` namespace.
 
 ## `--unstable-kv`
 
-Enabling this flag makes [Deno KV](/deploy/kv/manual/cron) APIs available in the
+Enabling this flag makes [Deno KV](/deploy/kv/manual) APIs available in the
 `Deno` namespace.
 
 ## `--unstable-ffi`


### PR DESCRIPTION
the description for [`--unstable-kv`](https://docs.deno.com/runtime/manual/tools/unstable_flags#--unstable-kv) links to [Deno.cron](https://docs.deno.com/deploy/kv/manual/cron) and not [deno KV](https://docs.deno.com/deploy/kv/manual/cron)