### PR TITLE
docs: fix outdated OpenTelemetry api example

### DIFF
--- a/examples/tutorials/basic_opentelemetry.md
+++ b/examples/tutorials/basic_opentelemetry.md
@@ -22,7 +22,7 @@ Let's start by creating a basic HTTP server that simulates a small web
 application:
 
 ```ts title="server.ts"
-import { metrics, trace } from "npm:@opentelemetry/api@1";
+import { metrics, SpanStatusCode, trace } from "npm:@opentelemetry/api@1";
 
 // Create a tracer and meter for our application
 const tracer = trace.getTracer("my-server", "1.0.0");
@@ -94,7 +94,7 @@ Deno.serve({ port: 8000 }, (req) => {
       if (error instanceof Error) {
         span.recordException(error);
         span.setStatus({
-          code: trace.SpanStatusCode.ERROR,
+          code: SpanStatusCode.ERROR,
           message: error.message,
         });
       }


### PR DESCRIPTION
## Problem

`trace.SpanStatusCode.ERROR` is not available in @opentelemetry/api 1.x.

```bash
deno check server.ts

TS2339 [ERROR]: Property 'SpanStatusCode' does not exist on type 'TraceAPI'.
          code: trace.SpanStatusCode.ERROR,
                      ~~~~~~~~~~~~~~
```

## Changes

- Import `SpanStatusCode` directly from `@opentelemetry/api`
- Replace `trace.SpanStatusCode.ERROR` with `SpanStatusCode.ERROR`