### PR TITLE
docs: document framework detection in `deno compile` (2.8)

### DIFF
--- a/runtime/reference/cli/compile.md
+++ b/runtime/reference/cli/compile.md
@@ -30,6 +30,41 @@ deno compile --allow-read --allow-net jsr:@std/http/file-server -p 8080
 ./file_server --help
 ```
 
+## Framework detection
+
+Starting in Deno 2.8, `deno compile .` (or `deno compile <directory>`) detects
+common web frameworks and produces an entrypoint that knows how to start them.
+The detected build script is run via `deno task build` first, so the compiled
+binary always contains a fresh build.
+
+Supported frameworks:
+
+- Next.js
+- Astro
+- Fresh (1.x and 2.x)
+- Remix
+- SvelteKit
+- Nuxt
+- SolidStart
+- TanStack Start
+- Vite (SSR mode)
+
+```sh
+# In a Next.js / Astro / Fresh / etc. project
+deno compile .
+
+# Or pointing at a specific app directory
+deno compile ./apps/web
+```
+
+Generated entrypoints use `import.meta.dirname` so framework asset paths
+resolve correctly against the
+[virtual filesystem](#including-data-files-or-directories) inside the compiled
+binary.
+
+If the project doesn't match any supported framework, `deno compile` errors
+out — pass an explicit entrypoint file in that case.
+
 ## Cross Compilation
 
 You can cross-compile binaries for other platforms by using the `--target` flag.

--- a/runtime/reference/cli/compile.md
+++ b/runtime/reference/cli/compile.md
@@ -34,8 +34,8 @@ deno compile --allow-read --allow-net jsr:@std/http/file-server -p 8080
 
 Starting in Deno 2.8, `deno compile .` (or `deno compile <directory>`) detects
 common web frameworks and produces an entrypoint that knows how to start them.
-The detected build script is run via `deno task build` first, so the compiled
-binary always contains a fresh build.
+The detected build script is run first, so the compiled binary always contains a
+fresh build.
 
 Supported frameworks:
 
@@ -57,13 +57,12 @@ deno compile .
 deno compile ./apps/web
 ```
 
-Generated entrypoints use `import.meta.dirname` so framework asset paths
-resolve correctly against the
-[virtual filesystem](#including-data-files-or-directories) inside the compiled
-binary.
+Generated entrypoints use `import.meta.dirname` so framework asset paths resolve
+correctly against the [virtual filesystem](#including-data-files-or-directories)
+inside the compiled binary.
 
-If the project doesn't match any supported framework, `deno compile` errors
-out — pass an explicit entrypoint file in that case.
+If the project doesn't match any supported framework, `deno compile` will error
+out.
 
 ## Cross Compilation
 


### PR DESCRIPTION
## Summary

Documents the new framework-detection behavior of `deno compile` in Deno 2.8 ([denoland/deno#33164](https://github.com/denoland/deno/pull/33164)). Pointing `deno compile` at a directory now detects common web frameworks, runs `deno task build`, and generates an appropriate entrypoint.

- New "Framework detection" section in `runtime/reference/cli/compile.md` listing the supported frameworks (Next.js, Astro, Fresh 1.x/2.x, Remix, SvelteKit, Nuxt, SolidStart, TanStack Start, Vite SSR).
- Notes that entrypoints use `import.meta.dirname` so framework asset paths resolve against the embedded VFS.
- Mentions the explicit-entrypoint fallback when no framework matches.

## Test plan

- [x] `deno task serve` — section renders, anchor `#framework-detection` resolves, link to "Including Data Files or Directories" works.