### PR TITLE
switch APIs to single col layout

### DIFF
--- a/overrides.css
+++ b/overrides.css
@@ -29,7 +29,7 @@
 }
 
 .ddoc .usageContent {
-  @apply bg-primary/5 border-primary/25 pt-3.5 pb-4 !important;
+  @apply bg-primary/5 border-primary/25 max-w-[75ch] pt-3.5 pb-4 !important;
 }
 
 .ddoc .usageContent > h3 {
@@ -42,4 +42,35 @@
 
 .ddoc .context_button:hover {
   @apply bg-gray-000/25 !important;
+}
+
+/* Single column APIs */
+
+.ddoc .namespaceSection {
+  @apply grid-cols-1 gap-1 mt-4 !important;
+}
+
+.ddoc .section {
+  @apply max-w-[75ch] !important;
+}
+
+.ddoc .namespaceSection .namespaceItem {
+  @apply min-h-0 mb-4 !important;
+}
+
+.ddoc .section > div:first-child > h2 {
+  @apply mb-0 !important;
+}
+
+/* This section attempts to style the headings on the category index pages differently from the symbol detail pages */
+.ddoc .space-y-7 > .section {
+  @apply mt-4 !important;
+}
+
+.ddoc .space-y-7 > .section:first-child {
+  @apply mt-0 !important;
+}
+
+.ddoc .space-y-7 > .section .markdown {
+  @apply mb-6 !important;
 }

--- a/styles.css
+++ b/styles.css
@@ -272,4 +272,7 @@ body:not(:has(.ddoc)) {
       background-color: var(--color-neutral-muted) !important;
     }
   }
+  .markdown_summary :not(pre) > code {
+    background-color: var(--color-neutral-muted) !important;
+  }
 }


### PR DESCRIPTION
<img width="1084" alt="Screenshot 2024-07-25 at 12 06 53 PM" src="https://github.com/user-attachments/assets/a3c50f43-26d2-4b6b-956b-b5444f0cb647">

This adds style overrides to render the APIs in a single column layout with some adjusted spacing to account for the new layout.