### PR TITLE
ci: pin Lint workflow to Deno v2.x stable

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: canary
+          deno-version: v2.x
 
       - run: deno fmt --check
       - run: deno task test


### PR DESCRIPTION
## Summary

The `lint and link check` workflow has been failing on every recent PR
with an MDX rendering error in `/styleguide/typography.mdx`:

```
TypeError: Cannot resolve module "lume/jsx-runtime":
relative URL with a cannot-be-a-base base
  at MDXEngine.render (https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/plugins/mdx.ts:96:21)
```

### Root cause

`.github/workflows/lint.yml` sets `deno-version: canary`. The lume MDX
plugin compiles MDX to JS, wraps the output in `URL.createObjectURL(new Blob(...))`,
and dynamic-imports the resulting `blob:` URL. The compiled output references
`"lume/jsx-runtime"`, which is supposed to be resolved via the import map in
`deno.json`:

```json
"lume/jsx-runtime": "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.14/jsx-runtime.ts"
```

A recent canary regression broke bare-specifier resolution when the importer
is a `blob:` URL — Deno now tries to resolve `"lume/jsx-runtime"` as a relative
URL against the `blob:` referrer (which is a [cannot-be-a-base](https://url.spec.whatwg.org/#cannot-be-a-base-url) URL) and errors out before the import map is consulted.

The same build succeeds locally on `deno 2.7.14` (stable). The `deploy/deno/docs`
preview build (which doesn't use canary) has been green throughout.

### Fix

Pin to the `v2.x` stable channel. This keeps automatic stable-version uptake
without exposure to unreleased regressions. Drop-in change — no other workflow
uses `canary`.

When canary stabilises this regression (likely in the next stable bump that
includes the underlying URL resolver change), `v2.x` will pick it up naturally.

cc @bartlomieju — fixes the CI breakage you flagged on #3114.

Closes bartlomieju/orchid-inbox#57

## Test plan

- [ ] CI's lint and link check passes on this PR (was failing on every recent PR including #3114, #3112, #3110, etc.).
- [ ] After merge, re-runs on those PRs succeed.