### PR TITLE
docs: add `deno transpile` reference page (2.8)

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -217,6 +217,10 @@ export const sidebar = [
             href: "/runtime/reference/cli/test/",
           },
           {
+            title: "deno transpile",
+            href: "/runtime/reference/cli/transpile/",
+          },
+          {
             title: "deno types",
             href: "/runtime/reference/cli/types/",
           },

--- a/runtime/reference/cli/index.md
+++ b/runtime/reference/cli/index.md
@@ -60,6 +60,8 @@ below for more information on each subcommand.
 - [deno lsp](/runtime/reference/cli/lsp/) - language server protocol integration
 - [deno publish](/runtime/reference/cli/publish/) - publish a module to JSR
 - [deno test](/runtime/reference/cli/test/) - run your tests
+- [deno transpile](/runtime/reference/cli/transpile/) - transpile TypeScript,
+  JSX, or TSX to JavaScript
 - [deno types](/runtime/reference/cli/types/) - print runtime types
 - [deno upgrade](/runtime/reference/cli/upgrade/) - upgrade Deno to the latest
   version

--- a/runtime/reference/cli/transpile.md
+++ b/runtime/reference/cli/transpile.md
@@ -1,0 +1,65 @@
+---
+last_modified: 2026-04-29
+title: "deno transpile"
+command: transpile
+openGraphLayout: "/open_graph/cli-commands.jsx"
+openGraphTitle: "deno transpile"
+description: "Transpile TypeScript, JSX, or TSX to JavaScript"
+---
+
+The `deno transpile` command emits JavaScript from TypeScript, JSX, or TSX
+sources. It is useful when you need plain `.js` output to ship to a runtime
+that does not understand TypeScript, or to feed into a build step that expects
+JavaScript.
+
+For most workflows you do **not** need `deno transpile` — `deno run`,
+`deno test`, and `deno serve` already accept `.ts`/`.tsx` files directly.
+
+## Usage
+
+```sh
+deno transpile <input> [flags]
+```
+
+### Output modes
+
+- **stdout** (default): write the transpiled output to standard out.
+- **single file** with `-o <path>`: write a single input file's output to
+  `<path>`.
+- **directory** with `--outdir <dir>`: transpile multiple inputs and mirror the
+  layout under `<dir>`.
+
+```sh
+# Print to stdout
+deno transpile main.ts
+
+# Write to a single file
+deno transpile main.ts -o dist/main.js
+
+# Transpile a tree of files
+deno transpile src/ --outdir dist/
+```
+
+### Source maps
+
+Pass `--source-map` with one of:
+
+| Mode       | Effect                                                 |
+| ---------- | ------------------------------------------------------ |
+| `none`     | (default) no source map                                |
+| `inline`   | embed the source map as a `data:` comment in each file |
+| `separate` | write a sibling `.js.map` file                         |
+
+```sh
+deno transpile main.ts -o dist/main.js --source-map separate
+```
+
+### Type declarations
+
+Use `--declaration` to emit `.d.ts` files alongside the JavaScript output.
+Declarations are produced by the TypeScript compiler, so this flag honors the
+`compilerOptions` from your `deno.json` / `tsconfig.json`.
+
+```sh
+deno transpile src/ --outdir dist/ --declaration
+```

--- a/runtime/reference/cli/transpile.md
+++ b/runtime/reference/cli/transpile.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-04-29
+last_modified: 2026-05-20
 title: "deno transpile"
 command: transpile
 openGraphLayout: "/open_graph/cli-commands.jsx"
@@ -8,8 +8,8 @@ description: "Transpile TypeScript, JSX, or TSX to JavaScript"
 ---
 
 The `deno transpile` command emits JavaScript from TypeScript, JSX, or TSX
-sources. It is useful when you need plain `.js` output to ship to a runtime
-that does not understand TypeScript, or to feed into a build step that expects
+sources. It is useful when you need plain `.js` output to ship to a runtime that
+does not understand TypeScript, or to feed into a build step that expects
 JavaScript.
 
 For most workflows you do **not** need `deno transpile` — `deno run`,
