### PR TITLE
Use single quotes to avoid need to escape the ! in this example

### DIFF
--- a/examples/scripts/tcp_echo_server.ts
+++ b/examples/scripts/tcp_echo_server.ts
@@ -8,7 +8,7 @@
  * @resource {https://docs.deno.com/api/deno/~/Deno.Conn#property_writable} Writable connection docs
  * @group Network
  *
- * An echo server is a simple network application that listens for incoming connections and requests, and then repeats back any data it receives from clients.<br><br>To test this example, try sending data to it with <a href="https://en.wikipedia.org/wiki/Netcat">Netcat</a> (Linux/MacOS only). For example, in your terminal run: <code>echo "Hello, Deno!" | nc localhost 8080</code>
+ * An echo server is a simple network application that listens for incoming connections and requests, and then repeats back any data it receives from clients.<br><br>To test this example, try sending data to it with <a href="https://en.wikipedia.org/wiki/Netcat">Netcat</a> (Linux/MacOS only). For example, in your terminal run: <code>echo 'Hello, Deno!' | nc localhost 8080</code>
  */
 
 // Create a TCP listener that listens on port 8080. Log that it is listening.


### PR DESCRIPTION
Fixes confusion as reported in #1765


closes: #1765 

 