### PR TITLE
type fixes

### DIFF
--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -97,6 +97,17 @@ export default function Doc(data: Lume.Data, helpers: Lume.Helpers) {
                   Available since {data.available_since}
                 </div>
               )}
+              {data.info && (
+                <div class="admonition info">
+                  <div class="title">Info</div>
+                  <div
+                    class="text-sm"
+                    dangerouslySetInnerHTML={{
+                      __html: helpers.md(data.info, true),
+                    }}
+                  />
+                </div>
+              )}
               {renderedCommand}
               {data.children}
             </div>

--- a/_includes/renderCommand.tsx
+++ b/_includes/renderCommand.tsx
@@ -138,7 +138,6 @@ export default function renderCommand(
             class="flex flex-col gap-4"
             dangerouslySetInnerHTML={{ __html: helpers.md(about) }}
           />
-          <br />
         </>
       )}
 

--- a/reference/reference.page.tsx
+++ b/reference/reference.page.tsx
@@ -126,7 +126,7 @@ export default function* () {
         } else if (content.kind === "SymbolPageCtx") {
           layout = "symbol";
         } else {
-          throw `unknown page kind: ${content.kind}`;
+          throw `unknown page kind: ${(content as { kind: string }).kind}`;
         }
 
         yield {

--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -227,18 +227,6 @@ export const sidebar = [
         ],
       },
       {
-        title: "Deno APIs",
-        href: "/api/deno/",
-      },
-      {
-        title: "Web APIs",
-        href: "/runtime/reference/web_platform_apis/",
-      },
-      {
-        title: "Node APIs",
-        href: "/runtime/reference/node_apis/",
-      },
-      {
         title: "TS Config Migration",
         href: "/runtime/reference/ts_config_migration/",
       },
@@ -367,7 +355,10 @@ export async function generateDescriptions(): Promise<Descriptions> {
     )
   ) {
     const file = await Deno.readTextFile(dirEntry.path);
-    const parsed = yamlParse(file);
+    const parsed = yamlParse(file) as Partial<DescriptionItem> & {
+      description?: Description | string;
+      symbols?: Record<string, Description | string>;
+    };
     if (!parsed) {
       throw `Invalid or empty file: ${dirEntry.path}`;
     }
@@ -379,7 +370,7 @@ export async function generateDescriptions(): Promise<Descriptions> {
       parsed.symbols = Object.fromEntries(
         Object.entries(parsed.symbols).map(([key, value]) => [
           key,
-          handleDescription(value),
+          handleDescription(value as Description | string),
         ]),
       );
     }
@@ -395,7 +386,7 @@ export async function generateDescriptions(): Promise<Descriptions> {
       throw `Invalid status provided in '${dirEntry.name}': ${parsed.status}`;
     }
 
-    descriptions[dirEntry.name.slice(0, -5)] = parsed;
+    descriptions[dirEntry.name.slice(0, -5)] = parsed as DescriptionItem;
   }
 
   return descriptions;

--- a/runtime/reference/cli/bundle.md
+++ b/runtime/reference/cli/bundle.md
@@ -4,10 +4,5 @@ oldUrl: /runtime/manual/cli/bundler/
 command: bundle
 openGraphLayout: "/open_graph/cli-commands.jsx"
 openGraphTitle: "deno bundle"
+info: "`deno bundle` is currently an experimental subcommand and is subject to changes."
 ---
-
-:::info
-
-`deno bundle` is currently an experimental subcommand and is subject to changes.
-
-:::


### PR DESCRIPTION
Add a new optional info block for the cli pages
Move the info block to the top of the cli pages (it currently gets stuck at the bottom if it is in the markdown)
Fix some broken types
Remove links to api landing pages from sidebar