### PR TITLE
docs: document hoisted node_modules linker mode (2.8)

### DIFF
--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -627,6 +627,56 @@ Running the above command, with a `--node-modules-dir` flag, will create a
 `node_modules` folder in the current directory with a similar folder structure
 to npm.
 
+### node_modules layout: isolated vs hoisted
+
+When a local `node_modules` directory exists, Deno can lay it out in two ways.
+The default — **isolated** — installs each package into a content-addressed
+`.deno/` directory and exposes it through a symlink, so every package only sees
+its declared dependencies. This is similar to pnpm's layout.
+
+```text
+node_modules/
+├── .deno/chalk@5.6.2/node_modules/chalk/   ← real files
+└── chalk -> .deno/chalk@5.6.2/node_modules/chalk
+```
+
+Some npm tooling — and any package that walks `node_modules` looking for
+flat-resolved siblings — assumes the **hoisted** layout that npm and Yarn
+classic use. Deno 2.8 adds a hoisted mode
+([denoland/deno#32788](https://github.com/denoland/deno/pull/32788)) you can opt
+into with `nodeModulesLinker` in `deno.json`:
+
+```json title="deno.json"
+{
+  "nodeModulesDir": "auto",
+  "nodeModulesLinker": "hoisted"
+}
+```
+
+Or as a one-off CLI flag:
+
+```sh
+deno install --node-modules-linker=hoisted
+```
+
+In hoisted mode the most-depended-upon version of each package is placed at the
+top of `node_modules/`; conflicting versions are nested under the dependent that
+needs them, just like npm:
+
+```text
+node_modules/
+├── chalk/         ← real files
+├── express/
+├── ms/            ← hoisted: most commonly needed version
+└── debug/
+    └── node_modules/
+        └── ms/    ← nested: a different version
+```
+
+Stick with the default isolated mode unless a tool you depend on requires the
+hoisted layout — isolated mode catches phantom dependencies that hoisted layouts
+hide.
+
 ## Node-API addons
 
 Summary: Node-API addons work in Deno when a local `node_modules/` is present

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-02-10
+last_modified: 2026-05-20
 title: "Node and npm Compatibility"
 description: "Guide to using Node.js modules and npm packages in Deno. Learn about compatibility features, importing npm packages, and differences between Node.js and Deno environments."
 oldUrl:
@@ -630,7 +630,7 @@ to npm.
 ### node_modules layout: isolated vs hoisted
 
 When a local `node_modules` directory exists, Deno can lay it out in two ways.
-The default — **isolated** — installs each package into a content-addressed
+The default (**isolated**) installs each package into a content-addressed
 `.deno/` directory and exposes it through a symlink, so every package only sees
 its declared dependencies. This is similar to pnpm's layout.
 
@@ -640,28 +640,29 @@ node_modules/
 └── chalk -> .deno/chalk@5.6.2/node_modules/chalk
 ```
 
-Some npm tooling — and any package that walks `node_modules` looking for
-flat-resolved siblings — assumes the **hoisted** layout that npm and Yarn
-classic use. Deno 2.8 adds a hoisted mode
+Some npm tooling, and any package that walks `node_modules` looking for
+flat-resolved siblings, assumes the **hoisted** layout that npm and Yarn classic
+use. Deno 2.8 adds a hoisted mode
 ([denoland/deno#32788](https://github.com/denoland/deno/pull/32788)) you can opt
-into with `nodeModulesLinker` in `deno.json`:
+into with `nodeModulesLinker` in `deno.json`. The hoisted linker requires a
+manually-managed `node_modules` directory, so set `nodeModulesDir` to `manual`:
 
 ```json title="deno.json"
 {
-  "nodeModulesDir": "auto",
+  "nodeModulesDir": "manual",
   "nodeModulesLinker": "hoisted"
 }
 ```
 
-Or as a one-off CLI flag:
+Or as a one-off CLI flag (also requiring `--node-modules-dir=manual`):
 
 ```sh
-deno install --node-modules-linker=hoisted
+deno install --node-modules-dir=manual --node-modules-linker=hoisted
 ```
 
 In hoisted mode the most-depended-upon version of each package is placed at the
-top of `node_modules/`; conflicting versions are nested under the dependent that
-needs them, just like npm:
+top of `node_modules/`, and conflicting versions are nested under the dependent
+that needs them, just like npm:
 
 ```text
 node_modules/
@@ -674,7 +675,7 @@ node_modules/
 ```
 
 Stick with the default isolated mode unless a tool you depend on requires the
-hoisted layout — isolated mode catches phantom dependencies that hoisted layouts
+hoisted layout. Isolated mode catches phantom dependencies that hoisted layouts
 hide.
 
 ## Node-API addons


### PR DESCRIPTION
## Summary

Documents the new hoisted `node_modules` linker mode shipping in Deno 2.8 ([denoland/deno#32788](https://github.com/denoland/deno/pull/32788)). Adds a sub-section to `runtime/fundamentals/node.md` that explains the two layouts (isolated default vs. hoisted) and shows how to opt in with `nodeModulesLinker: "hoisted"` in `deno.json` or `--node-modules-linker=hoisted` on the CLI.

- Side-by-side layout examples (real files vs. symlinks for isolated; nested versions for hoisted).
- Recommends sticking with isolated mode unless a specific tool needs hoisted, since isolated catches phantom dependencies.

## Test plan

- [x] `deno task serve` — node.md renders, new section sits between manual node_modules creation and Node-API addons.
- [x] `deno fmt` — clean.