### PR TITLE
docs: document --prod and --skip-types flags for deno install

### DIFF
--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-05
+last_modified: 2026-05-20
 title: "Modules and dependencies"
 description: "A guide to managing modules and dependencies in Deno. Learn about ECMAScript modules, third-party packages, import maps, dependency management, versioning, and how to publish your own modules."
 oldUrl:
@@ -648,12 +648,17 @@ are semantically "development time" dependencies, like (`@types/*`), are often
 defined in `dependencies` in `package.json` files, which means they are
 installed for production even though they are not needed.
 
-Because of this, Deno uses a different approach for installing production only
-dependencies: when running `deno install`, you can pass a `--entrypoint` flag
-that causes Deno to install only the dependencies that are actually
-(transitively) imported by the specified entrypoint file. Because this is
-automatic, and works based on the actual code that is being executed, there is
-no need to specify development dependencies in a separate field.
+Deno offers two approaches for installing production-only dependencies:
+
+- **`deno install --prod`** — skips `devDependencies` from `package.json`. You
+  can also pass `--skip-types` to additionally exclude `@types/*` packages.
+- **`deno install --entrypoint`** — installs only the dependencies that are
+  actually (transitively) imported by the specified entrypoint file. When
+  combined with `--prod`, type-only dependencies are also excluded from the
+  module graph.
+
+See the [`deno install` reference](/runtime/reference/cli/install/) for more
+details.
 
 ## Using only cached modules
 

--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -217,6 +217,50 @@ This combines the behavior of [`deno compile`](/runtime/reference/cli/compile/)
 with global installation — producing a native binary placed in the installation
 root (same as `--global` without `--compile`).
 
+### deno install --prod
+
+Use this command to install only production dependencies, skipping
+`devDependencies` from `package.json`.
+
+```sh
+deno install --prod
+```
+
+This is useful when deploying an application where development dependencies like
+test frameworks or build tools are not needed.
+
+The `--prod` flag conflicts with `--global` and `--dev`.
+
+#### --skip-types
+
+When combined with `--prod`, the `--skip-types` flag additionally skips
+`@types/*` packages from both `package.json` dependencies and `deno.json`
+imports:
+
+```sh
+deno install --prod --skip-types
+```
+
+:::caution
+
+The `--skip-types` flag identifies type packages by checking if the package name
+starts with `@types/`. This heuristic may not cover all type-only packages.
+
+:::
+
+#### --prod with --entrypoint
+
+When `--prod` is combined with `--entrypoint`, the module graph is built as
+"code only", which excludes type-only dependencies:
+
+```sh
+deno install --prod --entrypoint main.ts
+```
+
+This provides the most precise production install — only dependencies that are
+actually imported at runtime by the specified entrypoint (and its transitive
+imports) will be installed.
+
 ## Native Node.js addons
 
 A lot of popular packages npm packages like


### PR DESCRIPTION
## Summary
- Documents the new `--prod` flag for `deno install` that skips `devDependencies` from `package.json`
- Documents the `--skip-types` flag (requires `--prod`) that excludes `@types/*` packages
- Documents `--prod` + `--entrypoint` combination that builds a code-only module graph
- Updates the "Development only dependencies" section in modules fundamentals to reference these new flags

Ref: denoland/deno#32863

## Test plan
- [ ] Verify the CLI reference page renders correctly with the new sections
- [ ] Verify the modules fundamentals page reads well with the updated dev dependencies section
- [ ] Check that the caution admonition for `--skip-types` renders properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)