### PR TITLE
post-launch style updates

### DIFF
--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -71,7 +71,7 @@ export default function Header({
             url={url}
             activeOn="/api"
             href="/api/deno"
-            name="Reference"
+            name="Reference APIs"
             hideOnMobile
           />
         </div>
@@ -99,7 +99,7 @@ export default function Header({
                   url={url}
                   activeOn="/api/deno"
                   href="/api/deno"
-                  name="Deno"
+                  name="Deno APIs"
                 />
               </li>
               <li>
@@ -107,7 +107,7 @@ export default function Header({
                   url={url}
                   activeOn="/api/web"
                   href="/api/web"
-                  name="Web"
+                  name="Web APIs"
                 />
               </li>
               <li>
@@ -115,7 +115,7 @@ export default function Header({
                   url={url}
                   activeOn="/api/node"
                   href="/api/node"
-                  name="Node"
+                  name="Node APIs"
                 />
               </li>
             </ul>

--- a/overrides.css
+++ b/overrides.css
@@ -1,7 +1,7 @@
 /* Deno Doc Overrides */
 
 div.ddoc {
-  @apply flex h-screen p-2 pt-0;
+  @apply flex h-screen p-8 pt-2 sm:p-4 lg:p-2 lg:pt-0;
 }
 
 /* First column: fixed width of 300px */
@@ -14,8 +14,20 @@ div.ddoc {
   @apply flex-grow;
 }
 
+.toc {
+  @apply hidden;
+}
+
 .ddoc > .toc {
-  @apply flex flex-col h-full max-h-screen border-r border-gray-000;
+  @apply hidden md:flex md:flex-col !important;
+}
+
+.ddoc > div > div#content > div.toc {
+  @apply hidden xl:flex xl:flex-col !important;
+}
+
+.ddoc > .toc {
+  @apply h-full max-h-screen border-r border-gray-000;
 }
 
 .ddoc .documentNavigation > h3 {
@@ -63,6 +75,10 @@ div.ddoc {
 /* This comes from gfm css, should be replaced with something in our color palette once we establish it. */
 .ddoc .markdown :not(pre) > code {
   background-color: var(--color-neutral-muted) !important;
+}
+
+.ddoc .markdown pre {
+  @apply border-gray-000 !important;
 }
 
 .ddoc .max-w-prose {

--- a/overrides.css
+++ b/overrides.css
@@ -56,6 +56,19 @@ div.ddoc {
   @apply max-w-[75ch] !important;
 }
 
+.ddoc .markdown {
+  @apply max-w-[75ch] !important;
+}
+
+/* This comes from gfm css, should be replaced with something in our color palette once we establish it. */
+.ddoc .markdown :not(pre) > code {
+  background-color: var(--color-neutral-muted) !important;
+}
+
+.ddoc .max-w-prose {
+  @apply max-w-[75ch] !important;
+}
+
 .ddoc > div > div#content > div.toc > div > nav.documentNavigation > h3 {
   @apply hidden !important;
 }


### PR DESCRIPTION
1. Set a max width for code sample + lighten background color for monospace highlighted words
<img width="795" alt="Screenshot 2024-07-02 at 4 00 10 PM" src="https://github.com/denoland/deno-docs/assets/776987/7626b54b-a49f-436a-b687-2055a6df5f68">

2. conditionally show the doc nav only on wide viewports, also fix mobile view.
<img width="1438" alt="Screenshot 2024-07-02 at 4 22 34 PM" src="https://github.com/denoland/deno-docs/assets/776987/33a4d274-6e5b-4de3-aa23-5188cacb42a0">

3. more verbose nav items
<img width="761" alt="Screenshot 2024-07-02 at 4 27 34 PM" src="https://github.com/denoland/deno-docs/assets/776987/def088bc-51a9-4ff3-ac6e-6796758f7185">
