### PR TITLE
docs: ship deno deps to runtime stage in multi-stage Docker example

### DIFF
--- a/runtime/reference/docker.md
+++ b/runtime/reference/docker.md
@@ -36,6 +36,8 @@ For smaller production images:
 ```dockerfile
 # Build stage
 FROM denoland/deno:latest AS builder
+# Point Deno's cache at a known location so it can be copied to the next stage
+ENV DENO_DIR=/deno-dir
 WORKDIR /app
 COPY . .
 # Install dependencies (use just `deno install` if deno.json has imports)
@@ -43,10 +45,18 @@ RUN deno install --entrypoint main.ts
 
 # Production stage
 FROM denoland/deno:latest
+ENV DENO_DIR=/deno-dir
 WORKDIR /app
 COPY --from=builder /app .
+# Copy the populated Deno cache so the runtime stage has the dependencies
+COPY --from=builder /deno-dir /deno-dir
 CMD ["deno", "run", "--allow-net", "main.ts"]
 ```
+
+Without copying `$DENO_DIR`, `deno install` only writes to Deno's global
+cache inside the builder stage — those files do not travel with
+`COPY --from=builder /app .`, so the container re-downloads dependencies
+on first run.
 
 #### Permission Flags
 

--- a/runtime/reference/docker.md
+++ b/runtime/reference/docker.md
@@ -53,10 +53,10 @@ COPY --from=builder /deno-dir /deno-dir
 CMD ["deno", "run", "--allow-net", "main.ts"]
 ```
 
-Without copying `$DENO_DIR`, `deno install` only writes to Deno's global
-cache inside the builder stage — those files do not travel with
-`COPY --from=builder /app .`, so the container re-downloads dependencies
-on first run.
+Without copying `$DENO_DIR`, `deno install` only writes to Deno's global cache
+inside the builder stage — those files do not travel with
+`COPY --from=builder /app .`, so the container re-downloads dependencies on
+first run.
 
 #### Permission Flags
 


### PR DESCRIPTION
## Summary

The multi-stage Dockerfile example on `/runtime/reference/docker/` runs
`deno install --entrypoint main.ts` in the build stage, but `deno install`
populates Deno's global cache (`$DENO_DIR`), not the project directory.
The runtime stage only does `COPY --from=builder /app .`, so the cached
deps never reach it and the container re-downloads them on first run
(which also breaks any deployment that runs with `--network none` or
without outbound internet access).

This PR points `$DENO_DIR` at `/deno-dir` in both stages and adds a
second `COPY --from=builder /deno-dir /deno-dir` so the populated cache
ships with the image. A short paragraph below the snippet explains the
why.

The single-stage snippet at the top of the page wasn't affected — it
never moves the app between stages, so the existing `deno install`
already lives next to the runtime.

## Why this approach over `--vendor`

The reporter suggested `deno install --vendor`. I tried it and confirmed
that the `--vendor` flag alone is **not sufficient**: it does write deps
into `/app/vendor/`, but Deno only *uses* that folder at runtime when
the project has `"vendor": true` in its `deno.json` (or an equivalent
config). For a generic example that may not have a `deno.json` yet, the
`$DENO_DIR` route is more reliable — it doesn't depend on the user
adding any config and works for both jsr/https/npm specifiers
transparently.

## Verification

Built the updated Dockerfile against `denoland/deno:latest` with a tiny
`main.ts` that imports a remote module from JSR, then ran the resulting
image with `docker run --network none …`:

`main.ts`:

```ts
import { delay } from "jsr:@std/async@^1.0.0/delay";

console.log("Starting...");
await delay(100);
console.log("Hello from a deps-shipped container!");
```

Build output (excerpt):

```
#8 [builder 4/4] RUN deno install --entrypoint main.ts
#8 0.124 Download https://jsr.io/@std/async/meta.json
#8 0.337 Download https://jsr.io/@std/async/1.3.0_meta.json
#8 0.494 Download https://jsr.io/@std/async/1.3.0/delay.ts
#8 0.655 Installed 1 package in 539ms
#8 0.655 + jsr:@std/async 1.3.0
#8 DONE 0.7s

#9 [stage-1 3/4] COPY --from=builder /app .
#10 [stage-1 4/4] COPY --from=builder /deno-dir /deno-dir
```

Offline run:

```
$ docker run --rm --network none deno-fix-final
Starting...
Hello from a deps-shipped container!
```

For comparison, the same `main.ts` against the previous (unfixed) snippet
fails offline:

```
$ docker run --rm --network none deno-broken
Download https://jsr.io/@std/async/meta.json
error: JSR package manifest for '@std/async' failed to load. Import 'https://jsr.io/@std/async/meta.json' failed.
    at file:///app/main.ts:1:23
```

## Test plan

- [x] Reproduced the bug with the original Dockerfile (`--network none` → re-download → fail)
- [x] Built the updated Dockerfile against `denoland/deno:latest` (Deno 2.7.14)
- [x] Ran the resulting image with `--network none` and confirmed the app starts and serves without re-fetching

Closes denoland/docs#2935
Closes bartlomieju/orchid-inbox#65