### PR TITLE
docs: clarify deno info config discovery

### DIFF
--- a/runtime/reference/cli/info.md
+++ b/runtime/reference/cli/info.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-12
+last_modified: 2026-05-16
 title: "deno info"
 oldUrl:
   - /runtime/manual/tools/dependency_inspector/
@@ -14,6 +14,11 @@ description: "Inspect the dependencies of your project"
 `deno info` displays information about a module's dependency tree. See
 [Modules](/runtime/fundamentals/modules/) for more about how Deno resolves and
 caches dependencies.
+
+When you pass a local file, `deno info <file>` automatically discovers a
+`deno.json` or `deno.jsonc` configuration file in the current directory or a
+parent directory. Use `--config <file>` to specify a different configuration
+file, or `--no-config` to disable automatic config discovery.
 
 ## Example
 


### PR DESCRIPTION
## Summary

- Clarifies that `deno info <file>` automatically discovers `deno.json` or `deno.jsonc` from the current directory or parent directories.
- Notes `--config <file>` for an explicit config file and `--no-config` for disabling automatic config discovery.

Fixes denoland/docs#3130
Closes bartlomieju/orchid-inbox#103

## Verification

- `deno info --help`
- `deno task build:light`

Maintainer to ping after CI is green: @bartlomieju