### PR TITLE
stop subnav items from wrapping and reduce size on small screens

### DIFF
--- a/_components/RefHeader.css
+++ b/_components/RefHeader.css
@@ -10,6 +10,11 @@
   height: 3rem;
 }
 
+.refheader-link {
+  white-space: nowrap;
+  font-size: clamp(0.875rem, 1vw + 0.5rem, 1rem);
+}
+
 .refheader-link[data-active="true"] {
   color: hsl(var(--primary));
 }


### PR DESCRIPTION
old:
![image](https://github.com/user-attachments/assets/42d88970-b242-480c-adb1-279270f1892b)

New
![image](https://github.com/user-attachments/assets/02044b1a-c157-4b0f-a780-45485a8d7c49)
