### PR TITLE
docs: add `deno bump-version` reference page (2.8)

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -113,6 +113,10 @@ export const sidebar = [
             href: "/runtime/reference/cli/bench/",
           },
           {
+            title: "deno bump-version",
+            href: "/runtime/reference/cli/bump_version/",
+          },
+          {
             title: "deno bundle",
             href: "/runtime/reference/cli/bundle/",
           },

--- a/runtime/reference/cli/bump_version.md
+++ b/runtime/reference/cli/bump_version.md
@@ -1,0 +1,52 @@
+---
+last_modified: 2026-04-29
+title: "deno bump-version"
+command: bump-version
+openGraphLayout: "/open_graph/cli-commands.jsx"
+openGraphTitle: "deno bump-version"
+description: "Bump the project version field in deno.json or package.json"
+---
+
+The `deno bump-version` command updates the `version` field in your project's
+configuration file. It works with the first `version` field found in either
+`deno.json(c)` or `package.json`, similar to `npm version`.
+
+## Usage
+
+```sh
+deno bump-version <increment>
+```
+
+The `increment` argument selects how the version is bumped:
+
+| Increment    | Example                |
+| ------------ | ---------------------- |
+| `patch`      | `1.4.6` → `1.4.7`      |
+| `minor`      | `1.4.6` → `1.5.0`      |
+| `major`      | `1.4.6` → `2.0.0`      |
+| `prepatch`   | `1.4.6` → `1.4.7-0`    |
+| `preminor`   | `1.4.6` → `1.5.0-0`    |
+| `premajor`   | `1.4.6` → `2.0.0-0`    |
+| `prerelease` | `1.4.7-0` → `1.4.7-1`  |
+
+## Examples
+
+Release a patch:
+
+```sh
+deno bump-version patch
+```
+
+Cut a new minor release:
+
+```sh
+deno bump-version minor
+```
+
+Iterate on a prerelease:
+
+```sh
+deno bump-version prerelease
+```
+
+After bumping, commit the updated configuration file as part of your release.

--- a/runtime/reference/cli/bump_version.md
+++ b/runtime/reference/cli/bump_version.md
@@ -25,21 +25,21 @@ deno bump-version [increment]
 
 The `increment` argument selects how the version is bumped:
 
-| Increment    | Example                |
-| ------------ | ---------------------- |
-| `patch`      | `1.4.6` → `1.4.7`      |
-| `minor`      | `1.4.6` → `1.5.0`      |
-| `major`      | `1.4.6` → `2.0.0`      |
-| `prepatch`   | `1.4.6` → `1.4.7-0`    |
-| `preminor`   | `1.4.6` → `1.5.0-0`    |
-| `premajor`   | `1.4.6` → `2.0.0-0`    |
-| `prerelease` | `1.4.7-0` → `1.4.7-1`  |
+| Increment    | Example               |
+| ------------ | --------------------- |
+| `patch`      | `1.4.6` → `1.4.7`     |
+| `minor`      | `1.4.6` → `1.5.0`     |
+| `major`      | `1.4.6` → `2.0.0`     |
+| `prepatch`   | `1.4.6` → `1.4.7-0`   |
+| `preminor`   | `1.4.6` → `1.5.0-0`   |
+| `premajor`   | `1.4.6` → `2.0.0-0`   |
+| `prerelease` | `1.4.7-0` → `1.4.7-1` |
 
 If `increment` is omitted, the current version is printed and the configuration
 file is left unchanged.
 
-If the configuration file has no `version` field and an increment is given,
-the version defaults to `0.1.0`.
+If the configuration file has no `version` field and an increment is given, the
+version defaults to `0.1.0`.
 
 The command exits with an error if neither `deno.json` nor `package.json` is
 found in the current directory.

--- a/runtime/reference/cli/bump_version.md
+++ b/runtime/reference/cli/bump_version.md
@@ -8,13 +8,19 @@ description: "Bump the project version field in deno.json or package.json"
 ---
 
 The `deno bump-version` command updates the `version` field in your project's
-configuration file. It works with the first `version` field found in either
-`deno.json(c)` or `package.json`, similar to `npm version`.
+configuration file, similar to `npm version`. It reads and writes the `version`
+field in `deno.json(c)` if present, otherwise it falls back to `package.json`.
+
+:::caution
+
+`deno bump-version` is experimental and subject to change.
+
+:::
 
 ## Usage
 
 ```sh
-deno bump-version <increment>
+deno bump-version [increment]
 ```
 
 The `increment` argument selects how the version is bumped:
@@ -28,6 +34,15 @@ The `increment` argument selects how the version is bumped:
 | `preminor`   | `1.4.6` → `1.5.0-0`    |
 | `premajor`   | `1.4.6` → `2.0.0-0`    |
 | `prerelease` | `1.4.7-0` → `1.4.7-1`  |
+
+If `increment` is omitted, the current version is printed and the configuration
+file is left unchanged.
+
+If the configuration file has no `version` field and an increment is given,
+the version defaults to `0.1.0`.
+
+The command exits with an error if neither `deno.json` nor `package.json` is
+found in the current directory.
 
 ## Examples
 
@@ -47,6 +62,12 @@ Iterate on a prerelease:
 
 ```sh
 deno bump-version prerelease
+```
+
+Print the current version without modifying the file:
+
+```sh
+deno bump-version
 ```
 
 After bumping, commit the updated configuration file as part of your release.

--- a/runtime/reference/cli/index.md
+++ b/runtime/reference/cli/index.md
@@ -25,6 +25,8 @@ below for more information on each subcommand.
 - [deno approve-scripts](/runtime/reference/cli/approve_scripts) - manage
   lifecycle scripts of npm packages
 - [deno audit](/runtime/reference/cli/audit) - audit dependencies
+- [deno bump-version](/runtime/reference/cli/bump_version/) - bump the project
+  version in `deno.json` or `package.json`
 - deno cache - _(Deprecated. Please use
   [deno install](/runtime/reference/cli/install/))_
 - [deno install](/runtime/reference/cli/install/) - install a dependency or a


### PR DESCRIPTION
## Summary

Adds a CLI reference page for the new `deno bump-version` subcommand shipping in Deno 2.8 ([denoland/deno#30562](https://github.com/denoland/deno/pull/30562)).

The command updates the `version` field in `deno.json(c)` or `package.json` and accepts the same seven semver-style increments as `npm version` (`patch`, `minor`, `major`, `prepatch`, `preminor`, `premajor`, `prerelease`).

- New page at `runtime/reference/cli/bump_version.md` with usage and an examples table.
- Entry added to the CLI sidebar (`runtime/_data.ts`) and to the CLI index page.

## Test plan

- [x] `deno task serve` — page renders, sidebar entry resolves.
- [ ] After 2.8 ships, the auto-generated CLI flag table will pick up `bump-version`; we can extend the page then if any new flags are added.