### PR TITLE
fix: deno run examples should point to raw githubusercontent domain

### DIFF
--- a/src/components/DenoByExample/ByExample.tsx
+++ b/src/components/DenoByExample/ByExample.tsx
@@ -32,7 +32,8 @@ export default function ByExample({ example, examplesList }) {
       pathname: id,
     },
     rawUrl: {
-      origin: "https://raw.githubusercontent.com/denoland/deno-docs/main/by-example/",
+      origin:
+        "https://raw.githubusercontent.com/denoland/deno-docs/main/by-example/",
       pathname: id,
     },
     data: [

--- a/src/components/DenoByExample/ByExample.tsx
+++ b/src/components/DenoByExample/ByExample.tsx
@@ -31,6 +31,10 @@ export default function ByExample({ example, examplesList }) {
       origin: "https://github.com/denoland/deno-docs/blob/main/by-example/",
       pathname: id,
     },
+    rawUrl: {
+      origin: "https://raw.githubusercontent.com/denoland/deno-docs/main/by-example/",
+      pathname: id,
+    },
     data: [
       parsed,
       content,
@@ -89,6 +93,9 @@ function ExamplePage(props: PageProps<Data>) {
   }
   const [example, content] = props.data;
   const url = `${props.url.origin}${props.url.pathname}${
+    example.files.length > 1 ? "/main" : ""
+  }`;
+  const rawUrl = `${props.rawUrl.origin}${props.rawUrl.pathname}${
     example.files.length > 1 ? "/main" : ""
   }`;
 
@@ -166,7 +173,7 @@ function ExamplePage(props: PageProps<Data>) {
               <CodeBlock language="ts">
                 {example.run.startsWith("deno")
                   ? example.run.replace("<url>", url)
-                  : "deno run " + example.run.replace("<url>", url)}
+                  : "deno run " + example.run.replace("<url>", rawUrl)}
               </CodeBlock>
             </>
           )}


### PR DESCRIPTION
I reported this as issue #470, but it was easy enough to fix, so here's my solution. If there's a better way, let me know, I can update it. Thanks!