### PR TITLE
docs: fix static module graph description to include all module sources

### DIFF
--- a/runtime/fundamentals/security.md
+++ b/runtime/fundamentals/security.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-26
+last_modified: 2026-05-21
 title: "Security and permissions"
 description: "A guide to Deno's security model and permissions system. Learn about secure defaults, permission flags, runtime prompts, and how to safely execute code with granular access controls."
 oldUrl:
@@ -45,11 +45,14 @@ the key principles of Deno's security model:
 - **Code can not escalate its privileges without user consent**: Code executing
   in a Deno runtime can not escalate its privileges without the user agreeing
   explicitly to an escalation via interactive prompt or a invocation time flag.
-- **The initial static module graph can import local files without
-  restrictions**: All files that are imported in the initial static module graph
-  can be imported without restrictions, so even if an explicit read permission
-  is not granted for that file. This does not apply to any dynamic module
-  imports.
+- **The initial static module graph can import modules without restrictions**:
+  All modules that are imported in the initial static module graph (local files,
+  npm packages, jsr packages, and remote URLs) are loaded by the runtime without
+  consulting the permission system. No `--allow-read` is required to load local
+  files, and no `--allow-net` is required to fetch remote modules. This
+  exemption applies only to loading. Once code runs, anything it does still goes
+  through the permission system, and dynamic imports are not covered by the
+  exemption.
 
 These key principles are designed to provide an environment where a user can
 execute code with minimal risk of harm to the host machine or network. The


### PR DESCRIPTION
## Summary
- Fixes the "key principles" bullet in the security page that incorrectly stated only local files can be imported without restrictions in the static module graph
- Updates wording to clarify that npm packages, jsr packages, and remote URLs are also loaded without restrictions in the initial static module graph

Closes #2686

## Test plan
- [ ] Verify the updated bullet point renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)