### PR TITLE
Docs: correct placement of benchmark start

### DIFF
--- a/examples/videos/deno_bench.md
+++ b/examples/videos/deno_bench.md
@@ -114,8 +114,8 @@ benchmark reading just the first word? If we use the `bench`
 const FILENAME = "./Releases.md";
 
 Deno.bench("get first word", (b) => {
-  b.start();
   const file = Deno.readTextFileSync(FILENAME);
+  b.start();
   const firstWord = file.split(" ")[0];
   b.end();
 });


### PR DESCRIPTION
## Why are we making this change?

Otherwise I assume it’s the same as the previous example. Placing `bench.start()` after the file read is also [what’s done in the “critical sections” examples](https://docs.deno.com/runtime/reference/cli/bench/#critical-sections) of the CLI docs