### PR TITLE
docs: troubleshoot "command not found" after install

### DIFF
--- a/runtime/getting_started/installation.md
+++ b/runtime/getting_started/installation.md
@@ -214,6 +214,22 @@ Use `deno help` to see help text documenting Deno's flags and usage. Get a
 detailed guide on the CLI
 [here](/runtime/getting_started/command_line_interface/).
 
+### If you see "command not found"
+
+If `deno --version` reports `command not found`, the install directory isn't on
+your `PATH` yet. To fix this:
+
+- Open a new terminal window or restart your shell so the updated `PATH` is
+  picked up. This is the most common cause — the install script updates your
+  shell rc file, but existing shell sessions don't see the change until they
+  reload.
+- Confirm the install directory is on your `PATH`. The shell install script
+  defaults to `~/.deno/bin` on macOS and Linux; for npm-based installs, run
+  `npm config get prefix` to find the directory containing the global `bin`.
+- If you customised the install location, the shell install script's install
+  root can be overridden with the `DENO_INSTALL` environment variable, in which
+  case the binary lives at `$DENO_INSTALL/bin/deno`.
+
 ## Updating
 
 To update a previously installed version of Deno, you can run:

--- a/runtime/getting_started/installation.md
+++ b/runtime/getting_started/installation.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-05
+last_modified: 2026-05-14
 title: Installation
 description: "A Guide to installing Deno on different operating systems. Includes instructions for Windows, macOS, and Linux using various package managers, manual installation methods, and Docker containers."
 oldUrl:


### PR DESCRIPTION
## Summary

The Installation page tells readers to run `deno --version` to verify
the install but offers no guidance when that fails. The most common cause
is that the install directory isn't on `PATH` yet — the install script
updated the shell rc, but existing sessions don't see the change.

This adds a short `### If you see "command not found"` subsection under
**Testing your installation** covering:

- Restarting the shell so the updated `PATH` is picked up.
- The default install dir for the shell install script (`~/.deno/bin`),
  and how to find the npm global bin via `npm config get prefix`.
- The `DENO_INSTALL` env var override, for readers who customised the
  install location.

The wording for the default path and the `DENO_INSTALL` env var was
cross-checked against the current `denoland/deno_install` install.sh
(`deno_install="${DENO_INSTALL:-$HOME/.deno}"`, `bin_dir="$deno_install/bin"`).

Closes #3045
Closes bartlomieju/orchid-inbox#57

cc @bartlomieju

## Test plan

- [x] `deno fmt --check runtime/getting_started/installation.md` passes.
- [ ] CI lint / link checker passes.
- [ ] Visually confirm the new H3 renders under "Testing your installation".