### PR TITLE
fix "says importMap then has code for scopes"

### DIFF
--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -401,9 +401,6 @@ Limitations:
 
 ### Overriding HTTPS imports
 
-
-### Overriding HTTPS imports
-
 Deno also allows overriding HTTPS imports through the `scopes` field in
 `deno.json`. This feature is particularly useful when substituting a remote
 dependency with a local patched version for debugging or temporary fixes.


### PR DESCRIPTION
not quite sure what the paragraph here was going for given that the code snippet that follows is very different, this is the smallest edit that makes it make sense