### PR TITLE
docs: phase out prominent http/https specifier examples

### DIFF
--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-18
+last_modified: 2026-06-19
 title: "Modules"
 description: "Learn how Deno's ECMAScript module system works: importing local and third-party modules, import attributes, import maps, and supported import types such as Wasm and data URLs."
 oldUrl:
@@ -246,12 +246,11 @@ during tests.
 
 When working with third-party modules in Deno, use the same `import` syntax as
 you do for local code. Third party modules are typically imported from a remote
-registry and start with `jsr:` , `npm:` or `https://`.
+registry and start with `jsr:` or `npm:`.
 
 ```ts title="main.ts"
 import { camelCase } from "jsr:@luca/cases@1.0.0";
 import { say } from "npm:cowsay@1.6.0";
-import { pascalCase } from "https://deno.land/x/case/mod.ts";
 ```
 
 Deno recommends [JSR](https://jsr.io), the modern JavaScript registry, for third
@@ -274,8 +273,7 @@ field the **import map**, which is based on the [Import Maps Standard].
 {
   "imports": {
     "@luca/cases": "jsr:@luca/cases@^1.0.0",
-    "cowsay": "npm:cowsay@^1.6.0",
-    "cases": "https://deno.land/x/case/mod.ts"
+    "cowsay": "npm:cowsay@^1.6.0"
   }
 }
 ```
@@ -285,7 +283,6 @@ With remapped specifiers, the code looks cleaner:
 ```ts title="main.ts"
 import { camelCase } from "@luca/cases";
 import { say } from "cowsay";
-import { pascalCase } from "cases";
 ```
 
 The remapped name can be any valid specifier. It's a very powerful feature in

--- a/runtime/packages/supply_chain.md
+++ b/runtime/packages/supply_chain.md
@@ -1,11 +1,11 @@
 ---
-last_modified: 2026-06-12
+last_modified: 2026-06-19
 title: "Supply chain management"
 description: "Keep Deno dependencies deterministic and safe: lockfile discipline, minimum dependency age, deno audit, intentional updates, and a recommended CI baseline."
 ---
 
-Modern JavaScript projects pull code from many sources (JSR, npm, HTTPS URLs,
-local workspaces). Good supply chain management helps you achieve four goals:
+Modern JavaScript projects pull code from many sources (JSR, npm, local
+workspaces). Good supply chain management helps you achieve four goals:
 
 - Determinism: everyone (and your CI) runs the exact same code.
 - Security: unexpected upstream changes or compromises are detected early.
@@ -32,8 +32,8 @@ This page builds on
 4. Vendor when you need hermetic/offline builds (`"vendor": true`) or when you
    must patch third‑party code locally. Vendoring does not remove the need for a
    lockfile—it complements it.
-5. Prefer import map (`imports`) entries over raw HTTPS imports in larger
-   codebases to centralize version changes.
+5. Use `jsr:` and `npm:` specifiers with import map (`imports`) entries to
+   centralize version management.
 6. Periodically unfreeze and update consciously (for example on a weekly or
    sprint cadence) instead of ad‑hoc updates during feature work.
 7. Set a [minimum dependency age](#minimum-dependency-age) so freshly published

--- a/runtime/reference/cli/run.md
+++ b/runtime/reference/cli/run.md
@@ -1,11 +1,11 @@
 ---
-last_modified: 2026-05-20
+last_modified: 2026-06-19
 title: "deno run"
 oldUrl: /runtime/manual/tools/run/
 command: run
 openGraphLayout: "/open_graph/cli-commands.jsx"
 openGraphTitle: "deno run"
-description: "Run a JavaScript or TypeScript program from a file or URL with Deno's runtime"
+description: "Run a JavaScript or TypeScript program with Deno's runtime"
 ---
 
 ## Usage

--- a/runtime/reference/migration_guide.md
+++ b/runtime/reference/migration_guide.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-17
+last_modified: 2026-06-19
 title: "Deno 1.x to 2.x Migration Guide"
 description: "Comprehensive guide to migrating from Deno 1.x to 2.x. Learn about breaking changes, API updates, Node.js compatibility features, and how to update your codebase to work with Deno 2.x."
 oldUrl:
@@ -173,7 +173,7 @@ import { denoPlugins } from "jsr:@luca/esbuild-deno-loader";
 
 const result = await esbuild.build({
   plugins: [...denoPlugins()],
-  entryPoints: ["https://deno.land/std@0.185.0/bytes/mod.ts"],
+  entryPoints: ["./main.ts"],
   outfile: "./dist/bytes.esm.js",
   bundle: true,
   format: "esm",

--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-02-25
+last_modified: 2026-06-19
 title: "Configuring TypeScript"
 description: "A guide to TypeScript configuration in Deno. Learn about compiler options, type checking JavaScript, JSDoc support, type declarations, and configuring TypeScript for cross-platform compatibility."
 oldUrl:
@@ -308,13 +308,10 @@ file, its resolution follow the normal import rules of Deno. For a lot of the
 `.d.ts` files that are generated and available on the web, they may not be
 compatible with Deno.
 
-[esm.sh](https://esm.sh) is a CDN which provides type declarations by default
-(via the `X-TypeScript-Types` header). It can be disabled by appending `?no-dts`
-to the import URL:
-
-```ts
-import React from "https://esm.sh/react?no-dts";
-```
+When using HTTPS imports from CDNs like [esm.sh](https://esm.sh), type
+declarations are provided by default (via the `X-TypeScript-Types` header). This
+can be disabled by appending `?no-dts` to the import URL. Note that for most use
+cases, `npm:` specifiers are the recommended way to import npm packages.
 
 ## Behavior of JavaScript when type checking
 


### PR DESCRIPTION
## Summary
- Remove most HTTP/HTTPS URL import examples across runtime docs, replacing them with `jsr:` and `npm:` specifiers
- Condense the "HTTPS imports" section in `modules.md` to a single brief reference with a caution note
- Remove the "Overriding HTTPS imports" subsection entirely
- Update code examples in CLI docs, JSX, TypeScript config, and migration guide to use local files or `npm:` specifiers

## Test plan
- [ ] Verify no broken internal links from removed sections
- [ ] Confirm the remaining HTTPS imports section in `modules.md` reads well as a standalone reference
- [ ] Check that JSX pragma example with import map note is clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)