### PR TITLE
docs: note Node.js `Timeout` return for global timers (2.8)

### DIFF
--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -231,6 +231,21 @@ subclasses instead.
 
 - `__dirname` - use `import.meta.dirname` instead.
 
+- `setTimeout` / `setInterval` - starting in Deno 2.8, the global timer
+  functions return a Node.js
+  [`Timeout`](https://nodejs.org/api/timers.html#class-timeout) object instead
+  of a number, matching Node.js semantics. The returned object exposes methods
+  like `.ref()`, `.unref()`, `.refresh()`, and `.hasRef()`. It still coerces to
+  a number (via `Symbol.toPrimitive`), so existing code that stores the timer
+  ID as a number or passes it to `clearTimeout`/`clearInterval` continues to
+  work unchanged.
+
+  ```ts
+  const t = setTimeout(() => {}, 1000);
+  t.unref(); // don't keep the event loop alive for this timer
+  clearTimeout(t);
+  ```
+
 ## CommonJS support
 
 Deno supports CommonJS modules by default.

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-02-10
+last_modified: 2026-05-20
 title: "Node and npm Compatibility"
 description: "Guide to using Node.js modules and npm packages in Deno. Learn about compatibility features, importing npm packages, and differences between Node.js and Deno environments."
 oldUrl:


### PR DESCRIPTION
## Summary

Documents the global-timer behavior change shipping in Deno 2.8 ([denoland/deno#33249](https://github.com/denoland/deno/pull/33249)). Global `setTimeout` / `setInterval` now return a Node.js
[`Timeout`](https://nodejs.org/api/timers.html#class-timeout) object instead of a number, matching Node.js semantics.

- Adds a `setTimeout` / `setInterval` bullet to the "Node.js global objects" section in `runtime/fundamentals/node.md`.
- Calls out the new `.ref()` / `.unref()` / `.refresh()` / `.hasRef()` methods.
- Notes that numeric coercion still works via `Symbol.toPrimitive`, so existing code is unaffected.

## Test plan

- [x] `deno task serve` renders the new bullet inside the existing list.