### PR TITLE
Increase V8 heap size to prevent OOM during build

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -26,7 +26,7 @@
     "serve": "deno task dev",
     "serve:style": "BUILD_TYPE=FULL deno task lume -s --config=_config-styleguide.ts",
     "start": "deno task dev",
-    "build": "deno task generate:reference && deno task generate:std-docs && BUILD_TYPE=FULL deno run --env-file -A lume.ts && tailwindcss -i styles.css -o _site/styles.css --minify",
+    "build": "deno task generate:reference && deno task generate:std-docs && BUILD_TYPE=FULL deno run --env-file -A --v8-flags=--max-old-space-size=4096 lume.ts && tailwindcss -i styles.css -o _site/styles.css --minify",
     "build:light": "deno run --env-file -A lume.ts",
     "prod": "deno run --allow-read --allow-env --allow-net server.ts",
     "test": "deno test -A",


### PR DESCRIPTION
This is a temporary workaround to address OOM failures during the doc build process by increasing the V8 heap size limit to 4GB when invoking `lume`.

The build process has been failing with OOM errors when running `lume`, likely because Lume requires all the pages to be in memory while building the site. Although it's not an ideal solution, this can be temporarily mitigated by allocating more memory for V8, which is done in this PR.
To fundamentally solve this issue, we'll probaly need to figure out and propose some architectural change to Lume.