### PR TITLE
docs: clarify /deploy/kv/node/ is for Deploy Classic

### DIFF
--- a/deploy/kv/node.md
+++ b/deploy/kv/node.md
@@ -1,13 +1,35 @@
 ---
-last_modified: 2026-03-19
+last_modified: 2026-05-13
 title: "Using KV in Node.js"
 oldUrl:
   - /kv/manual/node/
 ---
 
-Connecting to a Deno KV database in Node.js is supported via our
+:::warning Sunsetting on July 20, 2026
+
+This page covers connecting to a Deno KV database hosted on **Deno Deploy
+Classic** ([dash.deno.com](https://dash.deno.com)). Deploy Classic will be shut
+down on July 20, 2026 — see the
+<a href="/deploy/migration_guide/">migration guide</a> for details.
+
+On the new [Deno Deploy](/deploy/) platform, KV databases are provisioned per
+app through the
+<a href="/deploy/reference/databases/">Databases</a> feature and accessed from
+your app code via [`Deno.openKv()`](/api/deno/~/Deno.openKv) without a
+connection URL — see
+<a href="/deploy/reference/deno_kv/">Deno KV on Deno Deploy</a>. External KV
+Connect access to new‑Deploy KV databases is not currently exposed.
+
+:::
+
+Connecting from Node.js to a Deno KV database hosted on Deno Deploy Classic is
+supported via our
 [official client library on npm](https://www.npmjs.com/package/@deno/kv). You
-can find usage instructions for this option below.
+can find usage instructions for this option below. The same library can also
+connect to any other endpoint implementing the open
+[KV Connect](https://github.com/denoland/denokv/blob/main/proto/kv-connect.md)
+protocol, such as a self‑hosted [`denokv`](https://github.com/denoland/denokv)
+instance.
 
 ## Installation and usage
 
@@ -71,11 +93,12 @@ used in Node as well.
 
 Connecting to a KV database outside of Deno requires a
 [KV Connect](https://github.com/denoland/denokv/blob/main/proto/kv-connect.md)
-URL. A KV Connect URL for a database hosted on Deno Deploy will be in this
-format: `https://api.deno.com/databases/<database-id>/connect`.
+URL. A KV Connect URL for a database hosted on Deno Deploy Classic will be in
+this format: `https://api.deno.com/databases/<database-id>/connect`.
 
 The `database-id` for your project can be found in the
-[Deno Deploy dashboard](https://console.deno.com), under the app's "KV" tab.
+[Deno Deploy Classic dashboard](https://dash.deno.com), under your project's
+"KV" tab.
 
 ![Connection string locations in Deploy](./images/kv-connect.png)
 

--- a/deploy/kv/node.md
+++ b/deploy/kv/node.md
@@ -7,15 +7,17 @@ oldUrl:
 
 :::warning Sunsetting on July 20, 2026
 
-This page covers connecting to a Deno KV database hosted on **Deno Deploy
-Classic** ([dash.deno.com](https://dash.deno.com)). Deploy Classic will be shut
+This page covers connecting to a Deno KV database hosted on
+<strong>Deno Deploy Classic</strong>
+(<a href="https://dash.deno.com">dash.deno.com</a>). Deploy Classic will be shut
 down on July 20, 2026 — see the
 <a href="/deploy/migration_guide/">migration guide</a> for details.
 
-On the new [Deno Deploy](/deploy/) platform, KV databases are provisioned per
-app through the
+On the new <a href="/deploy/">Deno Deploy</a> platform, KV databases are
+provisioned per app through the
 <a href="/deploy/reference/databases/">Databases</a> feature and accessed from
-your app code via [`Deno.openKv()`](/api/deno/~/Deno.openKv) without a
+your app code via
+<a href="/api/deno/~/Deno.openKv"><code>Deno.openKv()</code></a> without a
 connection URL — see
 <a href="/deploy/reference/deno_kv/">Deno KV on Deno Deploy</a>. External KV
 Connect access to new‑Deploy KV databases is not currently exposed.


### PR DESCRIPTION
## Summary

The `/deploy/kv/node/` page tells readers how to use the `@deno/kv` npm
client to talk to a Deno KV database, and points them to the
[Deno Deploy dashboard](https://console.deno.com) to find their database
ID. But the connection workflow it describes is a
**Deno Deploy Classic** workflow:

- The KV Connect URL pattern
  `https://api.deno.com/databases/<id>/connect` is only documented in
  [`deploy/classic/kv_on_deploy.md`](https://docs.deno.com/deploy/classic/kv_on_deploy/).
- The "KV" tab on a project lives in the **Classic** dashboard at
  `dash.deno.com`. The new Deploy dashboard at `console.deno.com`
  provisions KV per app through the
  [Databases](https://docs.deno.com/deploy/reference/databases/) feature,
  and the [new‑Deploy Deno KV reference](https://docs.deno.com/deploy/reference/deno_kv/)
  documents access only via `Deno.openKv()` from within the app — no
  external KV Connect URL is exposed.
- Deploy Classic sunsets on **July 20, 2026** (see
  [migration guide](https://docs.deno.com/deploy/migration_guide/)).

A reader (`@kuboon`) flagged this on the page with the comment
"this is for legacy deno deploy. I need for new one." — the page was
ambiguous about which product it covered.

This PR:

- Adds a "Sunsetting on July 20, 2026" admonition matching the one in
  `deploy/classic/kv_on_deploy.md`, telling new‑Deploy readers the
  page doesn't apply to them and linking to
  [Deno KV on Deno Deploy](https://docs.deno.com/deploy/reference/deno_kv/)
  and [Databases](https://docs.deno.com/deploy/reference/databases/).
- Updates the opening paragraph to name the scope (Classic) explicitly
  and to note `@deno/kv` also works against any self‑hosted
  [`denokv`](https://github.com/denoland/denokv) endpoint that implements
  the open KV Connect protocol.
- Fixes the "KV Connect URLs" section to point at the
  [Classic dashboard](https://dash.deno.com) (where the project's "KV"
  tab actually lives), instead of `console.deno.com`.

Closes denoland/docs#3056
Closes bartlomieju/orchid-inbox#53

cc @bartlomieju

## Test plan

- [x] `deno task test` — passes (frontmatter + content checks).
- [x] `deno task build:light` — site builds; the admonition appears in
      the generated `_site/deploy/kv/node/index.html`.
- [x] Re-read the page from a new‑Deploy user's perspective — the
      warning at the top now makes it obvious whether to follow the
      steps and where to go instead.