### PR TITLE
docs(docker): split dependency install for better layer caching

### DIFF
--- a/runtime/reference/docker.md
+++ b/runtime/reference/docker.md
@@ -14,18 +14,23 @@ To use the official image, create a `Dockerfile` in your project directory:
 ```dockerfile
 FROM denoland/deno:latest
 
-# Create working directory
 WORKDIR /app
 
-# Copy source
+# Copy manifests first so the dependency install layer caches across
+# source-only edits
+COPY deno.json deno.lock package.json* ./
+RUN deno ci --prod --skip-types
+
+# Then copy the rest of the source
 COPY . .
 
-# Install dependencies (use just `deno install` if deno.json has imports)
-RUN deno install --entrypoint main.ts
-
-# Run the app
 CMD ["deno", "run", "--allow-net", "main.ts"]
 ```
+
+[`deno ci`](/runtime/reference/cli/ci/) performs a reproducible install from
+`deno.lock`. `--prod` skips `devDependencies`, and `--skip-types` drops
+`@types/*` packages — both shrink the resulting image without affecting
+runtime behavior.
 
 ### Best Practices
 
@@ -39,9 +44,14 @@ FROM denoland/deno:latest AS builder
 # Point Deno's cache at a known location so it can be copied to the next stage
 ENV DENO_DIR=/deno-dir
 WORKDIR /app
+
+# Copy manifests first so the dependency install layer caches across
+# source-only edits
+COPY deno.json deno.lock package.json* ./
+RUN deno ci --prod --skip-types
+
+# Then copy the rest of the source
 COPY . .
-# Install dependencies (use just `deno install` if deno.json has imports)
-RUN deno install --entrypoint main.ts
 
 # Production stage
 FROM denoland/deno:latest
@@ -53,7 +63,7 @@ COPY --from=builder /deno-dir /deno-dir
 CMD ["deno", "run", "--allow-net", "main.ts"]
 ```
 
-Without copying `$DENO_DIR`, `deno install` only writes to Deno's global cache
+Without copying `$DENO_DIR`, `deno ci` only writes to Deno's global cache
 inside the builder stage — those files do not travel with
 `COPY --from=builder /app .`, so the container re-downloads dependencies on
 first run.


### PR DESCRIPTION
Rebased onto the 2.8 branch and updated the Dockerfile examples to use `deno ci` instead of `deno install --entrypoint main.ts`. `deno ci` is the new 2.8 install command intended for CI and image builds — it requires a committed lockfile, wipes any stale `node_modules`, and installs with `--frozen` semantics, so two builds of the same commit produce the same dependency tree.

For production images, the examples pass `--prod --skip-types`: `--prod` skips `devDependencies` from `package.json` and `--skip-types` drops `@types/*` packages from both `deno.json` imports and `package.json` dependencies. Both shrink the resulting image without changing runtime behavior.

The original layer-caching change is preserved: manifests (`deno.json`, `deno.lock`, `package.json*`) are copied before the full source tree so editing source code doesn't invalidate the dependency install layer, in both the basic and multi-stage examples. The `DENO_DIR` copy in the multi-stage example is untouched — that part of #2935 already landed in #3122.

Ref #2935