### PR TITLE
Fix nav item sizing

### DIFF
--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -92,7 +92,7 @@ export default function Header({
 
       {reference &&
         (
-          <nav className="px-6 sm:px-4 pt-2 pb-3 text-sm bg-white flex items-center justify-between border-box border-t border-gray-200 z-[1000]">
+          <nav className="px-4 md:px-6 pt-2 pb-3 text-sm bg-white flex items-center justify-between border-box border-t border-gray-200 z-[1000]">
             <ul className="flex">
               <li>
                 <HeaderItem

--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -92,7 +92,7 @@ export default function Header({
 
       {reference &&
         (
-          <nav className="px-4 pt-2 pb-3 bg-white flex items-center justify-between border-box border-t border-gray-200 z-[1000]">
+          <nav className="px-6 pt-2 pb-3 text-sm bg-white flex items-center justify-between border-box border-t border-gray-200 z-[1000]">
             <ul className="flex">
               <li>
                 <HeaderItem
@@ -147,7 +147,7 @@ function HeaderItem({
     <a
       class={`mt-1 ${
         firstItem ? "ml-0" : ""
-      } mx-2.5 px-0.5 text-sm hover:text-primary flex items-center ${
+      } mx-2.5 px-0.5 text-md hover:text-primary flex items-center ${
         activeOn && url.startsWith(activeOn)
           ? "text-primary border-b-2 border-primary"
           : "border-b-2 border-transparent"

--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -92,7 +92,7 @@ export default function Header({
 
       {reference &&
         (
-          <nav className="px-6 pt-2 pb-3 text-sm bg-white flex items-center justify-between border-box border-t border-gray-200 z-[1000]">
+          <nav className="px-6 sm:px-4 pt-2 pb-3 text-sm bg-white flex items-center justify-between border-box border-t border-gray-200 z-[1000]">
             <ul className="flex">
               <li>
                 <HeaderItem


### PR DESCRIPTION
<img width="745" alt="Screenshot 2024-07-08 at 3 32 02 PM" src="https://github.com/denoland/deno-docs/assets/776987/3c434fe4-d72d-45d6-be11-1355f6d56776">

I think I introduced this by accident in another PR but the primary nav should be a bit bigger than secondary nav font size to show that there is hierarchy to the navigation bars. 