### PR TITLE
Recommend using the @ symbol for the project root instead of remapping absolute imports

### DIFF
--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -110,22 +110,21 @@ import * as bar from "bar/file.ts";
 Path mapping of import specifies is commonly used in larger code bases for
 brevity.
 
-To use your project root for absolute imports:
+For example:
 
 ```json title="deno.json"
 {
   "imports": {
-    "/": "./",
-    "./": "./"
+    "@/": "./"
   }
 }
 ```
 
 ```ts title="main.ts"
-import { MyUtil } from "/util.ts";
+import { MyUtil } from "@/util.ts";
 ```
 
-This causes import specifiers starting with `/` to be resolved relative to the
+This causes import specifiers starting with `@/` to be resolved relative to the
 import map's URL or file path.
 
 ### Overriding packages


### PR DESCRIPTION
The previous recommendation causes problems (ex. https://github.com/denoland/deno/issues/30824 and a couple other issues I've seen in the past). It's better to use a symbol here.