### PR TITLE
docs: add `deno why` reference page (2.8)

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -237,6 +237,10 @@ export const sidebar = [
             href: "/runtime/reference/cli/unstable_flags/",
           },
           {
+            title: "deno why",
+            href: "/runtime/reference/cli/why/",
+          },
+          {
             title: "deno x",
             href: "/runtime/reference/cli/x/",
           },

--- a/runtime/reference/cli/index.md
+++ b/runtime/reference/cli/index.md
@@ -34,6 +34,8 @@ below for more information on each subcommand.
 - [deno remove](/runtime/reference/cli/remove) - Remove dependencies
 - [deno outdated](/runtime/reference/cli/outdated) - view or update outdated
   dependencies
+- [deno why](/runtime/reference/cli/why/) - explain why a package is in the
+  dependency tree
 
 ## Tooling
 

--- a/runtime/reference/cli/why.md
+++ b/runtime/reference/cli/why.md
@@ -1,0 +1,49 @@
+---
+last_modified: 2026-04-29
+title: "deno why"
+command: why
+openGraphLayout: "/open_graph/cli-commands.jsx"
+openGraphTitle: "deno why"
+description: "Explain why a package is installed by showing its dependency chains"
+---
+
+The `deno why` command explains why a particular package is installed by
+printing every dependency path from your project's direct dependencies down to
+the queried package. It reads the lockfile, so it works regardless of which
+node_modules / npm resolver mode you use.
+
+## Usage
+
+```sh
+deno why <package>
+```
+
+The argument is an npm or JSR package name, optionally pinned to a specific
+version with `@<version>`.
+
+## Examples
+
+Find every path that pulls in `ms`:
+
+```sh
+deno why ms
+ms@2.0.0
+  npm:express@^4.18.0 > debug@2.6.9 > ms@2.0.0
+  npm:express@^4.18.0 > body-parser@1.20.4 > debug@2.6.9 > ms@2.0.0
+  npm:express@^4.18.0 > finalhandler@1.3.2 > debug@2.6.9 > ms@2.0.0
+
+ms@2.1.3
+  npm:express@^4.18.0 > send@0.19.2 > ms@2.1.3
+```
+
+When more than one version is in the tree, each is shown in its own block.
+
+Filter to a single version:
+
+```sh
+deno why ms@2.0.0
+```
+
+If the package is not part of the resolved dependency tree, `deno why` reports
+that and exits non-zero — useful in CI scripts that assert a package is _not_
+pulled in.

--- a/runtime/reference/cli/why.md
+++ b/runtime/reference/cli/why.md
@@ -45,5 +45,5 @@ deno why ms@2.0.0
 ```
 
 If the package is not part of the resolved dependency tree, `deno why` reports
-that and exits non-zero — useful in CI scripts that assert a package is _not_
+that and exits non-zero: useful in CI scripts that assert a package is _not_
 pulled in.


### PR DESCRIPTION
## Summary

Adds a CLI reference page for the new `deno why <package>` subcommand shipping in Deno 2.8 ([denoland/deno#32908](https://github.com/denoland/deno/pull/32908)). The command prints every dependency path that pulls a package into the project, reading from the lockfile.

- New page at `runtime/reference/cli/why.md` with usage and example output (multiple versions, version filtering, missing-package case).
- Sidebar entry in `runtime/_data.ts` and an entry in the CLI index page.

## Test plan

- [x] `deno task serve` — page renders, sidebar entry resolves.
- [ ] If the upstream PR's flag set changes before merge, this page may need a refresh.