### PR TITLE
Fix command syntax for bundling output

### DIFF
--- a/runtime/reference/cli/bundle.md
+++ b/runtime/reference/cli/bundle.md
@@ -14,7 +14,7 @@ JavaScript file.
 ## Basic usage
 
 ```sh
-deno bundle main.ts output.js
+deno bundle main.ts > output.js
 ```
 
 The output file can then be run with Deno or in other JavaScript runtimes:


### PR DESCRIPTION
The previous command will error out with:
```
⚠️  deno bundle is experimental and subject to changes
error: No such file or directory (os error 2)
```

This change also makes it match the command in other areas of the doc