### PR TITLE
Fix: PostCSS nesting

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -9,6 +9,7 @@ import postcss from "lume/plugins/postcss.ts";
 import redirects from "lume/plugins/redirects.ts";
 import search from "lume/plugins/search.ts";
 import sitemap from "lume/plugins/sitemap.ts";
+import postcssNesting from "npm:@tailwindcss/nesting";
 
 import tailwind from "@tailwindcss/postcss";
 
@@ -134,7 +135,7 @@ site.use(mdx());
 site.use(
   postcss({
     includes: false,
-    plugins: [tailwind()],
+    plugins: [postcssNesting, tailwind()],
   }),
 );
 

--- a/deno.lock
+++ b/deno.lock
@@ -53,8 +53,10 @@
     "npm:@js-temporal/polyfill@0.4.4": "0.4.4",
     "npm:@mdx-js/mdx@3.1.0": "3.1.0",
     "npm:@octokit/core@*": "7.0.3",
+    "npm:@oramacloud/client@*": "2.1.4",
     "npm:@tailwindcss/cli@4.1.11": "4.1.11",
     "npm:@tailwindcss/cli@^4.1.11": "4.1.11",
+    "npm:@tailwindcss/nesting@*": "0.0.0-insiders.565cd3e_postcss@8.4.47",
     "npm:@tailwindcss/postcss@^4.1.11": "4.1.11",
     "npm:@types/estree@1.0.6": "1.0.6",
     "npm:@types/node@*": "22.15.15",
@@ -72,6 +74,7 @@
     "npm:meriyah@6.0.3": "6.0.3",
     "npm:mongodb@6.1.0": "6.1.0",
     "npm:postcss-import@16.1.0": "16.1.0_postcss@8.4.47",
+    "npm:postcss-nesting@13": "13.0.2_postcss@8.4.47_postcss-selector-parser@7.1.0",
     "npm:postcss@8.4.47": "8.4.47",
     "npm:postcss@^8.5.6": "8.5.6",
     "npm:postgres@*": "3.4.7",
@@ -256,6 +259,18 @@
       "dependencies": [
         "@jridgewell/gen-mapping",
         "@jridgewell/trace-mapping"
+      ]
+    },
+    "@csstools/selector-resolve-nested@3.1.0_postcss-selector-parser@7.1.0": {
+      "integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
+      "dependencies": [
+        "postcss-selector-parser@7.1.0"
+      ]
+    },
+    "@csstools/selector-specificity@5.0.0_postcss-selector-parser@7.1.0": {
+      "integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+      "dependencies": [
+        "postcss-selector-parser@7.1.0"
       ]
     },
     "@duckdb/node-api@1.3.2-alpha.25": {
@@ -515,6 +530,9 @@
         "@tybys/wasm-util@0.10.0"
       ]
     },
+    "@noble/hashes@1.8.0": {
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
+    },
     "@octokit/auth-token@6.0.0": {
       "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w=="
     },
@@ -568,6 +586,23 @@
       "integrity": "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==",
       "dependencies": [
         "@octokit/openapi-types"
+      ]
+    },
+    "@orama/cuid2@2.2.3": {
+      "integrity": "sha512-Lcak3chblMejdlSHgYU2lS2cdOhDpU6vkfIJH4m+YKvqQyLqs1bB8+w6NT1MG5bO12NUK2GFc34Mn2xshMIQ1g==",
+      "dependencies": [
+        "@noble/hashes"
+      ]
+    },
+    "@orama/orama@3.1.11": {
+      "integrity": "sha512-Szki0cgFiXE5F9RLx2lUyEtJllnuCSQ4B8RLDwIjXkVit6qZjoDAxH+xhJs29MjKLDz0tbPLdKFa6QrQ/qoGGA=="
+    },
+    "@oramacloud/client@2.1.4": {
+      "integrity": "sha512-uNPFs4wq/iOPbggCwTkVNbIr64Vfd7ZS/h+cricXVnzXWocjDTfJ3wLL4lr0qiSu41g8z+eCAGBqJ30RO2O4AA==",
+      "dependencies": [
+        "@orama/cuid2",
+        "@orama/orama",
+        "lodash"
       ]
     },
     "@parcel/watcher-android-arm64@2.5.1": {
@@ -680,6 +715,13 @@
         "tailwindcss"
       ],
       "bin": true
+    },
+    "@tailwindcss/nesting@0.0.0-insiders.565cd3e_postcss@8.4.47": {
+      "integrity": "sha512-WhHoFBx19TnH/c+xLwT/sxei6+4RpdfiyG3MYXfmLaMsADmVqBkF7B6lDalgZD9YdM459MF7DtxVbWkOrV7IaQ==",
+      "dependencies": [
+        "postcss@8.4.47",
+        "postcss-nested"
+      ]
     },
     "@tailwindcss/node@4.1.11": {
       "integrity": "sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==",
@@ -1079,6 +1121,10 @@
         "css-color-keywords",
         "postcss-value-parser"
       ]
