### PR TITLE
fix: syntax highlighting on workers example

### DIFF
--- a/runtime/manual/runtime/workers.md
+++ b/runtime/manual/runtime/workers.md
@@ -31,7 +31,7 @@ first `await`, since messages can be lost otherwise. This is not a bug in Deno,
 it's just an unfortunate interaction of features, and it also happens in all
 browsers that support module workers.
 
-```ts, ignore
+```ts
 import { delay } from "https://deno.land/std@$STD_VERSION/async/delay.ts";
 
 // First await: waits for a second, then continues running the module.
@@ -114,7 +114,7 @@ worker.postMessage({ filename: "./log.txt" });
 
 **worker.js**
 
-```js, ignore
+```js
 self.onmessage = async (e) => {
   const { filename } = e.data;
   const text = await Deno.readTextFile(filename);


### PR DESCRIPTION
Syntax highlighting on the [deno-docs site](https://docs.deno.com/runtime/manual/runtime/workers) for these two code blocks was missing. Not sure if the ignores were there on purpose


| Before | After |
| ------- | ----- |
| ![image](https://github.com/denoland/deno-docs/assets/22731314/2d562874-9a2f-4ad0-95b2-a48590c5a850)    | ![image](https://github.com/denoland/deno-docs/assets/22731314/4a10414b-fa0f-4ac5-a2bf-9f7e73802ecc)   |
|  ![image](https://github.com/denoland/deno-docs/assets/22731314/2ade75a6-7d28-40b7-b86d-659beb3a8cc5) | ![image](https://github.com/denoland/deno-docs/assets/22731314/be764ca9-f5ab-4047-8104-0a0975fef78c) |

The code blocks seem to work on github before these changes were made