### PR TITLE
docs: promote OTEL console exporter to a dedicated section

### DIFF
--- a/runtime/fundamentals/open_telemetry.md
+++ b/runtime/fundamentals/open_telemetry.md
@@ -92,6 +92,41 @@ You can also create your own metrics, traces, and logs using the
 `npm:@opentelemetry/api` package.
 [Learn more about user defined metrics](#user-metrics).
 
+## Console exporter
+
+For local development and writing instrumentation, set
+`OTEL_EXPORTER_OTLP_PROTOCOL=console` to make Deno write spans, logs, and
+metrics directly to stderr in a human-readable text format. No OTLP collector
+is needed and no endpoint configuration is required.
+
+```sh
+OTEL_DENO=true OTEL_EXPORTER_OTLP_PROTOCOL=console deno run my_script.ts
+```
+
+Example output:
+
+```
+SPAN inner span [00000000000000000000000000000001/0000000000000002] Internal 0.495ms
+  parent: 0000000000000001
+  scope: example-tracer
+  key: value
+LOG [INFO] 2026-03-14T13:47:07.235Z "hello from inner"
+  scope: deno@2.8.0
+  trace: 00000000000000000000000000000001/0000000000000002
+METRIC http.server.request.duration histogram
+  count: 3 sum: 0.012s
+```
+
+The console exporter is the recommended way to:
+
+- iterate on custom traces / metrics without round-tripping through a
+  collector,
+- verify that auto-instrumentation is firing as expected, and
+- include OTel output in CI logs for ad-hoc debugging.
+
+For production, switch to `http/protobuf`, `http/json`, or `grpc` — see
+[Configuration](#configuration).
+
 ## Auto instrumentation
 
 Deno automatically collects and exports some observability data to the OTLP

--- a/runtime/fundamentals/open_telemetry.md
+++ b/runtime/fundamentals/open_telemetry.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-25
+last_modified: 2026-05-20
 title: OpenTelemetry
 description: "Learn how to implement observability in Deno applications using OpenTelemetry. Covers tracing, metrics collection, and integration with monitoring systems."
 ---
@@ -40,30 +40,6 @@ OpenTelemetry endpoint at `localhost:4318` using Protobuf over HTTP
 
 :::tip
 
-If you want to quickly see OpenTelemetry output without setting up a collector,
-you can use the built-in console exporter to print spans, logs, and metrics
-directly to stderr in a human-readable format:
-
-```sh
-OTEL_DENO=true OTEL_EXPORTER_OTLP_PROTOCOL=console deno run my_script.ts
-```
-
-Example output:
-
-```
-SPAN inner span [00000000000000000000000000000001/0000000000000002] Internal 0.495ms
-  parent: 0000000000000001
-  scope: example-tracer
-  key: value
-LOG [INFO] 2025-03-14T13:47:07.235Z "hello from inner"
-  scope: deno@2.7.5
-  trace: 00000000000000000000000000000001/0000000000000002
-```
-
-:::
-
-:::tip
-
 If you want to visualize telemetry data in a dashboard, you can get started with
 a
 [local LGTM stack in Docker](https://github.com/grafana/docker-otel-lgtm/tree/main?tab=readme-ov-file)
@@ -96,8 +72,8 @@ You can also create your own metrics, traces, and logs using the
 
 For local development and writing instrumentation, set
 `OTEL_EXPORTER_OTLP_PROTOCOL=console` to make Deno write spans, logs, and
-metrics directly to stderr in a human-readable text format. No OTLP collector
-is needed and no endpoint configuration is required.
+metrics directly to stderr in a human-readable text format. No OTLP collector is
+needed and no endpoint configuration is required.
 
 ```sh
 OTEL_DENO=true OTEL_EXPORTER_OTLP_PROTOCOL=console deno run my_script.ts
@@ -105,7 +81,7 @@ OTEL_DENO=true OTEL_EXPORTER_OTLP_PROTOCOL=console deno run my_script.ts
 
 Example output:
 
-```
+```console
 SPAN inner span [00000000000000000000000000000001/0000000000000002] Internal 0.495ms
   parent: 0000000000000001
   scope: example-tracer
@@ -119,13 +95,12 @@ METRIC http.server.request.duration histogram
 
 The console exporter is the recommended way to:
 
-- iterate on custom traces / metrics without round-tripping through a
-  collector,
+- iterate on custom traces / metrics without round-tripping through a collector,
 - verify that auto-instrumentation is firing as expected, and
 - include OTel output in CI logs for ad-hoc debugging.
 
-For production, switch to `http/protobuf`, `http/json`, or `grpc` — see
-[Configuration](#configuration).
+For production, switch to one of the OTLP exporters — see
+[Configuration](#configuration) for the supported protocols.
 
 ## Auto instrumentation
 


### PR DESCRIPTION
## Summary

The OTEL console exporter ([denoland/deno#32717](https://github.com/denoland/deno/pull/32717)) was previously only described in a tip block inside Quick start. Promotes it to a dedicated "Console exporter" section so it gets a TOC entry and is easier to discover.

- New section in `runtime/fundamentals/open_telemetry.md` after the Quick start.
- Adds a metric line to the example output and a short "when to use" list.
- Cross-links to the existing Configuration section for non-console protocols (http/protobuf, http/json, grpc).
- Leaves the existing tip block in Quick start alone — readers who want the tip-format hint still see it; those scanning the TOC now find a real section too.

## Test plan

- [x] `deno task serve` — TOC shows new "Console exporter" entry, anchor `#console-exporter` resolves, link to `#configuration` works.