+    },
+    "cssesc@3.0.0": {
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "bin": true
     },
     "debug@2.6.9": {
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
@@ -1655,6 +1701,9 @@
       "dependencies": [
         "uc.micro"
       ]
+    },
+    "lodash@4.17.21": {
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "longest-streak@3.1.0": {
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
@@ -2367,6 +2416,36 @@
         "resolve"
       ]
     },
+    "postcss-nested@5.0.6_postcss@8.4.47": {
+      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
+      "dependencies": [
+        "postcss@8.4.47",
+        "postcss-selector-parser@6.1.2"
+      ]
+    },
+    "postcss-nesting@13.0.2_postcss@8.4.47_postcss-selector-parser@7.1.0": {
+      "integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
+      "dependencies": [
+        "@csstools/selector-resolve-nested",
+        "@csstools/selector-specificity",
+        "postcss@8.4.47",
+        "postcss-selector-parser@7.1.0"
+      ]
+    },
+    "postcss-selector-parser@6.1.2": {
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dependencies": [
+        "cssesc",
+        "util-deprecate"
+      ]
+    },
+    "postcss-selector-parser@7.1.0": {
+      "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
+      "dependencies": [
+        "cssesc",
+        "util-deprecate"
+      ]
+    },
     "postcss-value-parser@4.2.0": {
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
@@ -2865,6 +2944,9 @@
     },
     "url-template@2.0.8": {
       "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
+    },
+    "util-deprecate@1.0.2": {
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge@1.0.1": {
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="

--- a/styles.css
+++ b/styles.css
@@ -313,13 +313,13 @@
     row-gap: 1rem;
     width: 100%;
 
-    & > div {
+    > div {
       display: flex;
       flex-direction: column;
       row-gap: 1rem;
     }
 
-    & a:not([href]) {
+    a:not([href]) {
       color: inherit;
       text-decoration: none;
     }
@@ -335,14 +335,14 @@
     .anchor:focus {
       outline: none;
     }
-    & hr {
+    hr {
       background-color: var(--borderColor-default, var(--color-border-default));
       border: 0;
       height: 0.25em;
       margin: 24px 0;
       padding: 0;
     }
-    & blockquote {
+    blockquote {
       color: var(--fgColor-muted, var(--color-fg-muted));
       border-left: 0.25em solid
         var(--borderColor-default, var(--color-border-default));
@@ -351,14 +351,15 @@
       flex-direction: column;
       row-gap: 0.5rem;
     }
-    :where(
-      h1,
-      h2,
-      h3,
-      h4,
-      h5,
-      h6
-    ) {
+    &
+      :where(
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6
+      ) {
       font-weight: bold;
       line-height: 1.2;
 
@@ -385,86 +386,86 @@
       &:hover .anchor .octicon-link {
         visibility: visible;
       }
-      & :where(tt, code) {
+      :where(tt, code) {
         font-size: inherit;
         padding: 0 0.2em;
       }
     }
-    & h1 {
+    h1 {
       font-size: 2em;
       &:first-child {
         @apply md:text-4xl;
       }
     }
-    & h2 {
+    h2 {
       margin-top: 2.5rem;
       font-size: 1.5em;
     }
-    & h3 {
+    h3 {
       margin-top: 2rem;
       font-size: 1.25em;
     }
-    & h4 {
+    h4 {
       margin-top: 1.5rem;
       font-size: 1em;
     }
-    & h5 {
+    h5 {
       margin-top: 1rem;
       font-size: 0.875em;
     }
-    & h6 {
+    h6 {
       margin-top: 0.5rem;
       color: var(--fgColor-muted, var(--color-fg-muted));
       font-size: 0.85em;
     }
-    & summary :where(h1, h2, h3, h4, h5, h6) {
+    summary :where(h1, h2, h3, h4, h5, h6) {
       margin-top: 0;
 
       .anchor {
         margin-left: -40px;
       }
     }
-    & div > ol:not([type]) {
+    div > ol:not([type]) {
       list-style-type: decimal;
     }
     :where(ul, ol) :where(ul, ol) {
       margin-top: 0;
       margin-bottom: 0;
     }
-    & dl {
+    dl {
       padding: 0;
 
-      & dt {
+      dt {
         font-size: 1em;
         font-style: italic;
         font-weight: var(--base-text-weight-semibold, 600);
         margin-top: 16px;
         padding: 0;
       }
-      & dd {
+      dd {
         margin-bottom: 16px;
         padding: 0 16px;
       }
     }
-    & table {
+    table {
       width: 100%;
       width: max-content;
       max-width: 100%;
       display: block;
       overflow: auto;
 
-      & th {
+      th {
         font-weight: var(--base-text-weight-semibold, 600);
       }
-      & th, & td {
+      th, td {
         border: 1px solid
           var(--borderColor-default, var(--color-border-default));
         padding: 6px 13px;
       }
-      & td > :last-child {
+      td > :last-child {
         margin-bottom: 0;
       }
-      & tr {
+      tr {
         background-color: var(--bgColor-default, var(--color-canvas-default));
         border-top: 1px solid
           var(--borderColor-muted, var(--color-border-muted));
@@ -473,7 +474,7 @@
           background-color: var(--bgColor-muted, var(--color-canvas-subtle));
         }
       }
-      & img {
+      img {
         background-color: transparent;
       }
     }
@@ -501,22 +502,22 @@
     :where(code, tt) br {
       display: none;
     }
-    & del code {
+    del code {
       -webkit-text-decoration: inherit;
       -webkit-text-decoration: inherit;
       text-decoration: inherit;
     }
-    & samp {
+    samp {
       font-size: 85%;
     }
-    & pre {
+    pre {
       @apply mb-4 border border-foreground-tertiary;
       word-wrap: normal;
     }
-    & pre code {
+    pre code {
       font-size: 100%;
     }
-    & pre > code {
+    pre > code {
       word-break: normal;
       white-space: pre;
       background: 0 0;
@@ -540,7 +541,8 @@
       line-height: 1.45;
       overflow: auto;
     }
-    pre code, pre tt {
+    pre code,
+    pre tt {
       max-width: auto;
       line-height: inherit;
       word-wrap: normal;
@@ -573,7 +575,7 @@
       background: var(--bgColor-muted, var(--color-canvas-subtle));
       border-top: 0;
     }
-    & a {
+    a {
       color: var(--color-primary);
       text-decoration: underline;
       text-decoration-thickness: 1px;
@@ -582,10 +584,10 @@
         text-decoration: underline;
       }
     }
-    & img {
+    img {
       display: inline;
     }
-    & iframe {
+    iframe {
       background-color: #fff;
       border: 0;
       margin-bottom: 16px;
@@ -596,25 +598,25 @@
     .anchor > .octicon {
       display: inline;
     }
-    & figcaption {
+    figcaption {
       text-align: center;
       padding-top: 2px;
     }
-    & ul,
-    & ol {
+    ul,
+    ol {
       padding-left: 2em;
 
-      & li + li {
+      li + li {
         margin-top: 0.25rem;
       }
     }
-    & ol {
+    ol {
       list-style: decimal;
     }
-    & ul {
+    ul {
       list-style: disc;
     }
-    & table {
+    table {
       width: -webkit-fit-content;
       width: -moz-fit-content;
       width: fit-content;
@@ -694,14 +696,14 @@
       display: block;
     }
 
-    & details {
+    details {
       @apply rounded-sm border border-gray-600 py-4 px-4;
 
       &[open] summary {
         @apply pb-4 mb-4 border-b border-gray-300;
       }
 
-      & summary::marker {
+      summary::marker {
         @apply text-gray-700;
       }
     }
@@ -709,7 +711,7 @@
       @apply px-4 lg:px-6 pt-10 lg:pt-12 pb-4 rounded-md bg-gray-100 relative
         overflow-clip text-sm flex flex-col gap-2;
 
-      & a {
+      a {
         @apply text-primary underline underline-offset-2;
 
         &.no-color {
@@ -717,7 +719,7 @@
         }
       }
 
-      & > * {
+      > * {
         margin: 0;
       }
 
@@ -746,45 +748,45 @@
       }
     }
     .module-info {
-      & svg {
+      svg {
         @apply inline-block! w-6! h-6!;
       }
 
-      & h2 {
+      h2 {
         @apply flex gap-2 items-center;
       }
 
-      & h3 {
+      h3 {
         @apply my-2 text-base;
       }
       .item-content {
         @apply ml-3 text-base mb-8;
       }
-      & p {
+      p {
         @apply mb-1;
       }
-      & ul {
+      ul {
         @apply pl-6;
       }
     }
-    & pre.snippet-code {
+    pre.snippet-code {
       @apply m-0;
     }
-    & pre.snippet-code[data-example-position="only"] {
+    pre.snippet-code[data-example-position="only"] {
       @apply md:border-t md:border-b md:pt-4 h-full md:rounded-sm md:rounded-b;
     }
 
-    & pre.snippet-code[data-example-position="first"] {
+    pre.snippet-code[data-example-position="first"] {
       @apply md:border-t md:border-b-0 md:pt-4 md:rounded-t md:rounded-b-none
         h-full;
     }
 
-    & pre.snippet-code[data-example-position="middle"] {
+    pre.snippet-code[data-example-position="middle"] {
       @apply md:border-t-0 md:border-b-0 md:pt-0 md:pb-16 h-full
         md:rounded-none;
     }
 
-    & pre.snippet-code[data-example-position="last"] {
+    pre.snippet-code[data-example-position="last"] {
       @apply md:border-t-0 md:border-b md:pb-8 h-full md:rounded-t-none
         md:rounded-b;
     }
@@ -1137,7 +1139,7 @@
     .markdown-summary p {
       @apply text-foreground-secondary text-sm inline;
 
-      & p {
+      p {
         @apply inline-block line-clamp-4;
       }
 
@@ -1171,7 +1173,7 @@
       hover:bg-header-highlight dark:border-background-tertiary rounded-full
       transition inline-flex gap-2 items-center cursor-pointer no-underline!
       dark:hover:text-background-primary;
-    & svg {
+    svg {
       @apply inline-block size-4;
     }
   }
@@ -1282,7 +1284,7 @@
     .unfiltered {
       display: block;
     }
-    & [data-category="tutorial"] {
+    [data-category="tutorial"] {
       display: block;
     }
   }
@@ -1294,7 +1296,7 @@
     .unfiltered {
       display: block;
     }
-    & [data-category="video"] {
+    [data-category="video"] {
       display: block;
     }
   }
@@ -1306,7 +1308,7 @@
     .unfiltered {
       display: block;
     }
-    & [data-category="example"] {
+    [data-category="example"] {
       display: block;
     }
   }
@@ -1402,16 +1404,16 @@
       transition: grid 0.25s cubic-bezier(0.165, 0.84, 0.44, 1);
     }
 
-    & + ul {
+    + ul {
       margin-left: 1rem !important;
     }
 
-    li:has(> & .sub-nav-toggle-checkbox:checked) {
+    li:has(> .sub-nav-toggle-checkbox:checked) {
       grid-template-rows: max-content 1fr;
       padding-bottom: 1rem;
     }
 
-    li:has(> & + ul:focus-within) {
+    li:has(> + ul:focus-within) {
       grid-template-rows: max-content 1fr;
       padding-bottom: 1rem;
     }
@@ -1561,7 +1563,7 @@
       display: block;
       padding-bottom: calc(100% / (16 / 9));
     }
-    & > iframe {
+    > iframe {
       width: 100%;
       height: 100%;
       position: absolute;
@@ -1571,7 +1573,7 @@
     }
 
     /* play button */
-    & > .lyt-playbtn {
+    > .lyt-playbtn {
       display: block;
       /* Make the button element cover the whole area for a large hover/click target… */
       width: 100%;
@@ -1708,17 +1710,17 @@
   }
 
   .documentNavigation {
-    & #toc {
+    #toc {
       position: sticky;
       top: calc(var(--header-height) + var(--subnav-height));
       font-size: small;
       text-overflow: ellipsis;
       color: var(--color-foreground-secondary);
 
-      & ul li {
+      ul li {
         margin: 0.25rem 0;
 
-        & a {
+        a {
           font-weight: bold;
           line-height: 1.2rem;
 
@@ -1728,10 +1730,10 @@
           }
         }
 
-        & ul {
+        ul {
           margin-bottom: 1rem;
 
-          & li a {
+          li a {
             font-weight: normal;
             transition: all 0.2s cubic-bezier(0.86, 0, 0.07, 1);
           }
@@ -2334,6 +2336,7 @@
     .namespaceItem
     .namespaceItemContent
     .namespaceItemContentSubItems
+    &
     a {
     text-decoration-line: underline;
   }
@@ -2377,8 +2380,10 @@
     display: flex;
     align-items: center;
     list-style: none;
+
     li {
       margin: 0 !important;
+
       a {
         color: var(--color-foreground-secondary); /*marked*/
       }


### PR DESCRIPTION
Older versions of iOS have some odd handling for CSS nesting. Previously, we were trying to account for these edge cases manually, which wasn't always working, and the styling could still be wrong on iOS < 17.

So, this PR instead moves nesting handling to a PostCSS plugin, so it's more consistent and also we don't even have to think about it.

<img width="2730" height="1468" alt="CleanShot 2025-08-13 at 13 54 39@2x" src="https://github.com/user-attachments/assets/01412fd7-848a-4e35-9371-2579b9d7ca44" />
