### PR TITLE
Revert "chore: update for 1.45.0"

### DIFF
--- a/replacements.json
+++ b/replacements.json
@@ -1,4 +1,4 @@
 {
-  "CLI_VERSION": "1.45.0",
+  "CLI_VERSION": "1.44.4",
   "STD_VERSION": "0.224.0"
 }


### PR DESCRIPTION
Reverts denoland/deno-docs#568 because the mobile navigation doesn't load on 1.45.