### PR TITLE
Update import_maps.md with another example for using absolute project root imports

### DIFF
--- a/runtime/manual/basics/import_maps.md
+++ b/runtime/manual/basics/import_maps.md
@@ -108,6 +108,18 @@ something like this:
 }
 ```
 
+Additional example if you use project root for absolute imports but want to get rid of the incorrect recommendation from LSP.
+You can move the following into scope:
+
+```json
+  "scopes": {
+    "./": {
+      "/": "./",
+      "./": "./"
+    }
+  }
+```
+
 ## Import Maps are for Applications
 
 It is important to note that import map configuration files are


### PR DESCRIPTION
Since the Deno LSP provides incorrect recommendations for absolute project root imports when using the official example, I suggest adding another example to resolve this issue.

Reference issues:
- https://github.com/denoland/deno/issues/19908
- https://github.com/denoland/deno/issues/17193