### PR TITLE
mobile sidebar update for index and examples

### DIFF
--- a/examples.page.tsx
+++ b/examples.page.tsx
@@ -6,16 +6,8 @@ export const sidebar = [
   {
     items: [
       {
-        label: "Deno Runtime",
+        label: "Runtime Manual",
         id: "/runtime/manual/",
-      },
-      {
-        label: "Deno Deploy",
-        id: "/deploy/manual/",
-      },
-      {
-        label: "Subhosting",
-        id: "/subhosting/manual/",
       },
       {
         label: "Examples",
@@ -24,6 +16,14 @@ export const sidebar = [
       {
         label: "Reference",
         id: "/api/deno",
+      },
+      {
+        label: "Deploy",
+        id: "/deploy/manual/",
+      },
+      {
+        label: "Subhosting",
+        id: "/subhosting/manual/",
       },
       {
         label: "deno.com",

--- a/index.page.tsx
+++ b/index.page.tsx
@@ -7,16 +7,8 @@ export const sidebar = [
   {
     items: [
       {
-        label: "Deno Runtime",
+        label: "Runtime Manual",
         id: "/runtime/manual/",
-      },
-      {
-        label: "Deno Deploy",
-        id: "/deploy/manual/",
-      },
-      {
-        label: "Subhosting",
-        id: "/subhosting/manual/",
       },
       {
         label: "Examples",
@@ -25,6 +17,14 @@ export const sidebar = [
       {
         label: "Reference",
         id: "/api/deno",
+      },
+      {
+        label: "Deploy",
+        id: "/deploy/manual/",
+      },
+      {
+        label: "Subhosting",
+        id: "/subhosting/manual/",
       },
       {
         label: "deno.com",


### PR DESCRIPTION
Updates the links that render in the hamburger menu when you're on the index page or the examples page to match the ordering of items in the standard desktop-width navigation 

<img width="429" alt="Screenshot 2024-07-17 at 3 27 26 PM" src="https://github.com/user-attachments/assets/255bcd94-de00-42ac-9f42-26780af8d0bf">
