### PR TITLE
fix file path reference in building_from_source.md

### DIFF
--- a/runtime/manual/references/contributing/building_from_source.md
+++ b/runtime/manual/references/contributing/building_from_source.md
@@ -166,5 +166,5 @@ cargo build -vv
 cargo clean && cargo build -vv
 
 # Run:
-./target/debug/deno run cli/tests/testdata/run/002_hello.ts
+./target/debug/deno run tests/testdata/run/002_hello.ts
 ```


### PR DESCRIPTION
`002_hello.ts` was recently moved from `cli/tests/testdata/run/` to `tests/testdata/run/` in this PR https://github.com/denoland/deno/pull/22369