### PR TITLE
redirect /deploy/early-access without slash

### DIFF
--- a/oldurls.json
+++ b/oldurls.json
@@ -140,6 +140,7 @@
   "runtime/reference/node_apis/": "/api/node/",
   "/deploy/tutorials/vite/": "/examples/react_tutorial/",
   "/deploy/manual/*": "/deploy/classic/*",
+  "/deploy/early-access": "/deploy/",
   "/deploy/early-access/*": "/deploy/*",
   "/deploy/tutorials/": "/examples/",
   "/deploy/tutorials/*": "/examples/",


### PR DESCRIPTION
Mop up a missing redirect for the URL published in the playgrounds UI

https://docs.deno.com/deploy/early-access 