### PR TITLE
docs: update `DENO_DEPLOY_APPLICATION_SLUG` to `DENO_DEPLOY_APP_SLUG`

### DIFF
--- a/deploy/reference/env_vars_and_contexts.md
+++ b/deploy/reference/env_vars_and_contexts.md
@@ -142,8 +142,8 @@ Environment variables have the following limits:
 Deno Deploy provides these predefined environment variables in all contexts:
 
 - `DENO_DEPLOY`: `true` - Indicates that the code is running in Deno Deploy.
-- `DENO_DEPLOY_ORG_ID`: The ID of the organization that owns the
-  application. This is a UUID.
+- `DENO_DEPLOY_ORG_ID`: The ID of the organization that owns the application.
+- This is a UUID.
 - `DENO_DEPLOY_ORG_SLUG`: The slug of the organization that owns the
   application. This is the human-readable identifier used in URLs that was set
   when creating the organization.


### PR DESCRIPTION
The documentation states that the variable `DENO_DEPLOY_APPLICATION_SLUG` contains the human-readable slug for the app, whereas `DENO_DEPLOY_APP_SLUG` seems to be the variable that is actually populated.

This can be checked creating an App and adding a build step with:
```
echo "$DENO_DEPLOY_APP_SLUG"
```

which will yield the proper value, while

```
echo "$DENO_DEPLOY_APPLICATION_SLUG"
```

Will yield nothing.