@@ -18,16 +18,20 @@ For most workflows you do **not** need `deno transpile` — `deno run`,
 ## Usage
 
 ```sh
-deno transpile <input> [flags]
+deno transpile <files...> [flags]
 ```
+
+`<files>` is one or more source file paths (globs are expanded by the shell).
+`deno transpile` does **not** crawl a directory — pass the files you want
+transpiled, optionally via a shell glob.
 
 ### Output modes
 
 - **stdout** (default): write the transpiled output to standard out.
-- **single file** with `-o <path>`: write a single input file's output to
-  `<path>`.
-- **directory** with `--outdir <dir>`: transpile multiple inputs and mirror the
-  layout under `<dir>`.
+- **single file** with `-o <path>`: write the output to `<path>`. Conflicts with
+  `--outdir`.
+- **directory** with `--outdir <dir>`: write the output of each input file into
+  `<dir>`, mirroring the source layout.
 
 ```sh
 # Print to stdout
@@ -36,9 +40,26 @@ deno transpile main.ts
 # Write to a single file
 deno transpile main.ts -o dist/main.js
 
-# Transpile a tree of files
-deno transpile src/ --outdir dist/
+# Transpile multiple files into an output directory
+deno transpile src/main.ts src/helpers.ts --outdir dist
+
+# Use a shell glob
+deno transpile src/*.ts --outdir dist
 ```
+
+### Input/output extension mapping
+
+| Input  | Output | Source map |
+| ------ | ------ | ---------- |
+| `.ts`  | `.js`  | `.js.map`  |
+| `.tsx` | `.js`  | `.js.map`  |
+| `.jsx` | `.js`  | `.js.map`  |
+| `.mts` | `.mjs` | `.mjs.map` |
+| `.cts` | `.cjs` | `.cjs.map` |
+
+JSX transform, decorators, and other emit settings come from `compilerOptions`
+in your `deno.json` (or `tsconfig.json`), so the output matches what `deno run`
+would execute.
 
 ### Source maps
 
@@ -48,7 +69,7 @@ Pass `--source-map` with one of:
 | ---------- | ------------------------------------------------------ |
 | `none`     | (default) no source map                                |
 | `inline`   | embed the source map as a `data:` comment in each file |
-| `separate` | write a sibling `.js.map` file                         |
+| `separate` | write a sibling `.js.map` (or `.mjs.map` / `.cjs.map`) |
 
 ```sh
 deno transpile main.ts -o dist/main.js --source-map separate
@@ -56,10 +77,14 @@ deno transpile main.ts -o dist/main.js --source-map separate
 
 ### Type declarations
 
-Use `--declaration` to emit `.d.ts` files alongside the JavaScript output.
-Declarations are produced by the TypeScript compiler, so this flag honors the
-`compilerOptions` from your `deno.json` / `tsconfig.json`.
+Use `--declaration` to emit `.d.ts` declaration files. Declarations are produced
+by `tsc`, so this flag honors the `compilerOptions` from your `deno.json` /
+`tsconfig.json`.
+
+`.d.ts` files are always written to disk — next to the source when no output
+location is set, or into `--outdir` when one is supplied — even if the
+JavaScript output is going to stdout or a single `-o` file.
 
 ```sh
-deno transpile src/ --outdir dist/ --declaration
+deno transpile src/*.ts --outdir dist --declaration
 ```


### PR DESCRIPTION
## Summary

Adds a CLI reference page for the new `deno transpile` subcommand shipping in Deno 2.8 ([denoland/deno#32691](https://github.com/denoland/deno/pull/32691)). The command emits JavaScript from TypeScript / JSX / TSX sources, with configurable output paths, source maps, and `.d.ts` generation.

- New page at `runtime/reference/cli/transpile.md` — usage, the three output modes (stdout, `-o`, `--outdir`), the `--source-map` options table, and `--declaration`.
- Notes that most users don't need this — `deno run`/`deno test`/`deno serve` already accept TS directly.
- Sidebar entry in `runtime/_data.ts`, entry in the CLI index page.

## Test plan

- [x] `deno task serve` — page renders, sidebar entry resolves.
- [ ] If the upstream flag set changes (e.g. additional source-map modes), this page will need a refresh.