### PR TITLE
Navigation Updates

### DIFF
--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -12,13 +12,13 @@ export default function Header({
         reference ? "" : "sticky top-0 left-0 right-0"
       }`}
     >
-      <nav class="px-4 md:px-6 py-3 h-16 flex items-center justify-between">
+      <nav class="px-4 md:px-6 pt-2.5 pb-2 h-16 flex items-center justify-between">
         <div class="flex items-center">
           {hasSidebar && (
             <button class="mr-2 lg:hidden" id="sidebar-open">
               <svg
-                width="30"
-                height="30"
+                width="24"
+                height="24"
                 viewBox="0 0 30 30"
                 aria-hidden="true"
               >
@@ -33,31 +33,20 @@ export default function Header({
               </svg>
             </button>
           )}
-          <a class="flex items-center gap-3 mr-6" href="/">
+          <a class="flex items-center gap-2.5 mr-5" href="/">
             <div class="block size-6">
               <img src="/img/logo.svg" alt="Deno Docs" />
             </div>
-            <b class="text-xl">Docs</b>
+            {/* custom font size for logo */}
+            <span style={{ fontSize: "1.375rem" }} class="font-semibold">
+              Docs
+            </span>
           </a>
           <HeaderItem
             url={url}
             activeOn="/runtime"
             href="/runtime/manual"
-            name="Deno Runtime"
-            hideOnMobile
-          />
-          <HeaderItem
-            url={url}
-            activeOn="/deploy"
-            href="/deploy/manual"
-            name="Deno Deploy"
-            hideOnMobile
-          />
-          <HeaderItem
-            url={url}
-            activeOn="/subhosting"
-            href="/subhosting/manual"
-            name="Subhosting"
+            name="Runtime"
             hideOnMobile
           />
           <HeaderItem
@@ -71,11 +60,27 @@ export default function Header({
             url={url}
             activeOn="/api"
             href="/api/deno"
-            name="Reference APIs"
+            name="Reference"
+            hideOnMobile
+          />
+          <span class="hidden lg:inline-block mx-2">//</span>
+          <HeaderItem
+            url={url}
+            activeOn="/deploy"
+            href="/deploy/manual"
+            name="Deploy"
+            hideOnMobile
+          />
+          <HeaderItem
+            url={url}
+            activeOn="/subhosting"
+            href="/subhosting/manual"
+            name="Subhosting"
             hideOnMobile
           />
         </div>
-        <div class="flex items-center">
+
+        <div class="flex items-center gap-2">
           <HeaderItem
             url={url}
             href="https://deno.com"
@@ -83,7 +88,7 @@ export default function Header({
             external
             hideOnMobile
           />
-          <div class="w-[100px] lg:w-[150px]">
+          <div class="w-[150px] lg:w-64">
             <orama-search-button />
             <orama-searchbox />
           </div>
@@ -149,7 +154,7 @@ function HeaderItem({
         firstItem ? "ml-0" : ""
       } mx-2.5 px-0.5 text-md hover:text-primary flex items-center ${
         activeOn && url.startsWith(activeOn)
-          ? "text-primary border-b-2 border-primary"
+          ? "text-primary border-b-[1.5px] font-semibold border-blue-200"
           : "border-b-2 border-transparent"
       } ${hideOnMobile ? "max-lg:!hidden" : ""}`}
       href={href}

