### PR TITLE
docs: document function coverage in `deno coverage`

### DIFF
--- a/runtime/reference/cli/coverage.md
+++ b/runtime/reference/cli/coverage.md
@@ -128,6 +128,26 @@ console.log("This line is ignored");
 console.log("This line is not ignored");
 ```
 
+## Function coverage
+
+Starting in Deno 2.8, the summary table and the HTML report include a
+**function coverage** column alongside the existing branch and line columns:
+
+```
+----------------------------------
+File         | Branch % | Line % | Function %
+----------------------------------
+main.ts      |   85.7   |  92.3  |   100.0
+util.ts      |   75.0   |  88.5  |    66.7
+----------------------------------
+all files    |   80.0   |  90.5  |    83.3
+----------------------------------
+```
+
+Function coverage measures the percentage of declared functions that were
+called at least once during the test run. The same data was already written
+to `lcov` output — Deno 2.8 just surfaces it in the human-readable reporters.
+
 ## Output Formats
 
 By default we support Deno's own coverage format - but you can also output

--- a/runtime/reference/cli/coverage.md
+++ b/runtime/reference/cli/coverage.md
@@ -130,8 +130,8 @@ console.log("This line is not ignored");
 
 ## Function coverage
 
-Starting in Deno 2.8, the summary table and the HTML report include a
-**function coverage** column alongside the existing branch and line columns:
+The summary table and the HTML report include a **function coverage** column
+alongside the branch and line columns:
 
 ```
 ----------------------------------
@@ -145,8 +145,8 @@ all files    |   80.0   |  90.5  |    83.3
 ```
 
 Function coverage measures the percentage of declared functions that were
-called at least once during the test run. The same data was already written
-to `lcov` output — Deno 2.8 just surfaces it in the human-readable reporters.
+called at least once during the test run. The same data is also available in
+the `lcov` output.
 
 ## Output Formats
 

--- a/runtime/reference/cli/coverage.md
+++ b/runtime/reference/cli/coverage.md
@@ -144,9 +144,9 @@ all files    |   80.0   |  90.5  |    83.3
 ----------------------------------
 ```
 
-Function coverage measures the percentage of declared functions that were
-called at least once during the test run. The same data is also available in
-the `lcov` output.
+Function coverage measures the percentage of declared functions that were called
+at least once during the test run. The same data is also available in the `lcov`
+output.
 
 ## Output Formats
 

--- a/runtime/reference/cli/coverage.md
+++ b/runtime/reference/cli/coverage.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-04-23
+last_modified: 2026-05-20
 title: "deno coverage"
 oldUrl: /runtime/manual/tools/coverage/
 command: coverage
@@ -133,15 +133,15 @@ console.log("This line is not ignored");
 The summary table and the HTML report include a **function coverage** column
 alongside the branch and line columns:
 
-```
-----------------------------------
+```console
+---------------------------------------------
 File         | Branch % | Line % | Function %
-----------------------------------
-main.ts      |   85.7   |  92.3  |   100.0
-util.ts      |   75.0   |  88.5  |    66.7
-----------------------------------
-all files    |   80.0   |  90.5  |    83.3
-----------------------------------
+---------------------------------------------
+main.ts      |   85.7   |  92.3  |    100.0
+util.ts      |   75.0   |  88.5  |     66.7
+---------------------------------------------
+all files    |   80.0   |  90.5  |     83.3
+---------------------------------------------
 ```
 
 Function coverage measures the percentage of declared functions that were called


### PR DESCRIPTION
## Summary

Documents the new function-coverage column in the summary table and HTML report shipping in Deno 2.8 ([denoland/deno#32507](https://github.com/denoland/deno/pull/32507)).

- New "Function coverage" subsection in `runtime/reference/cli/coverage.md`.
- Mock summary-table snippet showing the new column alongside Branch % and Line %.
- Notes that the lcov output already contained the data — only the textual / HTML reporters changed.

## Test plan

- [x] `deno task serve` — section renders.