### PR TITLE
docs: simplify file existence example to use node:fs

### DIFF
--- a/examples/scripts/checking_file_existence.ts
+++ b/examples/scripts/checking_file_existence.ts
@@ -2,33 +2,26 @@
  * @title Checking for file existence
  * @difficulty beginner
  * @tags cli, deploy
- * @run -R -W <url>
+ * @run -R <url>
  * @group File System
  *
  * When creating files it can be useful to first ensure that
  * such a file doesn't already exist.
- * There are a number of ways to do this.
  */
 
-// Use the `exists` utility from the std library to check for existence of a file or folder.
-// Note: Can create a race condition if followed by file operation.
-// Consider the alternative below.
-import { exists } from "jsr:@std/fs/exists";
-await exists("./this_file_or_folder_exists"); // true
-await exists("./this_file_or_folder_does_not_exist"); // false
+// Use the Node.js-compatible `fs.exists` function for a simple check.
+import { exists } from "node:fs";
 
-// We can also use this function to check if the item on a path is a file or a directory
-await exists("./file", { isFile: true }); // true
-await exists("./directory", { isFile: true }); // false
+exists("./example.txt", (fileExists) => {
+  console.log(fileExists); // true or false
+});
 
-// Do not use the above function if performing a check directly before another operation on that file.
-// Doing so creates a race condition. The `exists` function is not recommended for that usecase.
-// Consider this alternative which checks for existence of a file without doing any other filesystem operations.
+// For a promise-based approach, use `access` from `node:fs/promises`.
+import { access } from "node:fs/promises";
+
 try {
-  const stats = await Deno.lstat("example.txt");
-} catch (err) {
-  if (!(err instanceof Deno.errors.NotFound)) {
-    throw err;
-  }
+  await access("./example.txt");
+  console.log("File exists");
+} catch {
   console.log("File does not exist");
 }


### PR DESCRIPTION
## Summary
- Rewrites the file existence checking example to use `node:fs` `exists` and `node:fs/promises` `access` APIs
- Removes the Deno-specific `@std/fs/exists` and `Deno.lstat` approaches in favor of the simpler, more familiar Node.js-compatible APIs

Closes #2987

## Test plan
- [ ] Verify the example renders correctly on the docs site
- [ ] Run the example script with `deno run -R`

🤖 Generated with [Claude Code](https://claude.com/claude-code)