### PR TITLE
Fix typo: “Sao Paolo” to “São Paulo” in regions list

### DIFF
--- a/deploy/classic/regions.md
+++ b/deploy/classic/regions.md
@@ -17,7 +17,7 @@ located in the following regions:
 - Singapore (`asia-southeast1`)
 - London (`europe-west2`)
 - Frankfurt (`europe-west3`)
-- Sao Paolo (`southamerica-east1`)
+- São Paulo (`southamerica-east1`)
 - North Virginia (`us-east4`)
 - California (`us-west2`)
 


### PR DESCRIPTION
Correct the city name in deploy/classic/regions.md from Sao Paolo to São Paulo while keeping the region code southamerica-east1 unchanged.