### PR TITLE
add image directory for missing deploy manual images

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -73,6 +73,7 @@ site.copy("deploy/docs-images");
 site.copy("deploy/kv/manual/images");
 site.copy("deploy/kv/tutorials/images");
 site.copy("runtime/manual/images");
+site.copy("deploy/manual/images");
 site.copy("deno.json");
 site.copy("server.ts");
 site.copy("middleware.ts");


### PR DESCRIPTION
There are a few broken images as a result of /deploy/manual/images being left out of the config. this fixes that.