### PR TITLE
Update Nova Deno extension link

### DIFF
--- a/runtime/getting_started/setup_your_environment.md
+++ b/runtime/getting_started/setup_your_environment.md
@@ -311,7 +311,7 @@ your `.sublime-project` configuration like the below:
 
 The [Nova editor](https://nova.app) can integrate the Deno language server via
 the
-[Deno extension](https://extensions.panic.com/extensions/jaydenseric/jaydenseric.deno).
+[Deno extension](https://extensions.panic.com/extensions/co.gwil/co.gwil.deno/).
 
 ### GitHub Codespaces
 


### PR DESCRIPTION
A small change. The Deno extension for Nova which is linked to has not been updated for several years and has worse support than extension provided in this change.