### PR TITLE
Explain how to test Deno KV code locally

### DIFF
--- a/deploy/kv/manual/index.mdx
+++ b/deploy/kv/manual/index.mdx
@@ -237,6 +237,45 @@ created by Apple.
 KV on Deploy - a new Deploy database will be provisioned for you when required
 by your code. Learn more about Deno KV on Deno Deploy [here](./on_deploy.mdx).
 
+## Testing
+
+By default, [`Deno.openKv()`](https://www.sqlite.org/inmemorydb.html) creates or
+opens a persistent store based on the path from which the script that invoked it
+was run. This isn't usually desireable for tests, which need to produce the same
+behavior when run many times in a row.
+
+To test code that uses Deno KV, you can use the special argument `":memory:"` to
+create an ephemeral Deno KV datastore.
+
+```ts
+async function setDisplayName(kv: Deno.Kv, username: string, displayname: string) {
+  await kv.set(["preferences", username, "displayname"], displayname);
+}
+
+async function getDisplayName(kv: Deno.Kv, username: string): Promise<string | null> {
+  return (await kv.get(["preferences", username, "displayname"])).value as string;
+}
+
+Deno.test("Preferences", async (t) => {
+  const kv = await Deno.openKv(":memory:");
+
+  await t.step("can set displayname", async () => {
+    const displayName = await getDisplayName(kv, "example");
+    assertEquals(displayName, null);
+
+    await setDisplayName(kv, "example", "Exemplary User");
+
+    const displayName = await getDisplayName(kv, "example");
+    assertEquals(displayName, "Exemplary User");
+  });
+});
+```
+
+This works becaus Deno KV is backed by SQLite when run for local development. Just like
+in-memory SQLite databases, multiple ephemeral Deno KV stores can exist at once without
+interfering with one another. For more information about special database addressing modes,
+see [the SQLite docs on the topic](https://www.sqlite.org/inmemorydb.html).
+
 ## Next steps
 
 At this point, you're just beginning to scratch the surface with Deno KV. Be

--- a/deploy/kv/manual/index.mdx
+++ b/deploy/kv/manual/index.mdx
@@ -239,7 +239,7 @@ by your code. Learn more about Deno KV on Deno Deploy [here](./on_deploy.mdx).
 
 ## Testing
 
-By default, [`Deno.openKv()`](https://www.sqlite.org/inmemorydb.html) creates or
+By default, [`Deno.openKv()`](https://deno.land/api?unstable=&s=Deno.openKv) creates or
 opens a persistent store based on the path from which the script that invoked it
 was run. This isn't usually desireable for tests, which need to produce the same
 behavior when run many times in a row.


### PR DESCRIPTION
This is easily apparent to users who are already familiar with SQLite, but people who either don't know about ":memory:" or who aren't aware that Deno KV is based on SQLite when run locally may not be able to figure this out for themselves.

I wasn't sure whether to include the assert import for the testing example; if that's needed I can add it.