### PR TITLE
docs: mark `no-process-global` and `no-node-globals` as opt-in (2.8)

### DIFF
--- a/lint/rules/no-node-globals.md
+++ b/lint/rules/no-node-globals.md
@@ -1,5 +1,5 @@
 ---
-tags: [recommended]
+tags: []
 ---
 
 Disallows the use of NodeJS global objects.
@@ -7,6 +7,19 @@ Disallows the use of NodeJS global objects.
 NodeJS exposes a set of global objects that differs from deno (and the web), so
 code should not assume they are available. Instead, import the objects from
 their defining modules as needed.
+
+This rule is **off by default** as of Deno 2.8. To opt in, add it to your
+`deno.json`:
+
+```json
+{
+  "lint": {
+    "rules": {
+      "include": ["no-node-globals"]
+    }
+  }
+}
+```
 
 **Invalid:**
 

--- a/lint/rules/no-process-global.md
+++ b/lint/rules/no-process-global.md
@@ -1,5 +1,5 @@
 ---
-tags: [recommended]
+tags: []
 ---
 
 Disallows the use of NodeJS `process` global.
@@ -7,6 +7,19 @@ Disallows the use of NodeJS `process` global.
 NodeJS and Deno expose `process` global but they are hard to statically analyze
 by tools, so code should not assume they are available. Instead,
 `import process from "node:process"`.
+
+This rule is **off by default** as of Deno 2.8. To opt in, add it to your
+`deno.json`:
+
+```json
+{
+  "lint": {
+    "rules": {
+      "include": ["no-process-global"]
+    }
+  }
+}
+```
 
 **Invalid:**
 

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -173,8 +173,10 @@ in Deno:
 
 - `process` - Deno provides the `process` global, which is by far the most
   popular global used in popular npm packages. It is available to all code.
-  However, Deno will guide you towards importing it explicitly from
-  `node:process` module by providing lint warnings and quick-fixes:
+  Deno can also guide you towards importing it explicitly from `node:process`.
+  Opt in by enabling the
+  [`no-process-global`](/lint/rules/no-process-global/) lint rule (off by
+  default since Deno 2.8):
 
 ```js title="process.js"
 console.log(process.versions.deno);

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -172,11 +172,10 @@ Here are a few globals that you might encounter in the wild and how to use them
 in Deno:
 
 - `process` - Deno provides the `process` global, which is by far the most
-  popular global used in popular npm packages. It is available to all code.
-  Deno can also guide you towards importing it explicitly from `node:process`.
-  Opt in by enabling the
-  [`no-process-global`](/lint/rules/no-process-global/) lint rule (off by
-  default since Deno 2.8):
+  popular global used in popular npm packages. It is available to all code. Deno
+  can also guide you towards importing it explicitly from `node:process`. Opt in
+  by enabling the [`no-process-global`](/lint/rules/no-process-global/) lint
+  rule (off by default since Deno 2.8):
 
 ```js title="process.js"
 console.log(process.versions.deno);


### PR DESCRIPTION
## Summary

Documents the lint default change shipping in Deno 2.8 ([denoland/deno#33247](https://github.com/denoland/deno/pull/33247)). `deno_lint` 0.84.0 removes `no-process-global` and `no-node-globals` from the recommended set, so they are off by default.

- Drops the `recommended` tag from both rule pages.
- Adds a short opt-in `deno.json` snippet to each rule page.
- Tweaks `runtime/fundamentals/node.md` to match — the warning shown in the example is now opt-in, not default.

## Test plan

- [x] `deno task serve` renders the two rule pages and the Node.js page without layout regressions.
- [ ] Confirm with reviewers whether the lint index (`/lint/`) needs the rule list adjusted — these rules will no longer appear under the "recommended" filter, which is the intent.