### PR TITLE
docs: fix deno create page to require jsr:/npm: prefix

### DIFF
--- a/runtime/reference/cli/create.md
+++ b/runtime/reference/cli/create.md
@@ -17,8 +17,9 @@ packages that provide project templates.
 deno create [OPTIONS] [PACKAGE] [-- [ARGS]...]
 ```
 
-By default, unprefixed package names are resolved from JSR. You can use the
-`npm:` or `jsr:` prefix to be explicit, or use the `--npm` / `--jsr` flags.
+The `[PACKAGE]` argument requires either a `jsr:` or `npm:` prefix, or one of
+the `--jsr` / `--npm` flags. Unprefixed package names error out with
+`Missing 'jsr:' or 'npm:' prefix.`
 
 ## How it works
 
@@ -42,15 +43,15 @@ Package resolution differs between npm and JSR:
 }
 ```
 
-When you run `deno create @my-scope/my-template`, Deno looks for the `./create`
-export and runs it as the scaffolding script.
+When you run `deno create jsr:@my-scope/my-template`, Deno looks for the
+`./create` export and runs it as the scaffolding script.
 
 ## Examples
 
 Create a project from a JSR package:
 
 ```sh
-deno create @fresh/init
+deno create jsr:@fresh/init
 ```
 
 Create a project from an npm package:
@@ -68,11 +69,11 @@ deno create --npm create-vite my-app
 Pass arguments to the template package:
 
 ```sh
-deno create @fresh/init -- --force
+deno create jsr:@fresh/init -- --force
 ```
 
 ## Flags
 
 - `--npm` - Treat unprefixed package names as npm packages
-- `--jsr` - Treat unprefixed package names as JSR packages (default)
+- `--jsr` - Treat unprefixed package names as JSR packages
 - `-y, --yes` - Bypass the prompt and run with full permissions


### PR DESCRIPTION
## Summary

The `deno create` page claimed unprefixed package names default to JSR, but on Deno 2.7.14 the CLI errors out with `Missing 'jsr:' or 'npm:' prefix.` for any unprefixed argument (e.g. `deno create @fresh/init`, the page's own example, fails). A prefix (`jsr:` / `npm:`) or flag (`--jsr` / `--npm`) is required.

This brings the docs in line with current CLI behavior:

- Rewrote the intro paragraph to say a prefix or flag is required, and quote the actual error.
- Updated the JSR examples (`deno create @fresh/init` → `deno create jsr:@fresh/init`, including the `-- --force` variant and the inline `@my-scope/my-template` reference in the "How it works" section).
- Dropped the `(default)` annotation from the `--jsr` flag — there is no default.

If the CLI later changes to actually default to JSR, the docs can be reverted to match — that's a runtime change tracked elsewhere.

Closes #3061
Closes bartlomieju/orchid-inbox#49

cc @bartlomieju

## Test plan

- [x] `deno create @fresh/init` against `denoland/deno:latest` (2.7.14) errors with `Missing 'jsr:' or 'npm:' prefix.` — matches the updated docs.
- [x] `deno create jsr:@fresh/init` and `deno create --jsr @fresh/init` proceed past the prefix check.
- [ ] Render the page locally and confirm the examples are copy-pasteable.