### PR TITLE
Replace deprecated deno cache with deno install in docker examples

### DIFF
--- a/runtime/reference/docker.md
+++ b/runtime/reference/docker.md
@@ -19,8 +19,8 @@ WORKDIR /app
 # Copy source
 COPY . .
 
-# Compile the main app
-RUN deno cache main.ts
+# Install dependencies (use just `deno install` if deno.json has imports)
+RUN deno install --entrypoint main.ts
 
 # Run the app
 CMD ["deno", "run", "--allow-net", "main.ts"]
@@ -37,7 +37,8 @@ For smaller production images:
 FROM denoland/deno:latest AS builder
 WORKDIR /app
 COPY . .
-RUN deno cache main.ts
+# Install dependencies (use just `deno install` if deno.json has imports)
+RUN deno install --entrypoint main.ts
 
 # Production stage
 FROM denoland/deno:latest


### PR DESCRIPTION
Per the [Deno 1.x to 2.x Migration Guide](https://docs.deno.com/runtime/reference/migration_guide/), `deno cache` has been merged into `deno install`.

Reasonable doc update?