### PR TITLE
docs: use colons as task name separators in examples

### DIFF
--- a/runtime/reference/cli/task.md
+++ b/runtime/reference/cli/task.md
@@ -88,18 +88,22 @@ pattern. A wildcard pattern is specified with the `*` character.
 ```json title="deno.json"
 {
   "tasks": {
-    "build-client": "deno run -RW client/build.ts",
-    "build-server": "deno run -RW server/build.ts"
+    "build:client": "deno run -RW client/build.ts",
+    "build:server": "deno run -RW server/build.ts"
   }
 }
 ```
 
-Running `deno task "build-*"` will run both `build-client` and `build-server`
+Running `deno task "build:*"` will run both `build:client` and `build:server`
 tasks.
+
+For multi-word task names, we recommend using `:` as the separator (e.g.
+`build:client`, `test:unit`, `lint:fix`) to match the convention used in the
+npm ecosystem and to group related tasks for wildcard matching.
 
 :::note
 
-**When using a wildcard** make sure to quote the task name (eg. `"build-*"`),
+**When using a wildcard** make sure to quote the task name (eg. `"build:*"`),
 otherwise your shell might try to expand the wildcard character, leading to
 surprising errors.
 
@@ -210,16 +214,16 @@ useful to logically group several tasks together:
 ```json title="deno.json"
 {
   "tasks": {
-    "dev-client": "deno run --watch client/mod.ts",
-    "dev-server": "deno run --watch sever/mod.ts",
+    "dev:client": "deno run --watch client/mod.ts",
+    "dev:server": "deno run --watch server/mod.ts",
     "dev": {
-      "dependencies": ["dev-client", "dev-server"]
+      "dependencies": ["dev:client", "dev:server"]
     }
   }
 }
 ```
 
-Running `deno task dev` will run both `dev-client` and `dev-server` in parallel.
+Running `deno task dev` will run both `dev:client` and `dev:server` in parallel.
 
 ## Node and npx binary support
 


### PR DESCRIPTION
Updates the task naming examples in `runtime/reference/cli/task.md` to use `:` as the separator (e.g. `build:client`, `dev:server`) instead of `-`, bringing this page in line with the rest of the docs, which already use the colon convention (`test:all`, `build:full`, `dev:api`, `lint:fix`, etc.). Adds a short note explicitly recommending `:` for multi-word task names — answering the question raised in #2989 — and incidentally fixes a preexisting "sever" typo in the dev-server example.

Ref #2989