### PR TITLE
chore: update `__runtime_js_source` -> `hmr`

### DIFF
--- a/runtime/manual/references/contributing/index.md
+++ b/runtime/manual/references/contributing/index.md
@@ -31,23 +31,23 @@ Some systems, including a large part of the Node.js compatibility layer are
 implemented in JavaScript and TypeScript modules. These are a good place to
 start if you are looking to make your first contribution.
 
-While iterating on such modules it is recommended to include
-`--features __runtime_js_sources` in your `cargo` flags. This is a special
-development mode where the JS/TS sources are not included in the binary but read
-at runtime, meaning the binary will not have to be rebuilt if they are changed.
+While iterating on such modules it is recommended to include `--features hmr` in
+your `cargo` flags. This is a special development mode where the JS/TS sources
+are not included in the binary but read at runtime, meaning the binary will not
+have to be rebuilt if they are changed.
 
 > To use the commands below, you need to first install the necessary tools on
 > your system as described [here](building_from_source).
 
 ```sh
 # cargo build
-cargo build --features __runtime_js_sources
+cargo build --features hmr
 
 # cargo run -- run hello.ts
-cargo run --features __runtime_js_sources -- run hello.ts
+cargo run --features hmr -- run hello.ts
 
 # cargo test integration::node_unit_tests::os_test
-cargo test --features __runtime_js_sources integration::node_unit_tests::os_test
+cargo test --features hmr integration::node_unit_tests::os_test
 ```
 
 Also remember to reference this feature flag in your editor settings. For VSCode
@@ -56,7 +56,7 @@ users, combine the following into your workspace file:
 ```json
 {
   "settings": {
-    "rust-analyzer.cargo.features": ["__runtime_js_sources"]
+    "rust-analyzer.cargo.features": ["hmr"]
   }
 }
 ```


### PR DESCRIPTION
The feature flag was recently renamed from `__runtime_js_source` to `hmr`.