### PR TITLE
fix: swap mismatched console.log calls in importing_bytes example

### DIFF
--- a/examples/scripts/importing_bytes.ts
+++ b/examples/scripts/importing_bytes.ts
@@ -17,13 +17,13 @@
 // Binary files can be imported in JS and TS modules. When doing so, you need to
 // specify the `type: "bytes"` import attribute.
 import bytes from "./image.png" with { type: "bytes" };
-console.log(text);
+console.log(bytes);
 
 // Dynamic imports are also supported.
 const text = await import("./image.png", {
   with: { type: "bytes" },
 });
-console.log(bytes);
+console.log(text);
 
 /* File: ./image.png
 89 50 4e 47 0d 0a 1a 0a 00 00 00 0d 49 48 44 52


### PR DESCRIPTION
## Summary

The `/examples/importing_bytes/` snippet logs the wrong variable in both halves of the example. As pointed out by the reader in #3044:

- Line 20 logs `text` immediately after `import bytes from "./image.png"` — `text` is not defined yet (TDZ).
- Line 26 logs `bytes` after `const text = await import(...)` — should log `text`.

Swap the two `console.log` arguments so each log matches its preceding import. Variable names are left as-is to keep the diff minimal, per the reporter's request.

## Test plan
- [x] Re-read the snippet end-to-end and confirmed both `console.log` calls now reference variables that exist at that point in the program.

Closes #3044
Closes bartlomieju/orchid-inbox#61

cc @bartlomieju