### PR TITLE
ddoc style overrides

### DIFF
--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -92,7 +92,7 @@ export default function Header({
 
       {reference &&
         (
-          <nav className="px-8 pt-2 pb-3 bg-white flex items-center justify-between border-box border-t border-gray-200 z-[1000]">
+          <nav className="px-6 pt-2 pb-3 bg-white flex items-center justify-between border-box border-t border-gray-200 z-[1000]">
             <ul className="flex">
               <li>
                 <HeaderItem

--- a/overrides.css
+++ b/overrides.css
@@ -1,1 +1,116 @@
-.hello {}
+/* Deno Doc Overrides */
+
+div.ddoc {
+  @apply flex h-screen p-2 pt-0;
+}
+
+/* First column: fixed width of 300px */
+.ddoc > :first-child {
+  @apply w-[290px] flex-shrink-0;
+}
+
+/* Second column: takes up the remaining space */
+.ddoc > :nth-child(2) {
+  @apply flex-grow;
+}
+
+.ddoc > .toc {
+  @apply flex flex-col h-full max-h-screen border-r border-gray-000;
+}
+
+.ddoc .documentNavigation > h3 {
+  margin: 0.75rem 0.75rem 0.5rem !important;
+  padding-bottom: 0.1rem;
+  @apply text-gray-4 font-normal text-xs border-b border-gray-000 leading-normal uppercase !important;
+}
+
+.ddoc .documentNavigation > ul {
+  @apply flex-grow overflow-y-auto;
+}
+
+.ddoc .documentNavigation > ul > li {
+  @apply mt-0.5 mx-3;
+}
+
+.ddoc .documentNavigation > ul > li > a {
+  @apply text-gray-3 text-sm py-1.5 px-3.5 hover:bg-blue-50 rounded-lg hover:no-underline !important;
+}
+
+.ddoc > div:not(.toc) {
+  @apply flex flex-col;
+}
+
+#content {
+  @apply mt-4 flex flex-row justify-between !important;
+}
+
+#content > main {
+  @apply pb-0 flex flex-col gap-3 flex-grow !important;
+}
+
+#content > .toc {
+  @apply flex-shrink-0 min-w-[250px] max-w-[300px] !important;
+}
+
+#content > main > section + div {
+  @apply max-w-[75ch] !important;
+}
+
+.ddoc > div > div#content > div.toc > div > nav.documentNavigation > h3 {
+  @apply hidden !important;
+}
+
+.ddoc > div > div#content > div.toc > div > nav.documentNavigation > ul {
+  @apply border-l border-gray-000 text-gray-1 text-[.8rem] leading-none !important;
+}
+
+.ddoc
+  > div
+  > div#content
+  > div.toc
+  > div
+  > nav.documentNavigation
+  > ul
+  > li:has(> a) {
+  @apply pb-0 !important;
+}
+
+.ddoc nav.documentNavigation li:has(> ul) {
+  @apply mt-0 !important;
+  /* CSS styles here */
+}
+
+.ddoc
+  > div
+  > div#content
+  > div.toc
+  > div
+  > nav.documentNavigation
+  > ul
+  > li
+  > ul
+  > li {
+  @apply mt-1 !important;
+}
+
+.ddoc
+  > div
+  > div#content
+  > div.toc
+  > div
+  > nav.documentNavigation
+  > ul
+  > li
+  > ul
+  > li
+  > a {
+  @apply hover:bg-blue-50 rounded-lg hover:no-underline p-1 !important;
+}
+
+@media (min-width: 1024px) {
+  .ddoc:not(:has(> div.toc)),
+  .ddoc:has(> div.toc) > div:not(.toc) {
+    padding-top: 0.25rem !important;
+    padding-left: 0.5rem !important;
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -197,6 +197,7 @@ body:not(:has(.ddoc)) {
 .deno-tabs > div.deno-tabs-content > div[data-active="true"] {
   @apply block;
 }
+
 .doc-pagination-label-next::after {
   content: " »";
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,7 @@ export default {
         "white-veil": "#ffffff03",
         "black-veil": "#00000003",
 
-        "primary": "#5673B8",
+        "primary": "rgb(9, 105, 218)",
 
         runtime: "rgba(112, 255, 175, 1)",
         "runtime-dark": "#172723",


### PR DESCRIPTION
PR to our working branch for the lume migration that just (hopefully) contains style adjustments to the reference docs. I split this out so we can decide if we want to merge these in with the rest of go-live stuff. 

<img width="1706" alt="Screenshot 2024-07-02 at 12 29 13 AM" src="https://github.com/denoland/deno-docs/assets/776987/7855221d-d109-4f5e-9d85-2bbe3f6a3d7a">
