### PR TITLE
Fix bundle command syntax in documentation

### DIFF
--- a/runtime/reference/cli/bundle.md
+++ b/runtime/reference/cli/bundle.md
@@ -14,7 +14,7 @@ JavaScript file.
 ## Basic usage
 
 ```sh
-deno bundle main.ts output.js
+deno bundle -o output.js main.ts
 ```
 
 The output file can then be run with Deno or in other JavaScript runtimes:


### PR DESCRIPTION
I believe the current deno docs are incorrect for the first code block under [Basic usage](https://docs.deno.com/runtime/reference/cli/bundle/#basic-usage)

It shows:
```bash
deno bundle main.ts output.js
```
Which does not work for me on deno 2.7.5. I believe the above is missing the `-o` output flag. It should be something like this:
```bash
deno bundle -o output.js main.ts
```