### PR TITLE
docs: document Geometry Interfaces (DOMMatrix, etc.) (2.8)

### DIFF
--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -496,15 +496,15 @@ Starting in Deno 2.8, the
 are available as globals. These are the same types you'd find in a browser:
 
 - [`DOMMatrix`](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrix) /
-  [`DOMMatrixReadOnly`](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrixReadOnly)
-  — 4×4 transform matrices for 2D and 3D operations.
+  [`DOMMatrixReadOnly`](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrixReadOnly):
+  4×4 transform matrices for 2D and 3D operations.
 - [`DOMPoint`](https://developer.mozilla.org/en-US/docs/Web/API/DOMPoint) /
-  [`DOMPointReadOnly`](https://developer.mozilla.org/en-US/docs/Web/API/DOMPointReadOnly)
-  — points in 2D / 3D space.
+  [`DOMPointReadOnly`](https://developer.mozilla.org/en-US/docs/Web/API/DOMPointReadOnly):
+  points in 2D / 3D space.
 - [`DOMRect`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect) /
-  [`DOMRectReadOnly`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly)
-  — axis-aligned rectangles.
-- [`DOMQuad`](https://developer.mozilla.org/en-US/docs/Web/API/DOMQuad) — a
+  [`DOMRectReadOnly`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly):
+  axis-aligned rectangles.
+- [`DOMQuad`](https://developer.mozilla.org/en-US/docs/Web/API/DOMQuad): a
   quadrilateral defined by four points.
 
 ```ts
@@ -513,7 +513,7 @@ const p = new DOMPoint(1, 1).matrixTransform(m);
 console.log(p.x, p.y); // 12 22
 ```
 
-These types are useful for graphics work — applying transforms to canvas
+These types are useful for graphics work; applying transforms to canvas
 drawings, computing layout math, or porting browser code that depends on
 geometry types.
 

--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -489,6 +489,34 @@ const worker = new Worker(import.meta.resolve("./worker.js"), {
 });
 ```
 
+## Geometry Interfaces
+
+Starting in Deno 2.8, the
+[Geometry Interfaces Module Level 1](https://drafts.fxtf.org/geometry/) types
+are available as globals. These are the same types you'd find in a browser:
+
+- [`DOMMatrix`](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrix) /
+  [`DOMMatrixReadOnly`](https://developer.mozilla.org/en-US/docs/Web/API/DOMMatrixReadOnly)
+  — 4×4 transform matrices for 2D and 3D operations.
+- [`DOMPoint`](https://developer.mozilla.org/en-US/docs/Web/API/DOMPoint) /
+  [`DOMPointReadOnly`](https://developer.mozilla.org/en-US/docs/Web/API/DOMPointReadOnly)
+  — points in 2D / 3D space.
+- [`DOMRect`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect) /
+  [`DOMRectReadOnly`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly)
+  — axis-aligned rectangles.
+- [`DOMQuad`](https://developer.mozilla.org/en-US/docs/Web/API/DOMQuad) — a
+  quadrilateral defined by four points.
+
+```ts
+const m = new DOMMatrix().translateSelf(10, 20).scaleSelf(2);
+const p = new DOMPoint(1, 1).matrixTransform(m);
+console.log(p.x, p.y); // 12 22
+```
+
+These types are useful for graphics work — applying transforms to canvas
+drawings, computing layout math, or porting browser code that depends on
+geometry types.
+
 ## Deviations of other APIs from spec
 
 ### Cache API


### PR DESCRIPTION
## Summary

Documents the Geometry Interfaces (DOMMatrix, DOMPoint, DOMRect, DOMQuad and ReadOnly variants) that became available globally in Deno 2.8 ([denoland/deno#27527](https://github.com/denoland/deno/pull/27527)).

- New "Geometry Interfaces" section in `runtime/reference/web_platform_apis.md` placed just above "Deviations of other APIs from spec".
- Lists each type with a one-line description and an MDN link.
- Small transform example so readers can see the shape of the API.

## Test plan

- [x] `deno task serve` — section renders, anchor `#geometry-interfaces` resolves.
- [ ] If the upstream PR ends up gated behind an `--unstable-` flag at merge time, this section will need that note added — current diff doesn't show one.