### PR TITLE
fix(runtime/manual/tools/init): remove bench

### DIFF
--- a/runtime/manual/tools/init.md
+++ b/runtime/manual/tools/init.md
@@ -23,9 +23,6 @@ Run these commands to get started
   // Run the tests
   deno test
 
-  // Run the benchmarks
-  deno bench
-
 $ deno run main.ts
 Add 2 + 3 = 5
 
@@ -61,7 +58,4 @@ Run these commands to get started
 
   // Run the tests
   deno test
-
-  // Run the benchmarks
-  deno bench
 ```


### PR DESCRIPTION
`deno init` no longer creates the bench file.
Output also does not include the instruction to run benchmarks.