### PR TITLE
docs: document `deno doc npm:` / `deno doc jsr:` (2.8)

### DIFF
--- a/runtime/reference/cli/doc.md
+++ b/runtime/reference/cli/doc.md
@@ -38,6 +38,22 @@ function add(x: number, y: number): number
   Adds x and y. @param {number} x @param {number} y @returns {number} Sum of x and y
 ```
 
+### Documenting an npm or JSR package
+
+Starting in Deno 2.8, `deno doc` accepts `npm:` and `jsr:` specifiers and will
+fetch the package's published types before generating documentation. This is
+useful for exploring a third-party API from the terminal without cloning the
+repository:
+
+```sh
+deno doc npm:code-block-writer
+deno doc jsr:@std/path
+```
+
+You can pin to a specific version like any other Deno specifier
+(`npm:zod@4`), and combine the specifier with `--html` or `--json` to render
+the same output formats as for local files.
+
 ## Linting
 
 You can use `--lint` flag to check for problems in your documentation while it's

--- a/runtime/reference/cli/doc.md
+++ b/runtime/reference/cli/doc.md
@@ -50,9 +50,9 @@ deno doc npm:code-block-writer
 deno doc jsr:@std/path
 ```
 
-You can pin to a specific version like any other Deno specifier
-(`npm:zod@4`), and combine the specifier with `--html` or `--json` to render
-the same output formats as for local files.
+You can pin to a specific version like any other Deno specifier (`npm:zod@4`),
+and combine the specifier with `--html` or `--json` to render the same output
+formats as for local files.
 
 ## Linting
 


### PR DESCRIPTION
## Summary

Documents the new ability for `deno doc` to accept `npm:` and `jsr:` specifiers, shipping in Deno 2.8 ([denoland/deno#32435](https://github.com/denoland/deno/pull/32435)).

- New "Documenting an npm or JSR package" subsection in `runtime/reference/cli/doc.md`.
- Examples for both `npm:` and `jsr:` specifiers, version pinning, and combining with `--html` / `--json`.

## Test plan

- [x] `deno task serve` — section renders.