### PR TITLE
Node usage styles

### DIFF
--- a/overrides.css
+++ b/overrides.css
@@ -143,3 +143,19 @@ div.ddoc {
     padding-left: 0.5rem !important;
   }
 }
+
+.ddoc .usageContent {
+  @apply bg-primary/5 border-primary/25 pt-3.5 pb-4 !important;
+}
+
+.ddoc .usageContent > h3 {
+  @apply font-semibold ml-1.5 mb-1.5 !important;
+}
+
+.ddoc .usageContent > .markdown {
+  @apply max-w-full !important;
+}
+
+.ddoc .context_button:hover {
+  @apply bg-gray-000/25 !important;
+}


### PR DESCRIPTION
<img width="820" alt="Screenshot 2024-07-08 at 3 55 07 PM" src="https://github.com/denoland/deno-docs/assets/776987/2123e9f8-78d1-4941-a394-34073eb2bb0a">

Note: this should say "Usage in Deno" though that change has to happen in @denoland/deno_doc

fixes #536 #538 