### PR TITLE
Update instruction for enabling Deno in JetBrains IDE

### DIFF
--- a/runtime/getting_started/setup_your_environment.md
+++ b/runtime/getting_started/setup_your_environment.md
@@ -52,7 +52,9 @@ Navigate to **Plugins** and search for `Deno`. Install the official Deno plugin.
 ![The WebStorm plugins settings](./images/webstorm_setup.png)
 
 To configure the Plugin, go to **File** > **Settings** again. Navigate to
-**Languages & Frameworks** > **JavaScript Runtime**. Switch **Preferred Runtime** to **Deno**. Under **Deno**, specify the path to the Deno executable (if it has not been auto-detected). 
+**Languages & Frameworks** > **JavaScript Runtime**. Switch **Preferred
+Runtime** to **Deno**. Under **Deno**, specify the path to the Deno executable
+(if it has not been auto-detected).
 
 Check out
 [this blog post](https://blog.jetbrains.com/webstorm/2020/06/deno-support-in-jetbrains-ides/)


### PR DESCRIPTION
It appears that the method for switching to Deno has changed. https://www.jetbrains.com/help/webstorm/deno.html#configure_deno

<img width="1302" height="951" alt="image" src="https://github.com/user-attachments/assets/8d475967-ffec-4833-aff5-5c6ebf5236d8" />

Just for extra confirmation, this specific line was last edited in 24 August 2024 via Git Blame. The instruction I linked is last updated 17 October 2025.