--- a/_components/Header.tsx
+++ b/_components/Header.tsx
@@ -46,7 +46,7 @@ export default function Header({
             url={url}
             activeOn="/runtime"
             href="/runtime/manual"
-            name="Runtime"
+            name="Runtime Manual"
             hideOnMobile
           />
           <HeaderItem

--- a/_components/Sidebar.tsx
+++ b/_components/Sidebar.tsx
@@ -12,7 +12,7 @@ export default function Sidebar(
 ) {
   return (
     <nav
-      class="pt-2 p-2 pr-0 overflow-y-auto h-[calc(100%-4rem)]"
+      class="pt-2 pb-8 p-2 pr-0 overflow-y-auto h-[calc(100%-2rem)]"
       style={{ scrollbarGutter: "stable", scrollbarWidth: "thin" }}
     >
       <ul>

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -72,8 +72,8 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
           >
             <svg
               viewBox="0 0 15 15"
-              width="21"
-              height="21"
+              width="16"
+              height="16"
               class="text-gray-600"
             >
               <g stroke="currentColor" stroke-width="1.2">
@@ -99,7 +99,7 @@ export default function Page(props: Lume.Data, helpers: Lume.Helpers) {
         style={{ scrollbarGutter: "stable" }}
       >
         <main class="mx-auto max-w-screen-xl w-full overflow-x-hidden pt-4 pb-8 flex flex-grow">
-          <div class="flex-grow px-4 sm:px-8 max-w-full lg:max-w-[75%]">
+          <div class="flex-grow px-4 sm:px-5 md:px-6 max-w-full lg:max-w-[75%]">
             <article class="max-w-[66ch]">
               <Breadcrumbs
                 title={props.title!}

--- a/overrides.css
+++ b/overrides.css
@@ -4,6 +4,42 @@
   @apply max-w-[75ch] !important;
 }
 
+/* Align content with the top of the TOC now that it has no header */
+
+#content {
+  @apply mt-2 !important;
+}
+
+#topnav {
+  @apply md:mt-1 !important;
+}
+
+/* Remove the header from the TOC */
+
+.ddoc > .toc > div > nav.documentNavigation > h3 {
+  @apply hidden !important;
+}
+
+/* Adjust spacing to account for removed header */
+
+.ddoc .toc .documentNavigation {
+  @apply md:mt-4 !important;
+}
+
+.ddoc .toc .documentNavigation > ul li {
+  @apply ml-1 !important;
+}
+
+.doc .toc :not(.documentNavigation) > a {
+  @apply text-xl !important;
+}
+
+/* Shrink the ToC a bit as items were rarely long enough to fill it */
+
+.ddoc > .toc {
+  width: 250px !important;
+}
+
 .ddoc .usageContent {
   @apply bg-primary/5 border-primary/25 pt-3.5 pb-4 !important;
 }

--- a/styles.css
+++ b/styles.css
@@ -104,6 +104,15 @@ body:not(:has(.ddoc)) {
   font-feature-settings: "cv05" on, "cv08" on, "cv09" on, "ss01" on, "ss08" on;
 }
 
+/* Orama search style overrides */
+.searchbutton-module_searchbutton__gg7JJ {
+  @apply w-64 border-gray-00 !important;
+}
+
+.searchbutton-module_searchbutton__keys__qckL6 {
+  @apply border-gray-00 text-gray-1 !important;
+}
+
 .searchbox-module_searchbox__TygrP {
   border: var(--ifm-toc-border-color) 1px solid;
 }
@@ -223,7 +232,7 @@ body:not(:has(.ddoc)) {
   /* Categories panel */
   > .toc {
     @apply border-r border-gray-000;
-    
+
     .documentNavigation {
       > h3 {
         margin: 0.75rem 0.75rem 0.5rem !important;
@@ -232,36 +241,36 @@ body:not(:has(.ddoc)) {
       }
     }
   }
-  
+
   .documentNavigation > ul > li > a {
-    @apply text-gray-3 hover:bg-blue-50 rounded-lg hover:no-underline  py-1.5 px-3.5 !important
+    @apply text-gray-3 hover:bg-blue-50 rounded-lg hover:no-underline  py-1.5 px-3.5 !important;
   }
-  
+
   .contextLink {
     @apply text-primary !important;
     /* 40% opacity of for decoration color primary */
     text-decoration-color: rgba(9, 107, 218, 0.4) !important;
   }
-  
+
   #content .toc .documentNavigation {
     > h3 {
       @apply hidden !important;
     }
-    
+
     > ul {
       @apply border-l border-gray-000 !important;
-      
+
       > ul > li a {
         @apply hover:bg-blue-50 rounded-lg hover:no-underline !important;
       }
     }
   }
-  
+
   .markdown {
     pre {
       @apply border-gray-000 !important;
     }
-    
+
     /* This comes from gfm css, should be replaced with something in our color palette once we establish it. */
     :not(pre) > code {
       background-color: var(--color-neutral-muted) !important;


### PR DESCRIPTION
This PR updates a number of nav styles on both the top nav and side nav

## Top Nav
- Content is re-arranged to group runtime and deploy content
- Style changes to fix alignment at different mobile viewports
- More subtle active state accent underlines
- Search box resizing 
- Slight spacing adjustments around logo

## Table of contents (API Ref)
- Removed header since there is only one section of content and every item is in that section
- Spacing changes to adjust for that.
- ToC width reduced since the table of contents only provides one level of navigation with no subnav content and thus don't utilize the arrow > icon like the rest of the docs do.

## Other
- Body content spacing adjustments to account for changes to ToC


<img width="1710" alt="Screenshot 2024-07-15 at 4 29 14 PM" src="https://github.com/user-attachments/assets/5bf585d3-9e74-4f80-8589-4b947606dbab">
