### PR TITLE
docs: update gh runner specific os versions to latest

### DIFF
--- a/runtime/manual/advanced/continuous_integration.md
+++ b/runtime/manual/advanced/continuous_integration.md
@@ -30,7 +30,7 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: denoland/setup-deno@v1
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-12, windows-2022 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
       - run: deno test --allow-all --coverage cov/
 ```
@@ -100,12 +100,12 @@ jobs:
     continue-on-error: ${{ matrix.canary }} # Continue in case the canary run does not succeed
     strategy:
       matrix:
-        os: [ ubuntu-22.04, macos-12, windows-2022 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
         deno-version: [ v1.x ]
         canary: [ false ]
         include: 
           - deno-version: canary
-            os: ubuntu-22.04
+            os: ubuntu-latest
             canary: true
 ```
 
@@ -121,11 +121,11 @@ coverage generation and upload steps only on the `ubuntu` (Linux) runner:
 
 ```yaml
 - name: Generate coverage report
-  if: matrix.os == 'ubuntu-22.04'
+  if: matrix.os == 'ubuntu-latest'
   run: deno coverage --lcov cov > cov.lcov
 
 - name: Upload coverage to Coveralls.io
-  if: matrix.os == 'ubuntu-22.04'
+  if: matrix.os == 'ubuntu-latest'
   # Any code coverage service can be used, Coveralls.io is used here as an example.
   uses: coverallsapp/github-action@master
   with:


### PR DESCRIPTION
Yesterday I've configured Github workflows on my OSS for the first time. I don't have paid subscription, and when I followed instructions from docs, the actions were not triggered. I believe that's because I don't have access to specific runners, I can only use `*-latest` runners:

![Screenshot_20240314_212929_Chrome](https://github.com/denoland/deno-docs/assets/2606245/bcb5facd-d490-4c8b-b81a-97ba32692bb1)
 
After I've changed to `ubuntu-latest`, actions were properly triggered. If it makes sense, I would propose to use `*-latest` in docs, that way it should be always up-to-date.