### PR TITLE
Fix anchor link to correctly navigate to permissions section

### DIFF
--- a/runtime/fundamentals/security.md
+++ b/runtime/fundamentals/security.md
@@ -116,7 +116,7 @@ which is an array contain all the stack trace frames.
 ### Configuration file
 
 Deno supports storing permissions in the deno.json/deno.jsonc file. Read more
-under [configuration](/runtime/fundamentals/configuration/#Permissions).
+under [configuration](/runtime/fundamentals/configuration/#permissions).
 
 ### File system access
 


### PR DESCRIPTION
https://docs.deno.com/runtime/fundamentals/configuration/#Permissions doesn't take you to the "Permissions" section. https://docs.deno.com/runtime/fundamentals/configuration/#permissions does.