### PR TITLE
web_frameworks.md: Add Hono

### DIFF
--- a/runtime/manual/getting_started/web_frameworks.md
+++ b/runtime/manual/getting_started/web_frameworks.md
@@ -71,10 +71,19 @@ configure, while being super flexible. Highlights include:
   for CSS.
 - No need to install thousand of packages in `node_modules` or complex bundlers.
 
+### Hono
+
+[Hono](https://hono.dev) is a light-weight web app framework in the tradition of
+Express and Sinatra. In just a few lines of code, you can set up an API server
+or a server for dynamic web pages. Hono provides a Deno-native installation path,
+and works great with Deno’s built-in TypeScript tooling.
+
+- This website is served by Hono running on [Deno Deploy](https://deno.com/deploy).
+
 ### Oak
 
-[Oak](https://deno.land/x/oak) is a web application framework for Deno, similar
-to Express in Node.js.
+[Oak](https://deno.land/x/oak) is a web application framework for Deno, inspired
+by Koa and @koa/router.
 
 As a middleware framework, Oak is the glue between your frontend application and
 a potential database or other data sources (e.g. REST APIs, GraphQL APIs). Just


### PR DESCRIPTION
The [State of Web Frameworks on Deno](https://deno.com/blog/web-frameworks-on-deno) blog post on deno.com includes Hono as a deno-native framework, which I found suspiciously missing from this page on the docs site, considering that the docs site itself is served by Hono.

I also corrected that Oak was described as inspired by Express, which is not really the case; Oak's lineage is from Koa, and Hono is inspired by Express's API. (This is also how it is described in the blog post.)