### PR TITLE
Add documentation for initializing an empty Deno project

### DIFF
--- a/runtime/reference/cli/init.md
+++ b/runtime/reference/cli/init.md
@@ -147,7 +147,8 @@ deno serve: Listening on http://0.0.0.0:8000/
 
 ## Initialize an empty project
 
-Running `deno init --empty` bootstraps an empty project with a basic console log.
+Running `deno init --empty` bootstraps an empty project with a basic console
+log.
 
 ```sh
 $ deno init --empty


### PR DESCRIPTION
This pull request adds documentation for initializing an empty Deno project using the `deno init --empty` command. The update provides a clear example and explanation of the generated files and recommended next steps for users.