### PR TITLE
fix: correct link for "go/permission-sets"

### DIFF
--- a/go.json
+++ b/go.json
@@ -27,7 +27,7 @@
   "lint-ignore": "/runtime/reference/cli/lint/#ignore-directives",
   "lint": "/runtime/reference/cli/lint/",
   "lsp": "/runtime/reference/cli/lsp/",
-  "permission-sets": "/runtime/fundamentals/configuration.md#permissions",
+  "permission-sets": "/runtime/fundamentals/configuration/#permissions",
   "permissions": "/runtime/fundamentals/security/",
   "run": "/runtime/reference/cli/run/",
   "serve": "/runtime/reference/cli/serve/",


### PR DESCRIPTION
**Bug**: https://docs.deno.com/go/permission-sets is broken.
**Fix**: Changing to the correct URL.
**Tested**: `deno task dev`