### PR TITLE
docs: default to npm for unprefixed names in `deno add`/`install` (2.8)

### DIFF
--- a/runtime/reference/cli/add.md
+++ b/runtime/reference/cli/add.md
@@ -21,6 +21,24 @@ Add packages from JSR and npm:
 deno add @std/path npm:express
 ```
 
+Starting in Deno 2.8, **unprefixed names default to the npm registry**, since
+npm is by far the most common source. Explicit `npm:` and `jsr:` prefixes
+always take precedence:
+
+```sh
+# Resolves from npm by default
+deno add express react
+
+# Mixed sources still work with explicit prefixes
+deno add express jsr:@std/async
+```
+
+To resolve unprefixed names from JSR instead, pass `--jsr`:
+
+```sh
+deno add --jsr @std/path
+```
+
 By default, dependencies are added with a caret (`^`) version range. Use
 `--save-exact` to pin to an exact version:
 
@@ -30,12 +48,6 @@ deno add --save-exact @std/path
 
 This saves the dependency without the `^` prefix (e.g., `1.0.0` instead of
 `^1.0.0`).
-
-Treat unprefixed package names as npm packages:
-
-```sh
-deno add --npm express
-```
 
 ## Where dependencies are stored
 

--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -36,6 +36,15 @@ Use this command to install particular packages and add them to `deno.json` or
 deno install jsr:@std/testing npm:express
 ```
 
+Starting in Deno 2.8, unprefixed names default to npm:
+
+```sh
+deno install express react jsr:@std/async
+```
+
+Use `--jsr` to resolve unprefixed names from JSR instead. Explicit `npm:` and
+`jsr:` prefixes always win.
+
 :::tip
 
 You can also use `deno add` which is an alias to `deno install [PACKAGES]`


### PR DESCRIPTION
## Summary

Documents the behavior change in Deno 2.8 ([denoland/deno#33246](https://github.com/denoland/deno/pull/33246)): `deno add express` and `deno install express` now resolve from the npm registry without needing `npm:` or `--npm`.

- Updates `runtime/reference/cli/add.md` to describe the new default and how `--jsr` flips the default for unprefixed names.
- Updates `runtime/reference/cli/install.md` similarly.
- Notes that explicit `npm:` / `jsr:` prefixes still take precedence over the default.

## Test plan

- [x] `deno task serve` — both pages render.