### PR TITLE
docs: document Deno.test() timeout option

### DIFF
--- a/runtime/fundamentals/testing.md
+++ b/runtime/fundamentals/testing.md
@@ -118,6 +118,30 @@ Deno.test("database operations", async (t) => {
 });
 ```
 
+## Timeouts
+
+You can set a maximum duration for individual tests using the `timeout` option.
+If a test exceeds its deadline it is marked as failed. Both asynchronous hangs
+(a promise that never resolves) and synchronous hot loops (`while (true) {}`)
+are caught.
+
+```ts
+Deno.test({
+  name: "completes within deadline",
+  timeout: 5000, // 5 seconds
+  async fn() {
+    const response = await fetch("https://example.com");
+    await response.body?.cancel();
+  },
+});
+```
+
+If a test times out the next test in the same file still runs normally.
+Sanitizers are skipped for the timed-out test since a forcibly terminated test
+will naturally have leaked resources or operations.
+
+Setting `timeout` to `0` or omitting it means the test runs without a deadline.
+
 ## Test Hooks
 
 Deno provides test hooks that allow you to run setup and teardown code before
@@ -676,30 +700,6 @@ Deno.test({
   },
 });
 ```
-
-## Timeouts
-
-You can set a maximum duration for individual tests using the `timeout` option.
-If a test exceeds its deadline it is marked as failed. Both asynchronous hangs
-(a promise that never resolves) and synchronous hot loops (`while (true) {}`)
-are caught.
-
-```ts
-Deno.test({
-  name: "completes within deadline",
-  timeout: 5000, // 5 seconds
-  async fn() {
-    const response = await fetch("https://example.com");
-    await response.body?.cancel();
-  },
-});
-```
-
-If a test times out the next test in the same file still runs normally.
-Sanitizers are skipped for the timed-out test since a forcibly terminated test
-will naturally have leaked resources or operations.
-
-Setting `timeout` to `0` or omitting it means the test runs without a deadline.
 
 ## Snapshot testing
 

--- a/runtime/fundamentals/testing.md
+++ b/runtime/fundamentals/testing.md
@@ -137,8 +137,6 @@ Deno.test({
 ```
 
 If a test times out the next test in the same file still runs normally.
-Sanitizers are skipped for the timed-out test since a forcibly terminated test
-will naturally have leaked resources or operations.
 
 Setting `timeout` to `0` or omitting it means the test runs without a deadline.
 

--- a/runtime/fundamentals/testing.md
+++ b/runtime/fundamentals/testing.md
@@ -677,6 +677,30 @@ Deno.test({
 });
 ```
 
+## Timeouts
+
+You can set a maximum duration for individual tests using the `timeout` option.
+If a test exceeds its deadline it is marked as failed. Both asynchronous hangs
+(a promise that never resolves) and synchronous hot loops (`while (true) {}`)
+are caught.
+
+```ts
+Deno.test({
+  name: "completes within deadline",
+  timeout: 5000, // 5 seconds
+  async fn() {
+    const response = await fetch("https://example.com");
+    await response.body?.cancel();
+  },
+});
+```
+
+If a test times out the next test in the same file still runs normally.
+Sanitizers are skipped for the timed-out test since a forcibly terminated test
+will naturally have leaked resources or operations.
+
+Setting `timeout` to `0` or omitting it means the test runs without a deadline.
+
 ## Snapshot testing
 
 The [Deno Standard Library](/runtime/reference/std/) includes a


### PR DESCRIPTION
## Summary

- Add a "Timeouts" section to the testing fundamentals page
  documenting the per-test `timeout` option for `Deno.test()`
- Covers async hangs, sync hot loops, and the `timeout: 0`
  disable behavior

Corresponds to denoland/deno#33815.