### PR TITLE
docs: document `deno x --package` flag (2.8)

### DIFF
--- a/runtime/reference/cli/x.md
+++ b/runtime/reference/cli/x.md
@@ -45,6 +45,23 @@ Run a JSR package:
 deno x jsr:@std/http/file-server
 ```
 
+## Specifying the package separately from the binary
+
+Some npm packages expose multiple binaries — `typescript` ships both `tsc` and
+`tsserver`, for example. Starting in Deno 2.8, `--package` (`-p`) lets you
+choose the package and the binary independently, matching the
+`npx -p <package> <binary>` convention:
+
+```sh
+# Run `tsc` from the typescript package
+deno x -p typescript tsc
+
+# Pin the package version
+deno x -p typescript@5 tsc
+```
+
+The previous form `deno x typescript/tsc` still works.
+
 ## How it works
 
 `deno x` downloads the package to the global cache (if not already cached),

--- a/runtime/reference/cli/x.md
+++ b/runtime/reference/cli/x.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-12-10
+last_modified: 2026-05-20
 title: "deno x"
 command: x
 openGraphLayout: "/open_graph/cli-commands.jsx"


### PR DESCRIPTION
## Summary

Documents the new `--package` / `-p` flag on `deno x` shipping in Deno 2.8 ([denoland/deno#32855](https://github.com/denoland/deno/pull/32855)). It separates the package to install from the binary to execute, matching the `npx -p <package> <binary>` convention.

- New "Specifying the package separately from the binary" section in `runtime/reference/cli/x.md`.
- Examples for both `-p typescript tsc` and the version-pinned `-p typescript@5 tsc`.
- Notes that the existing `package/binary` form is unaffected.

## Test plan

- [x] `deno task serve` — section renders, anchor resolves.