### PR TITLE
Fixed contact us link in Deploy Early Access Docs

### DIFF
--- a/deploy/early-access/index.md
+++ b/deploy/early-access/index.md
@@ -97,5 +97,5 @@ application, view the reference documentation.
 
 If you have any questions or feedback about Deno Deploy EA, please reach out to
 us on the [Deno Discord](https://discord.gg/deno) in the `#deploy-ea` channel or
-[contact us](../support). We are actively working on improving the platform and
+[contact us](./support). We are actively working on improving the platform and
 would love to hear your thoughts.


### PR DESCRIPTION
Towards #1773 

Quick fix to change link in [Support and Feedback](https://docs.deno.com/deploy/early-access/#support-and-feedback) so that link properly connects to support page.