### PR TITLE
docs: document OTLP gRPC exporter

### DIFF
--- a/runtime/fundamentals/open_telemetry.md
+++ b/runtime/fundamentals/open_telemetry.md
@@ -658,6 +658,10 @@ variables. Supported values for `OTEL_EXPORTER_OTLP_PROTOCOL` are:
 - `http/protobuf` (default): Export using Protobuf over HTTP to the configured
   endpoint.
 - `http/json`: Export using JSON over HTTP to the configured endpoint.
+- `grpc`: Export using gRPC (Protobuf over HTTP/2). Available in Deno 2.8+.
+  Useful for collectors that only accept gRPC, such as Azure Container Apps'
+  managed OpenTelemetry agent. The default OTLP gRPC port is `4317`, so you
+  typically also set `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`.
 - `console`: Print spans, logs, and metrics to stderr in a human-readable text
   format. This is useful for debugging and testing instrumentation without
   running an OTLP collector. When using `console`, no endpoint configuration is

--- a/runtime/fundamentals/open_telemetry.md
+++ b/runtime/fundamentals/open_telemetry.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-25
+last_modified: 2026-05-20
 title: OpenTelemetry
 description: "Learn how to implement observability in Deno applications using OpenTelemetry. Covers tracing, metrics collection, and integration with monitoring systems."
 ---
@@ -775,8 +775,8 @@ limitations to be aware of:
 - Metric exemplars are not supported.
 - Custom log streams (e.g. logs other than `console.log` and `console.error`)
   are not supported.
-- The supported exporters are OTLP (`http/protobuf`, `http/json`) and `console`.
-  Other exporters and protocols such as `grpc` are not supported.
+- The supported exporters are OTLP (`http/protobuf`, `http/json`, `grpc`) and
+  `console`. Other exporter formats are not supported.
 - Metrics from observable (asynchronous) meters are not collected on process
   exit/crash, so the last value of metrics may not be exported. Synchronous
   metrics are exported on process exit/crash.


### PR DESCRIPTION
## Summary

Adds `grpc` to the list of supported `OTEL_EXPORTER_OTLP_PROTOCOL` values on the OpenTelemetry page, documenting the new gRPC OTLP exporter shipping in Deno 2.8 ([denoland/deno#30365](https://github.com/denoland/deno/pull/30365)).

- Notes the default OTLP gRPC port (`4317`) so users know to set `OTEL_EXPORTER_OTLP_ENDPOINT` accordingly.
- Calls out a real-world driver (Azure Container Apps' managed OTel agent only supports gRPC).

## Test plan

- [x] `deno task serve` — Configuration section renders.