### PR TITLE
docs: document `import defer` syntax (2.8)

### DIFF
--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -108,6 +108,30 @@ Uint8Array(12) [
 // ]
 ```
 
+## Deferred module evaluation
+
+Starting in Deno 2.8, the
+[TC39 Deferred Module Evaluation proposal](https://github.com/tc39/proposal-defer-import-eval)
+is supported. The `import defer` syntax loads a module — including its
+dependencies — but does **not** execute its top-level code until you first read
+a property from the namespace:
+
+```ts title="main.ts"
+import defer * as expensive from "./expensive.ts";
+
+console.log("startup is fast — expensive.ts has not run yet");
+
+// Touching any property triggers synchronous evaluation
+console.log(expensive.value);
+```
+
+Use it to defer the cost of modules that are only needed conditionally — for
+example, error-path code in a CLI tool or feature flags whose implementation is
+heavy to initialize.
+
+The proposal is still at TC39 Stage 3, so the syntax is considered experimental
+and may change. Standard `import` remains the right default.
+
 ## WebAssembly modules
 
 Deno supports importing Wasm modules directly:

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -112,9 +112,9 @@ Uint8Array(12) [
 
 Starting in Deno 2.8, the
 [TC39 Deferred Module Evaluation proposal](https://github.com/tc39/proposal-defer-import-eval)
-is supported. The `import defer` syntax loads a module — including its
-dependencies — but does **not** execute its top-level code until you first read
-a property from the namespace:
+is supported. The `import defer` syntax loads a module (including its
+dependencies) but does **not** execute its top-level code until you first read a
+property from the namespace:
 
 ```ts title="main.ts"
 import defer * as expensive from "./expensive.ts";
@@ -125,7 +125,7 @@ console.log("startup is fast — expensive.ts has not run yet");
 console.log(expensive.value);
 ```
 
-Use it to defer the cost of modules that are only needed conditionally — for
+Use it to defer the cost of modules that are only needed conditionally; for
 example, error-path code in a CLI tool or feature flags whose implementation is
 heavy to initialize.
 


### PR DESCRIPTION
## Summary

Documents experimental support for the [TC39 Deferred Module Evaluation proposal](https://github.com/tc39/proposal-defer-import-eval), shipping in Deno 2.8 ([denoland/deno#32360](https://github.com/denoland/deno/pull/32360)).

- Adds a "Deferred module evaluation" section to `runtime/fundamentals/modules.md` covering the `import defer * as ns from "..."` syntax, lazy-evaluation semantics, and a typical use case.
- Notes the proposal is still at TC39 Stage 3 and the syntax may change.

## Test plan

- [x] `deno task serve` renders the new section.