### PR TITLE
fix: adjust mobile styles

### DIFF
--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -100,6 +100,7 @@ export default function Header({
                   activeOn="/api/deno"
                   href="/api/deno"
                   name="Deno APIs"
+                  firstItem={true}
                 />
               </li>
               <li>
@@ -132,6 +133,7 @@ function HeaderItem({
   name,
   external,
   hideOnMobile,
+  firstItem
 }: {
   url: string;
   activeOn?: string;
@@ -139,10 +141,11 @@ function HeaderItem({
   name: string;
   external?: boolean;
   hideOnMobile?: boolean;
+  firstItem?: boolean;
 }) {
   return (
     <a
-      class={`mt-1 mx-2.5 px-0.5 text-sm hover:text-primary flex items-center ${
+      class={`mt-1 ${firstItem ? 'ml-0' : ''} mx-2.5 px-0.5 text-sm hover:text-primary flex items-center ${
         activeOn && url.startsWith(activeOn)
           ? "text-primary border-b-2 border-primary"
           : "border-b-2 border-transparent"

--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -12,7 +12,7 @@ export default function Header({
         reference ? "" : "sticky top-0 left-0 right-0"
       }`}
     >
-      <nav class="px-4 md:px-8 py-3 h-16 flex items-center justify-between">
+      <nav class="px-4 md:px-6 py-3 h-16 flex items-center justify-between">
         <div class="flex items-center">
           {hassidebar && (
             <button class="mr-2 lg:hidden" id="sidebar-open">
@@ -92,7 +92,7 @@ export default function Header({
 
       {reference &&
         (
-          <nav className="px-6 pt-2 pb-3 bg-white flex items-center justify-between border-box border-t border-gray-200 z-[1000]">
+          <nav className="px-4 pt-2 pb-3 bg-white flex items-center justify-between border-box border-t border-gray-200 z-[1000]">
             <ul className="flex">
               <li>
                 <HeaderItem
@@ -142,7 +142,7 @@ function HeaderItem({
 }) {
   return (
     <a
-      class={`mt-1 mx-2.5 px-0.5 hover:text-primary flex items-center ${
+      class={`mt-1 mx-2.5 px-0.5 text-sm hover:text-primary flex items-center first:ml-1 ${
         activeOn && url.startsWith(activeOn)
           ? "text-primary border-b-2 border-primary"
           : "border-b-2 border-transparent"

--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -142,7 +142,7 @@ function HeaderItem({
 }) {
   return (
     <a
-      class={`mt-1 mx-2.5 px-0.5 text-sm hover:text-primary flex items-center first:ml-1 ${
+      class={`mt-1 mx-2.5 px-0.5 text-sm hover:text-primary flex items-center ${
         activeOn && url.startsWith(activeOn)
           ? "text-primary border-b-2 border-primary"
           : "border-b-2 border-transparent"

--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -133,7 +133,7 @@ function HeaderItem({
   name,
   external,
   hideOnMobile,
-  firstItem
+  firstItem,
 }: {
   url: string;
   activeOn?: string;
@@ -145,7 +145,9 @@ function HeaderItem({
 }) {
   return (
     <a
-      class={`mt-1 ${firstItem ? 'ml-0' : ''} mx-2.5 px-0.5 text-sm hover:text-primary flex items-center ${
+      class={`mt-1 ${
+        firstItem ? "ml-0" : ""
+      } mx-2.5 px-0.5 text-sm hover:text-primary flex items-center ${
         activeOn && url.startsWith(activeOn)
           ? "text-primary border-b-2 border-primary"
           : "border-b-2 border-transparent"

--- a/overrides.css
+++ b/overrides.css
@@ -1,12 +1,12 @@
 /* Deno Doc Overrides */
 
 div.ddoc {
-  @apply flex h-screen p-8 pt-2 sm:p-4 lg:p-2 lg:pt-0;
+  @apply flex h-screen p-4 pt-2 lg:p-2 lg:pt-0;
 }
 
 /* First column: fixed width of 300px */
 .ddoc > :first-child {
-  @apply w-[290px] flex-shrink-0;
+  @apply md:w-[290px] flex-shrink-0;
 }
 
 /* Second column: takes up the remaining space */
@@ -69,7 +69,7 @@ div.ddoc {
 }
 
 .ddoc .markdown {
-  @apply max-w-[75ch] !important;
+  @apply max-w-[40ch] sm:max-w-screen-sm md:max-w-screen-md lg:max-w-[75ch] !important;
 }
 
 /* This comes from gfm css, should be replaced with something in our color palette once we establish it. */

--- a/overrides.css
+++ b/overrides.css
@@ -4,9 +4,9 @@ div.ddoc {
   @apply flex h-screen p-4 pt-2 lg:p-2 lg:pt-0;
 }
 
-/* First column: fixed width of 300px */
+/* First column: fixed width of 290px */
 .ddoc > :first-child {
-  @apply md:w-[290px] flex-shrink-0;
+  @apply w-[290px] flex-shrink-0;
 }
 
 /* Second column: takes up the remaining space */

--- a/styles.css
+++ b/styles.css
@@ -205,3 +205,11 @@ body:not(:has(.ddoc)) {
 .doc-pagination-label-prev::before {
   content: "« ";
 }
+
+/* Custom DDOC styles for the Deno documentation */
+
+.ddoc .contextLink {
+  @apply text-primary !important;
+  /* 40% opacity of for decoration color primary */
+  text-decoration-color: rgba(9, 107, 218, 0.4) !important;
+}


### PR DESCRIPTION
<img width="488" alt="Screenshot 2024-07-05 at 4 50 13 PM" src="https://github.com/denoland/deno-docs/assets/776987/90502f10-0a94-447a-ae42-7c35b4549adc">

Adjusts some mobile styles to help with content overflow on mobile that are caused by using the character-per-line limit as max width.

fixes #547 