### PR TITLE
docs: add deno check --check-js and deno fmt --fail-fast

### DIFF
--- a/runtime/reference/cli/check.md
+++ b/runtime/reference/cli/check.md
@@ -7,9 +7,9 @@ openGraphTitle: "deno check"
 description: "Download and type-check code without execution"
 ---
 
-## Example
+## Examples
 
-Type-check without execution.
+Type-check a TypeScript file without execution:
 
 ```ts title="example.ts"
 const x: string = 1 + 1n;
@@ -17,4 +17,14 @@ const x: string = 1 + 1n;
 
 ```bash
 deno check example.ts
+```
+
+## Type-checking JavaScript files
+
+If you have a JavaScript-only project and want to type-check it with Deno, you
+can use the `--check-js` flag instead of adding `// @ts-check` to every file or
+setting `compilerOptions.checkJs` in your `deno.json`:
+
+```bash
+deno check --check-js main.js
 ```

--- a/runtime/reference/cli/fmt.md
+++ b/runtime/reference/cli/fmt.md
@@ -57,6 +57,16 @@ enclosed in triple backticks and have a language attribute.
 
 :::
 
+## Checking formatting in CI
+
+Use `--check` to verify files are formatted without modifying them. Add
+`--fail-fast` to stop on the first unformatted file instead of reporting all of
+them, which is useful in large codebases:
+
+```sh
+deno fmt --check --fail-fast
+```
+
 ## Ignoring Code
 
 ### JavaScript / TypeScript / JSONC


### PR DESCRIPTION
## Summary
- Document `--check-js` flag for `deno check` — type-check JS files without needing `// @ts-check` or config changes
- Document `--fail-fast` flag for `deno fmt --check` — stop on first unformatted file in CI

## Test plan
- [ ] Verify `/runtime/reference/cli/check/` renders correctly
- [ ] Verify `/runtime/reference/cli/fmt/` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)