### PR TITLE
feat: add last modified timestamp to content pages

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -325,6 +325,37 @@ site.ignore(
 // the default layout if no other layout is specified
 site.data("layout", "doc.tsx");
 
+// Populate lastModified from git history using a single git command
+site.preprocess([".md", ".mdx"], (filteredPages) => {
+  const result = Deno.spawnAndWaitSync("git", [
+    "log",
+    "--pretty=format:%aI",
+    "--name-only",
+    "--diff-filter=ACMR",
+    "HEAD",
+  ]);
+
+  const output = new TextDecoder().decode(result.stdout);
+  const lastModified = new Map<string, string>();
+  let currentDate = "";
+
+  for (const line of output.split("\n")) {
+    if (!line) continue;
+    if (line.match(/^\d{4}-/)) {
+      currentDate = line;
+    } else if (!lastModified.has(line)) {
+      lastModified.set(line, currentDate);
+    }
+  }
+
+  for (const page of filteredPages) {
+    const src = page.sourcePath?.replace(/^\//, "");
+    if (src && lastModified.has(src)) {
+      page.data.lastModified = new Date(lastModified.get(src)!);
+    }
+  }
+});
+
 // Load API categories data globally
 import denoCategories from "./reference_gen/deno-categories.json" with {
   type: "json",
@@ -373,9 +404,6 @@ site.data("apiCategories", {
 
 // Do more expensive operations if we're building the full site
 if (Deno.env.get("BUILD_TYPE") == "FULL" && !Deno.env.has("SKIP_OG")) {
-  // Use Lume's built in date function to get the last modified date of the file
-  // site.data("date", "Git Last Modified");;
-
   // Generate Open Graph images
   site.data("openGraphLayout", "/open_graph/default.jsx");
   site.use(

--- a/_includes/doc.tsx
+++ b/_includes/doc.tsx
@@ -101,6 +101,18 @@ export default function Doc(data: Lume.Data, helpers: Lume.Helpers) {
               {data.children}
             </div>
           </article>
+          {data.lastModified && !isReference && !isLintRule && (
+            <p class="text-sm text-foreground-secondary mt-8">
+              Last updated on{" "}
+              <time dateTime={data.lastModified.toISOString()}>
+                {data.lastModified.toLocaleDateString("en-US", {
+                  year: "numeric",
+                  month: "long",
+                  day: "numeric",
+                })}
+              </time>
+            </p>
+          )}
           <data.comp.Feedback file={file} />
         </div>
       </main>


### PR DESCRIPTION
## Summary
- Adds a "Last updated on <date>" timestamp to documentation pages, using git history as the source of truth
- Runs a **single `git log` command** (~150ms) via `Deno.spawnAndWaitSync()` during Lume preprocessing to build a file→date map — avoids the per-file `git log` cost of Lume's built-in `"Git Last Modified"`
- Displays the date above the feedback section on content pages; skips API reference and lint rule pages (auto-generated)

Closes #1280

## Test plan
- [x] `deno task build:light` succeeds
- [x] Verified `<time>` element with correct date appears in built HTML
- [ ] Visual check on deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)