### PR TITLE
docs: document `deno upgrade pr` (2.8)

### DIFF
--- a/runtime/reference/cli/upgrade.md
+++ b/runtime/reference/cli/upgrade.md
@@ -97,3 +97,30 @@ the `--canary` build flag for the latest canary build:
 # Upgrade to the latest canary build
 deno upgrade --canary
 ```
+
+## Install a build from a pull request
+
+Starting in Deno 2.8, `deno upgrade pr <number>` downloads the binary built by
+CI for a specific deno PR and installs it. This is handy when you need to
+verify a fix before it has shipped in a release.
+
+```sh
+# Install the binary built by CI for PR #12345
+deno upgrade pr 12345
+
+# Numeric prefix is also accepted
+deno upgrade pr '#12345'
+
+# Write to a path instead of replacing the current binary
+deno upgrade --output ./deno-test pr 12345
+
+# See what would be downloaded without replacing
+deno upgrade --dry-run pr 12345
+```
+
+This subcommand requires the [`gh` CLI](https://cli.github.com/) to be
+installed and authenticated. `deno upgrade` uses `gh` to look up the PR's CI
+run and download the matching `{profile}-{os}-{arch}-deno` artifact (for
+example `release-linux-x86_64-deno`), preferring release builds and falling
+back to debug. The downloaded binary is verified to run before it replaces
+the current executable.

--- a/runtime/reference/cli/upgrade.md
+++ b/runtime/reference/cli/upgrade.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-05
+last_modified: 2026-05-20
 title: "deno upgrade"
 oldUrl: /runtime/manual/tools/upgrade/
 command: upgrade
@@ -101,14 +101,14 @@ deno upgrade --canary
 ## Install a build from a pull request
 
 Starting in Deno 2.8, `deno upgrade pr <number>` downloads the binary built by
-CI for a specific deno PR and installs it. This is handy when you need to
-verify a fix before it has shipped in a release.
+CI for a specific deno PR and installs it. This is handy when you need to verify
+a fix before it has shipped in a release.
 
 ```sh
 # Install the binary built by CI for PR #12345
 deno upgrade pr 12345
 
-# Numeric prefix is also accepted
+# A `#` prefix is also accepted
 deno upgrade pr '#12345'
 
 # Write to a path instead of replacing the current binary
@@ -118,9 +118,9 @@ deno upgrade --output ./deno-test pr 12345
 deno upgrade --dry-run pr 12345
 ```
 
-This subcommand requires the [`gh` CLI](https://cli.github.com/) to be
-installed and authenticated. `deno upgrade` uses `gh` to look up the PR's CI
-run and download the matching `{profile}-{os}-{arch}-deno` artifact (for
-example `release-linux-x86_64-deno`), preferring release builds and falling
-back to debug. The downloaded binary is verified to run before it replaces
-the current executable.
+This subcommand requires the [`gh` CLI](https://cli.github.com/) to be installed
+and authenticated. `deno upgrade` uses `gh` to look up the PR's CI run and
+download the matching `{profile}-{os}-{arch}-deno` artifact (for example
+`release-linux-x86_64-deno`), preferring release builds and falling back to
+debug. The downloaded binary is verified to run before it replaces the current
+executable.


### PR DESCRIPTION
## Summary

Documents the new `deno upgrade pr <number>` subcommand shipping in Deno 2.8 ([denoland/deno#33252](https://github.com/denoland/deno/pull/33252)). It downloads the binary built by CI for a given denoland/deno PR via the `gh` CLI and installs it, optionally to a path with `--output`.

- New "Install a build from a pull request" section in `runtime/reference/cli/upgrade.md`.
- Notes the `gh` CLI prerequisite, `#`-prefix tolerance, the `--output`/`--dry-run` interactions, and the `{profile}-{os}-{arch}-deno` artifact-naming scheme.

## Test plan

- [x] `deno task serve` — section renders.