### PR TITLE
Fix the issue of displaying Traditional Chinese when using Google Translate to Simplified Chinese in Mac

### DIFF
--- a/static/fonts/inter.css
+++ b/static/fonts/inter.css
@@ -31,5 +31,5 @@
 }
 
 :root {
-  font-feature-settings: "cv05" on, "cv08" on, "cv10" on, "ss01" on, "ss08" on;
+  font-feature-settings: "cv05" on, "cv08" on, "cv09" on, "ss01" on, "ss08" on;
 }


### PR DESCRIPTION
After my testing, I found that using `font-feature-settings: "cv10" on` when translating, it will cause simplified Chinese to be displayed as traditional Chinese. 

![image](https://github.com/denoland/deno-docs/assets/19886374/e3e6b114-bb48-4c5d-ad2f-6d391386c1c1)


It would be strange to use software such as Google Translate to translate web pages in full screen. 

Therefore, I have adjusted `cv10` to `cv09`, and I believe it will not have much impact.

