### PR TITLE
Remove broken anchor link

### DIFF
--- a/runtime/reference/cli/unstable_flags.md
+++ b/runtime/reference/cli/unstable_flags.md
@@ -5,10 +5,10 @@ oldUrl:
   - /runtime/manual/tools/unstable_flags/
 ---
 
-New Deno runtime features are often released behind feature flags, so that 
-users can try out new APIs and features before they are finalized. Current
-unstable feature flags are listed on this page, and can also be found in the CLI
-help text by running:
+New Deno runtime features are often released behind feature flags, so that users
+can try out new APIs and features before they are finalized. Current unstable
+feature flags are listed on this page, and can also be found in the CLI help
+text by running:
 
 ```sh
 deno --help


### PR DESCRIPTION
This was removed in #1392 but the link was missed.

**Page**: https://docs.deno.com/runtime/reference/cli/unstable_flags/
**Link**: https://docs.deno.com/runtime/reference/cli/unstable_flags/#--unstable-byonm