### PR TITLE
improve: redesign CLI reference flag rendering

### DIFF
--- a/_includes/renderCommand.tsx
+++ b/_includes/renderCommand.tsx
@@ -181,7 +181,7 @@ export default function renderCommand(
             <h2 id={id}>
               {heading} <HeaderAnchor id={id} />
             </h2>
-            <div class="flex flex-col gap-5 mt-4">
+            <div class="flex flex-col gap-8 mt-4">
               {flags
                 .toSorted((a: ArgType, b: ArgType) =>
                   a.long.localeCompare(b.long)
@@ -226,7 +226,7 @@ function renderOption(group: string, arg: ArgType, helpers: Lume.Helpers) {
   const flagDisplay = arg.short ? `${longFlag}, -${arg.short}` : longFlag;
 
   return (
-    <div id={id} class="p-4 rounded-md border border-foreground-secondary/20">
+    <div id={id}>
       <div class="flex items-baseline justify-between gap-4 flex-wrap">
         <div class="flex items-baseline gap-2">
           <code class="text-sm font-semibold">


### PR DESCRIPTION
## Summary

- Redesign auto-generated CLI flags from bare `<h3>` headings into bordered cards for better scannability
- Show short flags inline with long flags (e.g. `--config, -c` instead of separate "Short flag" text)
- Parse the `usage` field from `json_reference` to extract and display value types (`<FILE>`, `<DIR>`, `<N>`) alongside the flag name
- Mark optional values with an "optional" tag for flags like `--fail-fast[=<N>]`
- Wrap each flag in a consistent card component with grouped spacing

Before:
<img width="772" height="612" alt="Screenshot 2026-03-27 at 14 53 42" src="https://github.com/user-attachments/assets/286b20d8-ce9d-47fa-9005-c5a4dfd368b8" />


After:
<img width="767" height="436" alt="Screenshot 2026-03-27 at 14 45 44" src="https://github.com/user-attachments/assets/8286e20b-1bc3-4cff-b882-67e544e33a60" />
