### PR TITLE
docs: document `compile.include` / `compile.exclude` config

### DIFF
--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -742,9 +742,8 @@ If you're ok with this risk, then this feature will be useful for you.
 
 The `"compile"` block configures
 [`deno compile`](/runtime/reference/cli/compile/) without requiring you to
-repeat flags on every invocation. Starting in Deno 2.8 you can declare which
-extra files or directories to bundle into the executable, and which paths to
-exclude:
+repeat flags on every invocation. You can declare which extra files or
+directories to bundle into the executable, and which paths to exclude:
 
 ```jsonc title="deno.json"
 {

--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -738,6 +738,28 @@ this requires an explicit opt-in with `-P` and is not loaded by default.
 
 If you're ok with this risk, then this feature will be useful for you.
 
+## Compile config
+
+The `"compile"` block configures
+[`deno compile`](/runtime/reference/cli/compile/) without requiring you to
+repeat flags on every invocation. Starting in Deno 2.8 you can declare which
+extra files or directories to bundle into the executable, and which paths to
+exclude:
+
+```jsonc title="deno.json"
+{
+  "compile": {
+    "include": ["names.csv", "data", "worker.ts"],
+    "exclude": ["data/secrets", "**/*.test.ts"]
+  }
+}
+```
+
+`--include` and `--exclude` flags on the command line are merged with these
+lists rather than replacing them. The `"compile"` block can also carry
+`permissions` (see
+[Test, bench, and compile permissions](#test-bench-and-compile-permissions)).
+
 ## An example `deno.json` file
 
 ```json

--- a/runtime/reference/cli/compile.md
+++ b/runtime/reference/cli/compile.md
@@ -116,8 +116,8 @@ files.
 
 ### Configuring `include` / `exclude` in `deno.json`
 
-The `--include` and `--exclude` paths can be set declaratively in `deno.json`
-so you don't have to repeat them on every `deno compile` invocation:
+The `--include` and `--exclude` paths can be set declaratively in `deno.json` so
+you don't have to repeat them on every `deno compile` invocation:
 
 ```jsonc title="deno.json"
 {

--- a/runtime/reference/cli/compile.md
+++ b/runtime/reference/cli/compile.md
@@ -128,7 +128,7 @@ you don't have to repeat them on every `deno compile` invocation:
 }
 ```
 
-CLI flags are merged with the config — `--include` and `--exclude` add to the
+CLI flags are merged with the config: `--include` and `--exclude` add to the
 lists in `deno.json` rather than replacing them.
 
 ## Workers

--- a/runtime/reference/cli/compile.md
+++ b/runtime/reference/cli/compile.md
@@ -114,6 +114,24 @@ const dataFiles = Deno.readDirSync(import.meta.dirname + "/data");
 Note this currently only works for files on the file system and not remote
 files.
 
+### Configuring `include` / `exclude` in `deno.json`
+
+Starting in Deno 2.8, the `--include` and `--exclude` paths can be set
+declaratively in `deno.json` so you don't have to repeat them on every
+`deno compile` invocation:
+
+```jsonc title="deno.json"
+{
+  "compile": {
+    "include": ["names.csv", "data", "worker.ts"],
+    "exclude": ["data/secrets", "**/*.test.ts"]
+  }
+}
+```
+
+CLI flags are merged with the config — `--include` and `--exclude` add to the
+lists in `deno.json` rather than replacing them.
+
 ## Workers
 
 Similarly to non-statically analyzable dynamic imports, code for

--- a/runtime/reference/cli/compile.md
+++ b/runtime/reference/cli/compile.md
@@ -116,9 +116,8 @@ files.
 
 ### Configuring `include` / `exclude` in `deno.json`
 
-Starting in Deno 2.8, the `--include` and `--exclude` paths can be set
-declaratively in `deno.json` so you don't have to repeat them on every
-`deno compile` invocation:
+The `--include` and `--exclude` paths can be set declaratively in `deno.json`
+so you don't have to repeat them on every `deno compile` invocation:
 
 ```jsonc title="deno.json"
 {


### PR DESCRIPTION
## Summary

Documents the `"compile"` block in `deno.json` for declaratively setting `--include` / `--exclude` paths for `deno compile` (shipped in 2.7.10 via [denoland/deno#33024](https://github.com/denoland/deno/pull/33024)).

- Adds a `## Compile config` section in `runtime/fundamentals/configuration.md`.
- Adds a sub-section in `runtime/reference/cli/compile.md` showing how CLI flags merge with the config.

## Test plan

- [x] `deno task serve` — pages render, links resolve.
- [x] `deno fmt` — clean.