### PR TITLE
Add pricing to subhosting

### DIFF
--- a/subhosting/manual/pricing_and_limits.md
+++ b/subhosting/manual/pricing_and_limits.md
@@ -1,10 +1,12 @@
 ---
 title: Pricing and Limits
+description: Overview of Deno Subhosting pricing plans, resource limits, deployment restrictions, and performance constraints for your applications.
 ---
 
-Please see [our pricing page](https://deno.com/deploy/pricing?subhosting) for
-an overview of the available features in all plans. If you have a use case that
-exceeds any of these limits, [please reach out](mailto:deploy@deno.com).
+You can see an
+[overview of available pricing plans and features](https://deno.com/deploy/pricing?subhosting)
+for Deno Subhosting on the Deno website. If you have a use case that exceeds any
+of these limits, [please reach out](mailto:deploy@deno.com).
 
 ## Deployment size
 


### PR DESCRIPTION
Towards #1717

Copied pricing blurb from `/deploy/manual/pricing-and-limits.md` and added it to `/subhosting/manual/pricing_and_limits.md`. Link in `/subhosting/manual/pricing_and_limits.md` goes to https://deno.com/deploy/pricing?subhosting