### PR TITLE
fix: the version number of `/std` and `update_versions.ts`

### DIFF
--- a/.github/workflows/update_versions.ts
+++ b/.github/workflows/update_versions.ts
@@ -13,7 +13,7 @@ interface ReplacementsData {
 
 const replacementsFile = $.path("replacements.json");
 const latestCliVersion = (await getLatestTagForRepo("deno")).replace("v", "");
-const latestStdVersion = await getLatestTagForRepo("deno_std");
+const latestStdVersion = await getLatestStdVersion();
 
 $.log(`cli version: ${latestCliVersion}`);
 $.log(`std version: ${latestStdVersion}`);
@@ -37,6 +37,14 @@ async function getLatestTagForRepo(name: string) {
     .header("accept", "application/vnd.github.v3+json")
     .json<{ tag_name: string }>();
   return latestRelease.tag_name;
+}
+
+async function getLatestStdVersion() {
+  $.logStep(`Fetching latest version number of std`);
+  const latestRelease = await $.request(`https://deno.com/versions.json`).json<
+    { std: string[] }
+  >();
+  return latestRelease.std[0];
 }
 
 async function tryCreatePr() {

--- a/replacements.json
+++ b/replacements.json
@@ -1,4 +1,4 @@
 {
   "CLI_VERSION": "1.43.3",
-  "STD_VERSION": "release-2024.05.07"
+  "STD_VERSION": "0.224.0"
 }


### PR DESCRIPTION
`getLatestTagForRepo("deno_std")` gets the latest tag from `deno_std` repo, but the latest release tag is not the latest version of `deno.land/std` anymore since the release https://github.com/denoland/deno_std/pull/4689

This PR fixes it.

related https://github.com/denoland/deno_std/issues/4728