### PR TITLE
docs: surface manual binary download on installation page

### DIFF
--- a/runtime/getting_started/installation.md
+++ b/runtime/getting_started/installation.md
@@ -195,6 +195,8 @@ You can also build and install from source using
 cargo install deno --locked
 ```
 
+## Manual download
+
 Deno binaries can also be installed manually, by downloading a zip file at
 [github.com/denoland/deno/releases](https://github.com/denoland/deno/releases).
 These packages contain just a single executable file. You will have to set the


### PR DESCRIPTION
## Summary

On `/runtime/getting_started/installation/`, the manual binary download instructions sat as two unheaded sentences immediately after the `cargo install` block, so readers easily missed them (the reporter on the upstream issue almost left negative feedback because they didn't see the option).

This promotes that paragraph to its own `## Manual download` H2, so it:
- appears in the right-rail TOC for the installation page, and
- sits at the same level as `## Docker` / `## Testing your installation` rather than being tucked under the Cargo build paragraph.

Wording is unchanged — only the heading is new.

## Test plan

- [ ] Build the site locally (`deno task build`) and confirm the new "Manual download" entry appears in the right-rail TOC of the installation page.
- [ ] Visually confirm the section renders at H2 level between the Cargo build block and the Docker section.

cc @bartlomieju

Closes denoland/docs#2927
Closes bartlomieju/orchid-inbox#66