### PR TITLE
docs: clarify that ignore skips evaluation and type-checking

### DIFF
--- a/runtime/reference/documentation.md
+++ b/runtime/reference/documentation.md
@@ -41,7 +41,7 @@ If no language identifier is specified then the language is inferred from media
 type of the source document that the code block is extracted from.
 
 Another attribute supported is `ignore`, which tells the test runner to skip
-type-checking the code block.
+evaluation and type-checking of the code block.
 
 ````ts
 /**


### PR DESCRIPTION
## Summary
- Fixes the description of the `ignore` attribute for doc test code blocks to mention it skips both evaluation and type-checking, not just type-checking

Closes #2657

## Test plan
- [ ] Verify the updated text renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)