### PR TITLE
docs: expand HTTPS support section with a runnable example

### DIFF
--- a/runtime/fundamentals/http_server.md
+++ b/runtime/fundamentals/http_server.md
@@ -179,9 +179,6 @@ Deno.serve({
 }, (_req) => new Response("Hello over HTTPS!"));
 ```
 
-Port `8443` avoids needing root, which binding to the standard HTTPS port `443`
-would require on macOS and Linux.
-
 Run it with network access plus read access to the two files:
 
 ```sh

--- a/runtime/fundamentals/http_server.md
+++ b/runtime/fundamentals/http_server.md
@@ -173,11 +173,14 @@ PEM-encoded contents of the certificate and private key — not file paths.
 
 ```ts title="server.ts"
 Deno.serve({
-  port: 443,
+  port: 8443,
   cert: Deno.readTextFileSync("./cert.pem"),
   key: Deno.readTextFileSync("./key.pem"),
 }, (_req) => new Response("Hello over HTTPS!"));
 ```
+
+Port `8443` avoids needing root, which binding to the standard HTTPS port `443`
+would require on macOS and Linux.
 
 Run it with network access plus read access to the two files:
 
@@ -199,9 +202,8 @@ Then check the server responds. The `-k` flag tells curl to accept a self-signed
 certificate — only use it for local testing:
 
 ```console
-$ curl -kI https://localhost/
-HTTP/2 200
-content-length: 17
+$ curl -k https://localhost:8443/
+Hello over HTTPS!
 ```
 
 :::note

--- a/runtime/fundamentals/http_server.md
+++ b/runtime/fundamentals/http_server.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-09-10
+last_modified: 2026-05-13
 title: "Writing an HTTP Server"
 description: "A guide to creating HTTP servers in Deno. Learn about the Deno.serve API, request handling, WebSocket support, response streaming, and how to build production-ready HTTP/HTTPS servers with automatic compression."
 oldUrl:
@@ -168,21 +168,47 @@ object that is attached to the response body
 
 ### HTTPS support
 
-To use HTTPS, pass two extra arguments in the options: `cert` and `key`. These
-are contents of the certificate and key files, respectively.
+To serve HTTPS, pass `cert` and `key` in the options. Both values are the
+PEM-encoded contents of the certificate and private key — not file paths.
 
-```js
+```ts title="server.ts"
 Deno.serve({
   port: 443,
   cert: Deno.readTextFileSync("./cert.pem"),
   key: Deno.readTextFileSync("./key.pem"),
-}, handler);
+}, (_req) => new Response("Hello over HTTPS!"));
+```
+
+Run it with network access plus read access to the two files:
+
+```sh
+deno run --allow-net --allow-read=cert.pem,key.pem server.ts
+```
+
+For local development you can generate a short-lived self-signed certificate
+with [OpenSSL](https://www.openssl.org/):
+
+```sh
+openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+  -keyout key.pem -out cert.pem \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost"
+```
+
+Then check the server responds. The `-k` flag tells curl to accept a self-signed
+certificate — only use it for local testing:
+
+```console
+$ curl -kI https://localhost/
+HTTP/2 200
+content-length: 17
 ```
 
 :::note
 
-To use HTTPS, you will need a valid TLS certificate and a private key for your
-server.
+In production, use a certificate issued by a trusted authority such as
+[Let's Encrypt](https://letsencrypt.org/) instead of a self-signed one. The
+runtime API is the same; only the source of `cert` and `key` changes.
 
 :::
 


### PR DESCRIPTION
The HTTPS support section in `runtime/fundamentals/http_server.md` previously consisted of a single `Deno.serve` snippet plus a note saying readers would need "a valid TLS certificate and a private key" — without telling them how to actually obtain one. A reader following the docs end-to-end was left to figure out cert generation and verification on their own.

This PR rewrites that one section: the snippet now declares a real handler and binds to port `8443` (so it works without root on macOS/Linux), the prose clarifies that `cert`/`key` take PEM contents rather than file paths, and three new blocks show the `deno run` command (with a scoped `--allow-read=cert.pem,key.pem`), an OpenSSL one-liner for a short-lived local self-signed cert (with a `subjectAltName` so it works against `localhost`), and a `curl -k` step that proves the server responds with the expected body. The closing note now points at Let's Encrypt as the production path instead of restating the precondition.

Verified locally with `denoland/deno:latest` (2.7.14 — Docker Hub doesn't publish a `canary` tag right now): generated the cert with the OpenSSL command, ran the example with `--allow-net --allow-read=cert.pem,key.pem`, and got `Hello over HTTPS!` from `curl -k https://localhost:8443/`. `deno fmt` and `deno task build:light` both pass.