### PR TITLE
docs: document `--package-json` flag (2.8)

### DIFF
--- a/runtime/reference/cli/add.md
+++ b/runtime/reference/cli/add.md
@@ -42,3 +42,16 @@ deno add --npm express
 If your project has a `package.json`, npm packages will be added to
 `dependencies` in `package.json`. Otherwise, all packages are added to the
 `imports` field in [`deno.json`](/runtime/fundamentals/configuration/).
+
+To force every dependency to be written to `package.json` (creating one if
+needed), pass `--package-json` (Deno 2.8+):
+
+```sh
+deno add --package-json npm:express jsr:@std/path
+```
+
+JSR packages added with `--package-json` are written in their npm-compatible
+form (`npm:@jsr/...`). The same flag works on
+[`deno install`](/runtime/reference/cli/install/),
+[`deno remove`](/runtime/reference/cli/remove/), and
+[`deno uninstall`](/runtime/reference/cli/uninstall/).

--- a/runtime/reference/cli/add.md
+++ b/runtime/reference/cli/add.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-12
+last_modified: 2026-05-20
 title: "deno add"
 command: add
 openGraphLayout: "/open_graph/cli-commands.jsx"

--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -46,6 +46,22 @@ If your project has a `package.json` file, the packages coming from npm will be
 added to `dependencies` in `package.json`. Otherwise all packages will be added
 to `deno.json`.
 
+### deno install --package-json
+
+By default, Deno picks the configuration file to write to (`deno.json` or
+`package.json`) based on which one is closest to the current working directory.
+Starting in Deno 2.8, `--package-json` forces dependencies to be written to
+`package.json`, regardless of any nearby `deno.json`. If no `package.json`
+exists yet, one is created.
+
+```sh
+deno install --package-json npm:express jsr:@std/path
+```
+
+JSR packages added with `--package-json` are written in their npm-compatible
+form (`npm:@jsr/...`). The same flag works on `deno add`, `deno remove`, and
+`deno uninstall`.
+
 ### deno install --entrypoint [FILES]
 
 Use this command to install all dependencies that are used in the provided files

--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-12
+last_modified: 2026-05-20
 title: "deno install"
 oldUrl:
   - /runtime/manual/tools/script_installer/


### PR DESCRIPTION
## Summary

Documents the new `--package-json` flag added to `deno add` / `install` / `remove` / `uninstall` in Deno 2.8 ([denoland/deno#33199](https://github.com/denoland/deno/pull/33199)). When set, dependency management is forced to operate on `package.json` (creating one if necessary), bypassing the distance-based config-file heuristic.

- New "deno install --package-json" subsection in `runtime/reference/cli/install.md`.
- Companion paragraph in `runtime/reference/cli/add.md` under "Where dependencies are stored".
- Calls out the JSR-to-npm-compat (`npm:@jsr/...`) rewrite when JSR deps go into `package.json`.

## Test plan

- [x] `deno task serve` — both pages render.
- [ ] If reviewers prefer one combined section instead of edits in two pages, happy to refactor.