### PR TITLE
docs: document `catalog:` protocol for workspace dependencies (2.8)

### DIFF
--- a/runtime/fundamentals/workspaces.md
+++ b/runtime/fundamentals/workspaces.md
@@ -660,6 +660,113 @@ This approach allows you to:
 3. Test and develop interdependent modules together
 4. Gradually migrate monolithic codebases to modular architecture
 
+## Centralized dependency versions with `catalog:`
+
+When several workspace members depend on the same npm package, keeping their
+versions in sync usually means editing every `package.json` (or `deno.json`)
+whenever you bump a version. The `catalog:` protocol — added in Deno 2.8 and
+compatible with the equivalent feature in pnpm, Bun, and Yarn — lets the
+workspace root declare a single version requirement, and members reference it by
+name.
+
+Define a catalog in the root `deno.json`:
+
+```jsonc title="deno.json"
+{
+  "workspace": ["./packages/a", "./packages/b"],
+  "catalog": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "chalk": "^5.3.0"
+  }
+}
+```
+
+A member references the entry with `catalog:` (the default catalog):
+
+```json title="packages/a/package.json"
+{
+  "dependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  }
+}
+```
+
+To bump everyone to a new React version, edit the catalog once.
+
+### Named catalogs
+
+Use the plural `catalogs` field when different members need different versions
+of the same package — for example, while migrating between major versions:
+
+```jsonc title="deno.json"
+{
+  "workspace": ["./packages/a", "./packages/b"],
+  "catalogs": {
+    "react18": {
+      "react": "^18.3.0",
+      "react-dom": "^18.3.0"
+    },
+    "react19": {
+      "react": "^19.0.0",
+      "react-dom": "^19.0.0"
+    }
+  }
+}
+```
+
+Members select a catalog by name:
+
+```json title="packages/a/package.json"
+{
+  "dependencies": {
+    "react": "catalog:react18",
+    "react-dom": "catalog:react18"
+  }
+}
+```
+
+```json title="packages/b/package.json"
+{
+  "dependencies": {
+    "react": "catalog:react19",
+    "react-dom": "catalog:react19"
+  }
+}
+```
+
+`catalog:` (with no name) and `catalog:default` are equivalent and resolve to
+the singular `catalog` field.
+
+### Catalogs in `package.json`
+
+Catalogs can also live in the root `package.json`, which keeps configuration
+together for projects that haven't moved to `deno.json`:
+
+```json title="package.json"
+{
+  "catalog": {
+    "react": "^19.0.0"
+  },
+  "catalogs": {
+    "testing": {
+      "vitest": "^2.0.0"
+    }
+  }
+}
+```
+
+If both `deno.json` and `package.json` define catalogs at the workspace root,
+`package.json` wins entirely — the two are not merged.
+
+### Restrictions
+
+- Catalogs are root-only. Defining `catalog` or `catalogs` inside a workspace
+  member emits a diagnostic.
+- Members must reference a catalog name that exists. A missing entry produces a
+  resolution error during install or run.
+
 ## Using workspace protocol in package.json
 
 Deno supports workspace protocol specifiers in `package.json` files. These are

--- a/runtime/fundamentals/workspaces.md
+++ b/runtime/fundamentals/workspaces.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-11-04
+last_modified: 2026-05-20
 title: "Workspaces and monorepos"
 description: "A guide to managing workspaces and monorepos in Deno. Learn about workspace configuration, package management, dependency resolution, and how to structure multi-package projects effectively."
 oldUrl: /runtime/manual/basics/workspaces
@@ -659,6 +659,115 @@ This approach allows you to:
 2. Share code between packages without publishing to a registry
 3. Test and develop interdependent modules together
 4. Gradually migrate monolithic codebases to modular architecture
+
+## Centralized dependency versions with `catalog:`
+
+When several workspace members depend on the same npm package, keeping their
+versions in sync usually means editing every member's `package.json` whenever
+you bump a version. The `catalog:` protocol — added in Deno 2.8 and compatible
+with the equivalent feature in pnpm, Bun, and Yarn — lets the workspace root
+declare a single version requirement, and each member references it by name from
+its `package.json` dependencies. (The `catalog:` specifier itself is only read
+from `package.json` files; the catalog definition can live in either `deno.json`
+or `package.json` at the workspace root.)
+
+Define a catalog in the root `deno.json`:
+
+```jsonc title="deno.json"
+{
+  "workspace": ["./packages/a", "./packages/b"],
+  "catalog": {
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "chalk": "^5.3.0"
+  }
+}
+```
+
+A member references the entry with `catalog:` (the default catalog):
+
+```json title="packages/a/package.json"
+{
+  "dependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  }
+}
+```
+
+To bump everyone to a new React version, edit the catalog once.
+
+### Named catalogs
+
+Use the plural `catalogs` field when different members need different versions
+of the same package — for example, while migrating between major versions:
+
+```jsonc title="deno.json"
+{
+  "workspace": ["./packages/a", "./packages/b"],
+  "catalogs": {
+    "react18": {
+      "react": "^18.3.0",
+      "react-dom": "^18.3.0"
+    },
+    "react19": {
+      "react": "^19.0.0",
+      "react-dom": "^19.0.0"
+    }
+  }
+}
+```
+
+Members select a catalog by name:
+
+```json title="packages/a/package.json"
+{
+  "dependencies": {
+    "react": "catalog:react18",
+    "react-dom": "catalog:react18"
+  }
+}
+```
+
+```json title="packages/b/package.json"
+{
+  "dependencies": {
+    "react": "catalog:react19",
+    "react-dom": "catalog:react19"
+  }
+}
+```
+
+`catalog:` (with no name) and `catalog:default` are equivalent and resolve to
+the singular `catalog` field.
+
+### Catalogs in `package.json`
+
+Catalogs can also live in the root `package.json`, which keeps configuration
+together for projects that haven't moved to `deno.json`:
+
+```json title="package.json"
+{
+  "catalog": {
+    "react": "^19.0.0"
+  },
+  "catalogs": {
+    "testing": {
+      "vitest": "^2.0.0"
+    }
+  }
+}
+```
+
+If both `deno.json` and `package.json` define catalogs at the workspace root,
+`package.json` wins entirely — the two are not merged.
+
+### Restrictions
+
+- Catalogs are root-only. Defining `catalog` or `catalogs` inside a workspace
+  member emits a diagnostic.
+- Members must reference a catalog name that exists. A missing entry produces a
+  resolution error during install or run.
 
 ## Using workspace protocol in package.json
 


### PR DESCRIPTION
## Summary

Documents the new `catalog:` protocol shipping in Deno 2.8 ([denoland/deno#32947](https://github.com/denoland/deno/pull/32947)). Catalogs let a workspace root declare shared dependency versions in one place; members reference them with `\"pkg\": \"catalog:\"` or `\"pkg\": \"catalog:<name>\"`.

- Adds a new "Centralized dependency versions with `catalog:`" section to `runtime/fundamentals/workspaces.md`.
- Covers the default catalog, named catalogs (`catalogs`), and catalogs declared in `package.json`.
- Notes the precedence rule when both `deno.json` and `package.json` define catalogs (package.json wins, no merging) and the root-only restriction.

## Test plan

- [x] `deno task serve` — workspaces page renders, new section sits cleanly between "Sharing and managing dependencies" and "Using workspace protocol in package.json".
- [x] `deno fmt` — clean.