### PR TITLE
Revert compiler option for Satori support

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -54,7 +54,7 @@
     "types": [
       "lume/types.ts"
     ],
-    "jsx": "precompile",
+    "jsx": "react-jsx",
     "jsxImportSource": "lume"
   },
   "test": {


### PR DESCRIPTION
Update compiler options to re-enable failing OG image generation