### PR TITLE
docs: add file reading example to CSV parsing page

### DIFF
--- a/examples/scripts/parsing_serializing_csv.ts
+++ b/examples/scripts/parsing_serializing_csv.ts
@@ -2,7 +2,7 @@
  * @title Parsing and serializing CSV
  * @difficulty beginner
  * @tags cli, deploy, web
- * @run <url>
+ * @run -R <url>
  * @resource {/examples/import_export} Example: Importing & Exporting
  * @resource {https://datatracker.ietf.org/doc/html/rfc4180} Spec: CSV
  * @group Encoding
@@ -11,8 +11,13 @@
  */
 import { parse, stringify } from "jsr:@std/csv";
 
-// To parse a CSV string, you can use the the standard library's CSV
-// parse function. The value is returned as a JavaScript object.
+// To parse a CSV file, read its contents and pass them to the parse function.
+const fileContent = await Deno.readTextFile("data.csv");
+const fileData = parse(fileContent, { skipFirstRow: true });
+console.log(fileData);
+
+// You can also parse CSV strings directly. The value is returned as an
+// array of objects when skipFirstRow is true.
 let text = `
 url,views,likes
 https://deno.land,10,7

--- a/examples/scripts/parsing_serializing_csv.ts
+++ b/examples/scripts/parsing_serializing_csv.ts
@@ -13,7 +13,7 @@ import { parse, stringify } from "jsr:@std/csv";
 
 // To parse a CSV file, read its contents and pass them to the parse function.
 const fileContent = await Deno.readTextFile("data.csv");
-const fileData = parse(fileContent, { skipFirstRow: true });
+const fileData = parse(fileContent, { skipFirstRow: true, strip: true });
 console.log(fileData);
 
 // You can also parse CSV strings directly. The value is returned as an


### PR DESCRIPTION
Adds an example showing how to read and parse a CSV file with `Deno.readTextFile` at the top of the page, addressing feedback that the existing example only covered hardcoded strings. The original string-based examples are kept below for reference, and `@run` gains `-R` so the example runs with read permission.

Closes #2894