### PR TITLE
docs: link to @std/fs exists from file-existence example

### DIFF
--- a/examples/scripts/checking_file_existence.ts
+++ b/examples/scripts/checking_file_existence.ts
@@ -3,6 +3,8 @@
  * @difficulty beginner
  * @tags cli, deploy
  * @run -R -W <url>
+ * @resource {https://jsr.io/@std/fs/doc/exists/~} Doc: @std/fs/exists
+ * @resource {https://docs.deno.com/api/deno/~/Deno.lstat} Doc: Deno.lstat
  * @group File System
  *
  * When creating files it can be useful to first ensure that


### PR DESCRIPTION
## Summary

Adds reference links to `@std/fs exists` and `Deno.lstat` in the "Checking for file existence" example, matching the `@resource` pattern used by other file-system examples (e.g. `walking_directories.ts`).

## Issue

Fixes #3052

## Changes

- `examples/scripts/checking_file_existence.ts` — add two `@resource` entries pointing at `jsr.io/@std/fs/doc/exists/~` and `docs.deno.com/api/deno/~/Deno.lstat`, matching the APIs the example already imports/uses.

## Testing

- Docs-only change, no runtime code modified.