### PR TITLE
fix: update link url

### DIFF
--- a/by-example/http-server-routing.ts
+++ b/by-example/http-server-routing.ts
@@ -3,7 +3,7 @@
  * @difficulty intermediate
  * @tags cli, deploy
  * @run --allow-net <url>
- * @resource {/example/http-server} Example: HTTP Server: Hello World
+ * @resource {/examples/http-server} Example: HTTP Server: Hello World
  * @resource {https://developer.mozilla.org/en-US/docs/Web/API/URL_Pattern_API} MDN: URL Pattern API
  * @playground https://dash.deno.com/playground/example-routing
  * @group Network

--- a/by-example/http-server-websocket.ts
+++ b/by-example/http-server-websocket.ts
@@ -3,7 +3,7 @@
  * @difficulty intermediate
  * @tags cli, deploy
  * @run --allow-net <url>
- * @resource {/example/http-server} Example: HTTP Server: Hello World
+ * @resource {/examples/http-server} Example: HTTP Server: Hello World
  * @resource {https://developer.mozilla.org/en-US/docs/Web/API/WebSocket} MDN: WebSocket
  * @group Network
  *

--- a/by-example/parsing-serializing-yaml.ts
+++ b/by-example/parsing-serializing-yaml.ts
@@ -3,7 +3,7 @@
  * @difficulty beginner
  * @tags cli, deploy, web
  * @run <url>
- * @resource {/example/import-export} Example: Importing & Exporting
+ * @resource {/examples/import-export} Example: Importing & Exporting
  * @resource {https://yaml.org} Spec: YAML
  * @group Encoding
  *

--- a/by-example/websocket.ts
+++ b/by-example/websocket.ts
@@ -3,7 +3,7 @@
  * @difficulty beginner
  * @tags cli, deploy, web
  * @run --allow-net <url>
- * @resource {/http-server-websocket} HTTP Server: WebSockets
+ * @resource {/examples/http-server-websocket} HTTP Server: WebSockets
  * @resource {https://developer.mozilla.org/en-US/docs/Web/API/WebSocket} MDN: WebSocket
  * @group Network
  *


### PR DESCRIPTION
I found dead URLs on the following pages.

https://docs.deno.com/examples/http-server-routing/
https://docs.deno.com/examples/http-server-websocket/
https://docs.deno.com/examples/parsing-serializing-yaml/
https://docs.deno.com/examples/websocket/
