### PR TITLE
feat(docs): add pinned copy-to-clipboard button for code blocks

### DIFF
--- a/copy.client.ts
+++ b/copy.client.ts
@@ -3,7 +3,9 @@
 // Uses the compact 3-line "copy" icon and shows a check icon briefly on success.
 
 function cleanShellPrompts(text: string) {
-  return text.split(/\r?\n/).map((line) => line.replace(/^\s*(?:[$>❯#%]|\u203A|>>)\s?/, "")).join("\n");
+  return text.split(/\r?\n/).map((line) =>
+    line.replace(/^\s*(?:[$>❯#%]|\u203A|>>)\s?/, "")
+  ).join("\n");
 }
 
 function findScrollableAncestor(el: Element | null): Element | null {
@@ -11,7 +13,10 @@ function findScrollableAncestor(el: Element | null): Element | null {
     const cs = window.getComputedStyle(el as Element);
     const overflowX = cs.overflowX;
     const overflow = cs.overflow;
-    if (overflowX === "auto" || overflowX === "scroll" || overflow === "auto" || overflow === "scroll") {
+    if (
+      overflowX === "auto" || overflowX === "scroll" || overflow === "auto" ||
+      overflow === "scroll"
+    ) {
       return el;
     }
     el = el.parentElement;
@@ -59,7 +64,10 @@ function hideThemePlaceholders(pre: HTMLElement) {
   // Hide any small dashed boxes heuristically inside the pre
   Array.from(pre.querySelectorAll<HTMLElement>("div,span")).forEach((el) => {
     const cs = window.getComputedStyle(el);
-    if ((cs.borderStyle && cs.borderStyle.includes("dashed")) || (cs.border && cs.border.includes("dashed"))) {
+    if (
+      (cs.borderStyle && cs.borderStyle.includes("dashed")) ||
+      (cs.border && cs.border.includes("dashed"))
+    ) {
       el.style.display = "none";
     }
   });
@@ -83,7 +91,10 @@ function attachButtons() {
     // We want to attach to a container that is NOT the scrollable element.
     // If the scrollable ancestor is the `pre` itself (common), attach to pre.parentElement instead.
     let attachTarget: HTMLElement | null = null;
-    if (scrollAncestor && scrollAncestor !== pre && scrollAncestor instanceof HTMLElement) {
+    if (
+      scrollAncestor && scrollAncestor !== pre &&
+      scrollAncestor instanceof HTMLElement
+    ) {
       // Found some scrolling ancestor above pre -> attach to that ancestor
       attachTarget = scrollAncestor as HTMLElement;
     } else {
@@ -99,7 +110,8 @@ function attachButtons() {
 
     // Ensure code has enough right padding so that content doesn't sit under the button
     const codeEl = code as HTMLElement;
-    const currentPRight = parseFloat(window.getComputedStyle(codeEl).paddingRight || "0") || 0;
+    const currentPRight =
+      parseFloat(window.getComputedStyle(codeEl).paddingRight || "0") || 0;
     if (currentPRight < 56) {
       codeEl.style.paddingRight = "56px";
     }
@@ -114,7 +126,9 @@ function attachButtons() {
 
 // Delegate click handling (single listener)
 document.addEventListener("click", (e) => {
-  const wrapper = (e.target as HTMLElement).closest(".copy-wrapper") as HTMLElement | null;
+  const wrapper = (e.target as HTMLElement).closest(".copy-wrapper") as
+    | HTMLElement
+    | null;
   if (!wrapper) return;
 
   const raw = wrapper.getAttribute("data-copy") || "";

--- a/styles.css
+++ b/styles.css
@@ -343,7 +343,6 @@
       padding: 0;
     }
 
-    
     blockquote {
       color: var(--fgColor-muted, var(--color-fg-muted));
       border-left: 0.25em solid
@@ -393,82 +392,89 @@
         padding: 0 0.2em;
       }
     }
-    
+
     /* COPY BUTTON  */
-.copy-wrapper {
-  position: absolute !important;
-  top: 10px !important;
-  right: 10px !important;
-  z-index: 40 !important;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  pointer-events: auto;
-}
+    .copy-wrapper {
+      position: absolute !important;
+      top: 10px !important;
+      right: 10px !important;
+      z-index: 40 !important;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      pointer-events: auto;
+    }
 
-/* The button */
-.copy-wrapper .copy-button {
-  background: rgba(255,255,255,0.02);
-  border: 1px solid rgba(255,255,255,0.04);
-  border-radius: 8px;
-  width: 40px;
-  height: 36px;
-  padding: 6px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  outline: none;
-  box-shadow: none;
-  transition: background 120ms ease, transform 120ms ease;
-}
+    /* The button */
+    .copy-wrapper .copy-button {
+      background: rgba(255, 255, 255, 0.02);
+      border: 1px solid rgba(255, 255, 255, 0.04);
+      border-radius: 8px;
+      width: 40px;
+      height: 36px;
+      padding: 6px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      outline: none;
+      box-shadow: none;
+      transition: background 120ms ease, transform 120ms ease;
+    }
 
-/* Hover & focus */
-.copy-wrapper .copy-button:hover,
-.copy-wrapper .copy-button:focus {
-  background: rgba(255,255,255,0.04);
-  transform: translateY(-1px);
-}
+    /* Hover & focus */
+    .copy-wrapper .copy-button:hover,
+    .copy-wrapper .copy-button:focus {
+      background: rgba(255, 255, 255, 0.04);
+      transform: translateY(-1px);
+    }
 
-/* icon sizing */
-.copy-wrapper svg {
-  width: 18px;
-  height: 18px;
-  display: block;
-  color: rgba(255,255,255,0.86);
-}
+    /* icon sizing */
+    .copy-wrapper svg {
+      width: 18px;
+      height: 18px;
+      display: block;
+      color: rgba(255, 255, 255, 0.86);
+    }
 
-/* hide theme controls inside pre (aggressive) */
-pre .code-actions,
-pre .code-toolbar,
-pre .copy-area,
-pre .placeholder,
-pre .controls,
-pre .actions,
-pre .code-block__actions,
-pre .pre-actions {
-  display: none !important;
-  visibility: hidden !important;
-  pointer-events: none !important;
-}
+    /* hide theme controls inside pre (aggressive) */
+    pre .code-actions,
+    pre .code-toolbar,
+    pre .copy-area,
+    pre .placeholder,
+    pre .controls,
+    pre .actions,
+    pre .code-block__actions,
+    pre .pre-actions {
+      display: none !important;
+      visibility: hidden !important;
+      pointer-events: none !important;
+    }
 
-.copy-wrapper,
-.copy-wrapper * {
-  border: none !important;
-  outline: none !important;
-  box-shadow: none !important;
-  background-clip: padding-box !important;
-}
+    .copy-wrapper,
+    .copy-wrapper * {
+      border: none !important;
+      outline: none !important;
+      box-shadow: none !important;
+      background-clip: padding-box !important;
+    }
 
-/* mobile adjustments */
-@media (max-width: 560px) {
-  .copy-wrapper { top: 8px !important; right: 8px !important; }
-  .copy-wrapper .copy-button { width: 34px; height: 30px; padding: 5px; }
-  pre > code { padding-right: 48px !important; }
-}
+    /* mobile adjustments */
+    @media (max-width: 560px) {
+      .copy-wrapper {
+        top: 8px !important;
+        right: 8px !important;
+      }
+      .copy-wrapper .copy-button {
+        width: 34px;
+        height: 30px;
+        padding: 5px;
+      }
+      pre > code {
+        padding-right: 48px !important;
+      }
+    }
 
- 
-    
     h1 {
       font-size: 2em;
       &:first-child {


### PR DESCRIPTION
Summary

This PR adds a copy-to-clipboard button to all <pre><code> blocks in the Deno documentation.

Previously, users had to manually select and copy code snippets, which was inefficient and error-prone — especially for longer commands. This enhancement improves usability by adding a persistent, accessible copy button that works across all code blocks.

Features

✨ Adds a copy button pinned to the top-right corner of every code block

✨ Handles horizontal scrolling: button stays fixed while code scrolls

✨ Strips shell prompts like $, >, and ❯ before copying

✅ Displays a ✔️ check icon briefly after successful copy

✅ Styled to blend with the existing docs look (no emojis, clean UI)

Implementation

copy.client.ts: injects the copy button and handles copy logic

styles.css: includes styles for button positioning, appearance, and animation

Code is scoped and non-invasive; it de-duplicates any existing theme-based buttons

How to Test Locally

Run the dev server:

deno task serve


Visit any page with code examples (e.g. Install or Getting Started)

Hover over a code block — confirm:

Copy icon is pinned to top-right

It stays fixed during horizontal scroll

Clicking it copies the code (without $, >, etc.)

A check icon appears briefly then reverts

Linked Issue:

Closes #2745

Screenshots

Before:

<img width="1600" height="1005" alt="Before copy button" src="https://github.com/user-attachments/assets/d11eb1fa-37dc-41d5-812f-cab7b98bb6ed" />

After:

<img width="1600" height="1007" alt="After copy button added" src="https://github.com/user-attachments/assets/310dd140-af60-479a-b265-99f38382c9c0" />

Notes for Reviewers

This is a non-breaking, client-side UX improvement

Does not modify build, runtime, or API logic

Happy to refine styling or placement if requested