### PR TITLE
docs: link to sys permissions

### DIFF
--- a/runtime/fundamentals/security.md
+++ b/runtime/fundamentals/security.md
@@ -354,8 +354,9 @@ operating system release, system uptime, load average, network interfaces, and
 system memory information.
 
 Access to system information is granted using the `--allow-sys` flag. This flag
-can be specified with a list of allowed interfaces from the list defined in [Deno.SysPermissionDescriptor](/api/deno/~/Deno.SysPermissionDescriptor). These strings map to functions in the
-`Deno` namespace that provide OS info, like
+can be specified with a list of allowed interfaces from the list defined in
+[Deno.SysPermissionDescriptor](/api/deno/~/Deno.SysPermissionDescriptor). These
+strings map to functions in the `Deno` namespace that provide OS info, like
 [Deno.systemMemoryInfo](https://docs.deno.com/api/deno/~/Deno.SystemMemoryInfo).
 
 Definition: `--allow-sys[=<API_NAME>...]` or `-S[=<API_NAME>...]`


### PR DESCRIPTION
The security documentation didn't list all sys permissions. To keep upkeep low, this PR suggests a link to the api docs instead!