### PR TITLE
docs: document how to exclude files from deno check

### DIFF
--- a/runtime/reference/cli/check.md
+++ b/runtime/reference/cli/check.md
@@ -25,6 +25,31 @@ Check multiple files:
 deno check src/server.ts src/utils.ts
 ```
 
+## Scoping and excluding files
+
+You can pass directories or globs as positional arguments to type-check a whole
+tree at once:
+
+```sh
+deno check src/
+deno check "src/**/*.ts"
+```
+
+To skip files or directories, use the top-level `exclude` field in `deno.json`.
+It applies to `deno check` along with other subcommands like `deno fmt` and
+`deno lint`:
+
+```jsonc title="deno.json"
+{
+  "exclude": ["dist/", "vendor/", "**/*.generated.ts"]
+}
+```
+
+See
+[include and exclude](/runtime/fundamentals/configuration/#include-and-exclude)
+in the configuration reference for the full glob syntax, including how to
+un-exclude a sub-path.
+
 ## Type-checking remote modules
 
 By default, only local modules are type-checked. Use `--all` to also type-check


### PR DESCRIPTION
## Summary

The `deno check` reference page didn't mention how to scope or exclude paths from type-checking — a reader asked in denoland/docs#2915 "How do I ignore checking files under a directory?" and the page only showed checking single files or lists of files.

Adds a short **Scoping and excluding files** section to `runtime/reference/cli/check.md` covering:

- Passing directories/globs as positional args (e.g. `deno check src/`, `deno check "src/**/*.ts"`)
- Using the top-level `exclude` field in `deno.json`, which applies to `deno check` along with `deno fmt`/`deno lint`
- A link to the [include and exclude](/runtime/fundamentals/configuration/#include-and-exclude) section of the configuration reference for full glob syntax

Kept the addition focused per the issue's guidance — one section, one code block, link out to the configuration reference for the deeper details.

## Test plan

- [x] `deno fmt --check runtime/reference/cli/check.md` clean
- [x] Verified the documented exclude behavior locally:
  ```sh
  $ echo '{"exclude":["skip/"]}' > deno.json
  $ mkdir -p skip && echo 'const x: number = "s";' > skip/bad.ts
  $ echo 'const y: number = 1;' > good.ts
  $ deno check .
  Check good.ts          # skip/bad.ts correctly excluded
  ```
- [x] Anchor `#include-and-exclude` matches Lume's slug for `## include and exclude` in `runtime/fundamentals/configuration.md` (same pattern as other in-repo links like `#linting`, `#formatting`)

cc @bartlomieju

Closes #2915
Closes bartlomieju/orchid-inbox#67