### PR TITLE
Remove Fig autocomplete section from CLI docs

### DIFF
--- a/runtime/manual/getting_started/command_line_interface.md
+++ b/runtime/manual/getting_started/command_line_interface.md
@@ -231,15 +231,3 @@ More flags which affect the execution environment.
 --seed <NUMBER>              Seed Math.random()
 --v8-flags=<v8-flags>        Set V8 command line options. For help: ...
 ```
-
-## Autocomplete
-
-You can get IDE-style autocompletions for Deno with [Fig](https://fig.io/)
-<a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>.
-It works in bash, zsh, and fish.
-
-To install, run:
-
-```shell
-brew install fig
-```


### PR DESCRIPTION
Fig was [acquired by Amazon](https://fig.io/blog/post/fig-is-sunsetting) and is sunsetting in September 2024:

From [fig.io](https://fig.io/):

> Dear Fig users,
> 
> Effective September 1, 2024 we will be ending access to Fig.
> 
> We encourage users to migrate to Amazon Q for command line. It’s free on the Individual tier and is designed to be faster and more reliable than Fig. To make this transition as easy as possible, users can upgrade to Amazon Q for command line directly from the Fig dashboard.

---

Since shell completions are already [documented](https://docs.deno.com/runtime/manual/getting_started/setup_your_environment#shell-completions) on the Set Up Your Environment page, I feel like it is safe to remove this Autocomplete section entirely, especially since it only gave instructions for Fig.