### PR TITLE
fix: add missing cli subcommands and update descriptions

### DIFF
--- a/runtime/manual/tools/index.md
+++ b/runtime/manual/tools/index.md
@@ -8,26 +8,35 @@ programs. These tools are listed below. You may also want to check out our list
 of [unstable feature flags](./unstable_flags.md), which give early access to new
 Deno features before they are finalized.
 
-- [`deno bench`](./benchmarker.md)
-- [`deno bundle`](./bundler.md)
-- [`deno cache`](./cache.md)
-- [`deno check`](./check.md)
-- [`deno compile`](./compiler.md)
-- [`deno coverage`](./coverage.md)
-- [`deno doc` -- documentation generator](./documentation_generator.md)
-- [`deno fmt` -- code formatter](./formatter.md)
-- [`deno info` -- dependency inspector](./dependency_inspector.md)
-- [`deno init`](./init.md)
-- [`deno install`](./script_installer.md)
-- [`deno jupyter`](./jupyter.md)
-- [`deno lint` -- linter](./linter.md)
-- [`deno lsp` -- language server](./lsp.md)
-- [`deno publish` -- publish modules to JSR](./publish.md)
-- [`deno repl` -- interactive read-eval-print-loop](./repl.md)
-- [`deno run`](./run.md)
-- [`deno serve`](./serve.md)
-- [`deno task` -- task runner](./task_runner.md)
-- [`deno test` -- test runner](../basics/testing/index.md)
-- [`deno types`](./types.md)
-- [`deno uninstall`](./uninstall.md)
-- [`deno upgrade`](./upgrade.md)
+- [`deno add`](../basics/modules/index.md#package-registries) - add dependencies
+- [`deno bench`](./benchmarker.md) - run benchmarks
+- [`deno bundle`](./bundler.md) - bundle module and dependencies into a single
+  file
+- [`deno cache`](./cache.md) - cache dependencies
+- [`deno check`](./check.md) - type-check dependencies
+- [`deno compile`](./compiler.md) - compile the script into a self contained
+  executable
+- [`deno completions`](./completions.md) - generate shell completions
+- [`deno coverage`](./coverage.md) - print coverage reports
+- [`deno doc`](./documentation_generator.md) - show documentation for a module
+- [`deno eval`](./eval.md) - eval script
+- [`deno fmt`](./formatter.md) - format source files
+- [`deno help`](./help.md) - show command help text
+- [`deno info`](./dependency_inspector.md) - show info about cache or related
+  source file
+- [`deno init`](./init.md) - initialize a new project.
+- [`deno install`](./script_installer.md) - install script as an executable
+- [`deno jupyter`](./jupyter.md)- Deno kernel fo Jupyter notebooks
+- [`deno lint`](./linter.md) - lint source files
+- [`deno lsp`](./lsp.md) - start the language server
+- [`deno publish`](../basics/modules/publishing_modules.md) - publish a module
+  to JSR
+- [`deno repl`](./repl.md) - read eval print loop
+- [`deno run`](./run.md) - run a JavaScript or TypeScript program
+- [`deno serve`](./serve.md) - run a server
+- [`deno task`](./task_runner.md)
+- [`deno test`](../basics/testing.md) - run tests
+- [`deno types`](./types.md) - print runtime TypeScript declarations
+- [`deno uninstall`](./uninstall.md) - uinstall a script previously installed
+  with deno install
+- [`deno upgrade`](./upgrade.md) - upgrade deno executable to given version

--- a/runtime/manual/tools/index.md
+++ b/runtime/manual/tools/index.md
@@ -21,12 +21,12 @@ Deno features before they are finalized.
 - [`deno doc`](./documentation_generator.md) - show documentation for a module
 - [`deno eval`](./eval.md) - eval script
 - [`deno fmt`](./formatter.md) - format source files
-- [`deno help`](./help.md) - show command help text
+- [`deno help`](./index.md) - show command help text
 - [`deno info`](./dependency_inspector.md) - show info about cache or related
   source file
 - [`deno init`](./init.md) - initialize a new project.
 - [`deno install`](./script_installer.md) - install script as an executable
-- [`deno jupyter`](./jupyter.md)- Deno kernel fo Jupyter notebooks
+- [`deno jupyter`](./jupyter.md)- Deno kernel for Jupyter notebooks
 - [`deno lint`](./linter.md) - lint source files
 - [`deno lsp`](./lsp.md) - start the language server
 - [`deno publish`](../basics/modules/publishing_modules.md) - publish a module
@@ -34,9 +34,9 @@ Deno features before they are finalized.
 - [`deno repl`](./repl.md) - read eval print loop
 - [`deno run`](./run.md) - run a JavaScript or TypeScript program
 - [`deno serve`](./serve.md) - run a server
-- [`deno task`](./task_runner.md)
-- [`deno test`](../basics/testing.md) - run tests
+- [`deno task`](./task_runner.md) - run a task defined in the configuration file
+- [`deno test`](../basics/testing/index.md) - run tests
 - [`deno types`](./types.md) - print runtime TypeScript declarations
-- [`deno uninstall`](./uninstall.md) - uinstall a script previously installed
+- [`deno uninstall`](./uninstall.md) - uninstall a script previously installed
   with deno install
 - [`deno upgrade`](./upgrade.md) - upgrade deno executable to given version


### PR DESCRIPTION
Compared this content to `deno -h` and updated accordingly. Note that I linked `add` and `publish` to docs in other parts of the manual tree. On the fence if that's lazy or clever - but the linked sections contain useful content that seemed unnecessary to duplicate.