### PR TITLE
docs: document `OffscreenCanvas` (2.8)

### DIFF
--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -489,6 +489,34 @@ const worker = new Worker(import.meta.resolve("./worker.js"), {
 });
 ```
 
+## OffscreenCanvas
+
+Starting in Deno 2.8, the
+[`OffscreenCanvas`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas)
+API is available. `OffscreenCanvas` is a canvas that lives outside any DOM and
+can be used in any context — including Web Workers — for off-thread rendering
+and image generation.
+
+```ts
+const canvas = new OffscreenCanvas(256, 256);
+const ctx = canvas.getContext("2d");
+ctx.fillStyle = "tomato";
+ctx.fillRect(0, 0, 256, 256);
+
+// Encode to PNG / JPEG / WebP via convertToBlob()
+const blob = await canvas.convertToBlob({ type: "image/png" });
+await Deno.writeFile("./tile.png", new Uint8Array(await blob.arrayBuffer()));
+```
+
+Typical uses:
+
+- generating images server-side without spinning up a headless browser,
+- running 2D drawing code originally written for the browser inside a Web
+  Worker,
+- producing thumbnails or social-card images at request time.
+
+WebGL / WebGPU rendering contexts on `OffscreenCanvas` are not yet supported.
+
 ## Deviations of other APIs from spec
 
 ### Cache API

--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -494,28 +494,49 @@ const worker = new Worker(import.meta.resolve("./worker.js"), {
 Starting in Deno 2.8, the
 [`OffscreenCanvas`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas)
 API is available. `OffscreenCanvas` is a canvas that lives outside any DOM and
-can be used in any context — including Web Workers — for off-thread rendering
-and image generation.
+can be used anywhere — including Web Workers — for off-thread rendering and
+image generation.
+
+### Supported rendering contexts
+
+`OffscreenCanvas#getContext` accepts two of the spec-defined context ids:
+
+- `"bitmaprenderer"` — returns an
+  [`ImageBitmapRenderingContext`](https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmapRenderingContext)
+  for displaying an `ImageBitmap` produced via `createImageBitmap`.
+- `"webgpu"` — returns a
+  [`GPUCanvasContext`](https://developer.mozilla.org/en-US/docs/Web/API/GPUCanvasContext)
+  for rendering with WebGPU.
+
+Calling `getContext` with `"2d"`, `"webgl"`, or `"webgl2"` returns `null` —
+these contexts are not implemented in Deno.
+
+### Example: encoding an image to PNG
+
+Decode an image into an `ImageBitmap`, place it on an `OffscreenCanvas` via
+the `bitmaprenderer` context, and write the result to disk:
 
 ```ts
-const canvas = new OffscreenCanvas(256, 256);
-const ctx = canvas.getContext("2d");
-ctx.fillStyle = "tomato";
-ctx.fillRect(0, 0, 256, 256);
+const data = await Deno.readFile("./input.jpg");
+const bitmap = await createImageBitmap(new Blob([data]));
 
-// Encode to PNG / JPEG / WebP via convertToBlob()
+const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+const ctx = canvas.getContext("bitmaprenderer")!;
+ctx.transferFromImageBitmap(bitmap);
+
 const blob = await canvas.convertToBlob({ type: "image/png" });
-await Deno.writeFile("./tile.png", new Uint8Array(await blob.arrayBuffer()));
+await Deno.writeFile(
+  "./output.png",
+  new Uint8Array(await blob.arrayBuffer()),
+);
 ```
 
 Typical uses:
 
-- generating images server-side without spinning up a headless browser,
-- running 2D drawing code originally written for the browser inside a Web
-  Worker,
-- producing thumbnails or social-card images at request time.
-
-WebGL / WebGPU rendering contexts on `OffscreenCanvas` are not yet supported.
+- producing thumbnails, format conversions, or social-card images at request
+  time without spinning up a headless browser,
+- running off-thread image work inside a Web Worker,
+- driving WebGPU rendering targets that don't need a window.
 
 ## Deviations of other APIs from spec
 

--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -494,21 +494,21 @@ const worker = new Worker(import.meta.resolve("./worker.js"), {
 Starting in Deno 2.8, the
 [`OffscreenCanvas`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas)
 API is available. `OffscreenCanvas` is a canvas that lives outside any DOM and
-can be used anywhere — including Web Workers — for off-thread rendering and
+can be used anywhere (including Web Workers) for off-thread rendering and
 image generation.
 
 ### Supported rendering contexts
 
 `OffscreenCanvas#getContext` accepts two of the spec-defined context ids:
 
-- `"bitmaprenderer"` — returns an
+- `"bitmaprenderer"`: returns an
   [`ImageBitmapRenderingContext`](https://developer.mozilla.org/en-US/docs/Web/API/ImageBitmapRenderingContext)
   for displaying an `ImageBitmap` produced via `createImageBitmap`.
-- `"webgpu"` — returns a
+- `"webgpu"`: returns a
   [`GPUCanvasContext`](https://developer.mozilla.org/en-US/docs/Web/API/GPUCanvasContext)
   for rendering with WebGPU.
 
-Calling `getContext` with `"2d"`, `"webgl"`, or `"webgl2"` returns `null` —
+Calling `getContext` with `"2d"`, `"webgl"`, or `"webgl2"` returns `null`;
 these contexts are not implemented in Deno.
 
 ### Example: encoding an image to PNG

--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -513,8 +513,8 @@ these contexts are not implemented in Deno.
 
 ### Example: encoding an image to PNG
 
-Decode an image into an `ImageBitmap`, place it on an `OffscreenCanvas` via
-the `bitmaprenderer` context, and write the result to disk:
+Decode an image into an `ImageBitmap`, place it on an `OffscreenCanvas` via the
+`bitmaprenderer` context, and write the result to disk:
 
 ```ts
 const data = await Deno.readFile("./input.jpg");

--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -494,8 +494,8 @@ const worker = new Worker(import.meta.resolve("./worker.js"), {
 Starting in Deno 2.8, the
 [`OffscreenCanvas`](https://developer.mozilla.org/en-US/docs/Web/API/OffscreenCanvas)
 API is available. `OffscreenCanvas` is a canvas that lives outside any DOM and
-can be used anywhere (including Web Workers) for off-thread rendering and
-image generation.
+can be used anywhere (including Web Workers) for off-thread rendering and image
+generation.
 
 ### Supported rendering contexts
 
@@ -508,8 +508,8 @@ image generation.
   [`GPUCanvasContext`](https://developer.mozilla.org/en-US/docs/Web/API/GPUCanvasContext)
   for rendering with WebGPU.
 
-Calling `getContext` with `"2d"`, `"webgl"`, or `"webgl2"` returns `null`;
-these contexts are not implemented in Deno.
+Calling `getContext` with `"2d"`, `"webgl"`, or `"webgl2"` returns `null`; these
+contexts are not implemented in Deno.
 
 ### Example: encoding an image to PNG
 


### PR DESCRIPTION
## Summary

Documents the new `OffscreenCanvas` web API shipping in Deno 2.8 ([denoland/deno#29357](https://github.com/denoland/deno/pull/29357)).

- New "OffscreenCanvas" section in `runtime/reference/web_platform_apis.md`.
- Includes a 2D-drawing + `convertToBlob` example and a list of typical use cases (server-side image generation, Web Worker off-thread drawing, thumbnails).
- Notes the WebGL/WebGPU-on-OffscreenCanvas limitation.

## Test plan

- [x] `deno task serve` — section renders ahead of the "Deviations of other APIs from spec" heading.
- [ ] If the upstream PR's spec coverage changes (e.g. adds WebGL2 support) before merge, the limitation note should be updated.