### PR TITLE
add links to TCP options and deno.serve

### DIFF
--- a/deploy/api/runtime-sockets.md
+++ b/deploy/api/runtime-sockets.md
@@ -7,6 +7,10 @@ oldUrl:
 Deno Deploy supports outbound TCP and TLS connections. These APIs allow you to
 use databases like PostgreSQL, SQLite, MongoDB, etc., with Deploy.
 
+Looking for information on _serving_ TCP? Take a look at the documentation for
+[`Deno.serve`](/api/deno/~/Deno.serve) including its support for
+[TCP options](/api/deno/~/Deno.ServeTcpOptions).
+
 ## `Deno.connect`
 
 Make outbound TCP connections.


### PR DESCRIPTION
Help those arriving on the page who might be looking for info on _listening_ over TCP

closes: #1719 