### PR TITLE
Replace winget commands with full ID in installation.md

### DIFF
--- a/runtime/manual/getting_started/installation.md
+++ b/runtime/manual/getting_started/installation.md
@@ -89,7 +89,7 @@ choco install deno
 Using [Winget](https://github.com/microsoft/winget-cli):
 
 ```shell
-winget install deno
+winget install DenoLand.Deno
 ```
 
 Using [vfox](https://vfox.lhan.me/):
@@ -185,7 +185,7 @@ deno upgrade
 Or using [Winget](https://github.com/microsoft/winget-cli) (Windows):
 
 ```shell
-winget upgrade deno
+winget upgrade DenoLand.Deno
 ```
 
 This will fetch the latest release from


### PR DESCRIPTION
A few days ago, an app with "denoiser" in its name was uploaded to Microsoft Store, causing winget to fail when trying to install Deno using the current command in the documentation.

Replacing the command with the full ID will fix this problem.

```
$ winget install deno
Multiple packages found matching input criteria. Please refine the input.
Name              Id            Source
---------------------------------------
AI Image Denoiser 9PPNM05292R2  msstore
deno              DenoLand.Deno winget
```

