### PR TITLE
the content in columns 1 and 2 needs to not wrap. 

### DIFF
--- a/runtime/manual/advanced/typescript/configuration.md
+++ b/runtime/manual/advanced/typescript/configuration.md
@@ -39,36 +39,36 @@ ignored.
 Here is a table of compiler options that can be changed, their default in Deno
 and any other notes about that option:
 
-| Option                           | Default                 | Notes                                                                                                                                     |
-| -------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `allowJs`                        | `true`                  | This almost never needs to be changed                                                                                                     |
-| `allowUnreachableCode`           | `false`                 |                                                                                                                                           |
-| `allowUnusedLabels`              | `false`                 |                                                                                                                                           |
-| `checkJs`                        | `false`                 | If `true` causes TypeScript to type check JavaScript                                                                                      |
-| `jsx`                            | `"react"`               |                                                                                                                                           |
-| `jsxFactory`                     | `"React.createElement"` |                                                                                                                                           |
-| `jsxFragmentFactory`             | `"React.Fragment"`      |                                                                                                                                           |
-| `keyofStringsOnly`               | `false`                 |                                                                                                                                           |
-| `lib`                            | `[ "deno.window" ]`     | The default for this varies based on other settings in Deno. If it is supplied, it overrides the default. See below for more information. |
-| `noErrorTruncation`              | `false`                 |                                                                                                                                           |
-| `noFallthroughCasesInSwitch`     | `false`                 |                                                                                                                                           |
-| `noImplicitAny`                  | `true`                  |                                                                                                                                           |
-| `noImplicitReturns`              | `false`                 |                                                                                                                                           |
-| `noImplicitThis`                 | `true`                  |                                                                                                                                           |
-| `noImplicitUseStrict`            | `true`                  |                                                                                                                                           |
-| `noStrictGenericChecks`          | `false`                 |                                                                                                                                           |
-| `noUnusedLocals`                 | `false`                 |                                                                                                                                           |
-| `noUnusedParameters`             | `false`                 |                                                                                                                                           |
-| `noUncheckedIndexedAccess`       | `false`                 |                                                                                                                                           |
-| `reactNamespace`                 | `React`                 |                                                                                                                                           |
-| `strict`                         | `true`                  |                                                                                                                                           |
-| `strictBindCallApply`            | `true`                  |                                                                                                                                           |
-| `strictFunctionTypes`            | `true`                  |                                                                                                                                           |
-| `strictPropertyInitialization`   | `true`                  |                                                                                                                                           |
-| `strictNullChecks`               | `true`                  |                                                                                                                                           |
-| `suppressExcessPropertyErrors`   | `false`                 |                                                                                                                                           |
-| `suppressImplicitAnyIndexErrors` | `false`                 |                                                                                                                                           |
-| `useUnknownInCatchVariables`     | `false`                 |                                                                                                                                           |
+| <div style={{width: '220px'}}>Option</div> | <div style={{width: '180px'}}>Default</div> | Notes                                                                                                                                     |
+| ------------------------------------------ | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `allowJs`                                  | `true`                                      | This almost never needs to be changed                                                                                                     |
+| `allowUnreachableCode`                     | `false`                                     |                                                                                                                                           |
+| `allowUnusedLabels`                        | `false`                                     |                                                                                                                                           |
+| `checkJs`                                  | `false`                                     | If `true` causes TypeScript to type check JavaScript                                                                                      |
+| `jsx`                                      | `"react"`                                   |                                                                                                                                           |
+| `jsxFactory`                               | `"React.createElement"`                     |                                                                                                                                           |
+| `jsxFragmentFactory`                       | `"React.Fragment"`                          |                                                                                                                                           |
+| `keyofStringsOnly`                         | `false`                                     |                                                                                                                                           |
+| `lib`                                      | `[ "deno.window" ]`                         | The default for this varies based on other settings in Deno. If it is supplied, it overrides the default. See below for more information. |
+| `noErrorTruncation`                        | `false`                                     |                                                                                                                                           |
+| `noFallthroughCasesInSwitch`               | `false`                                     |                                                                                                                                           |
+| `noImplicitAny`                            | `true`                                      |                                                                                                                                           |
+| `noImplicitReturns`                        | `false`                                     |                                                                                                                                           |
+| `noImplicitThis`                           | `true`                                      |                                                                                                                                           |
+| `noImplicitUseStrict`                      | `true`                                      |                                                                                                                                           |
+| `noStrictGenericChecks`                    | `false`                                     |                                                                                                                                           |
+| `noUnusedLocals`                           | `false`                                     |                                                                                                                                           |
+| `noUnusedParameters`                       | `false`                                     |                                                                                                                                           |
+| `noUncheckedIndexedAccess`                 | `false`                                     |                                                                                                                                           |
+| `reactNamespace`                           | `React`                                     |                                                                                                                                           |
+| `strict`                                   | `true`                                      |                                                                                                                                           |
+| `strictBindCallApply`                      | `true`                                      |                                                                                                                                           |
+| `strictFunctionTypes`                      | `true`                                      |                                                                                                                                           |
+| `strictPropertyInitialization`             | `true`                                      |                                                                                                                                           |
+| `strictNullChecks`                         | `true`                                      |                                                                                                                                           |
+| `suppressExcessPropertyErrors`             | `false`                                     |                                                                                                                                           |
+| `suppressImplicitAnyIndexErrors`           | `false`                                     |                                                                                                                                           |
+| `useUnknownInCatchVariables`               | `false`                                     |                                                                                                                                           |
 
 For a full list of compiler options and how they affect TypeScript, please refer
 to the


### PR DESCRIPTION
markdown tables are…not the easiest to style. I apologise for this "fix".

Problem:
![image](https://github.com/denoland/deno-docs/assets/3490640/642495ee-886b-49a4-992d-b8af8494ba93)


Solution:
![image](https://github.com/denoland/deno-docs/assets/3490640/8cc0faa5-e020-430e-b4d3-f101c253ef0b)
