### PR TITLE
docs: mention apt repository status on installation page

### DIFF
--- a/runtime/getting_started/installation.md
+++ b/runtime/getting_started/installation.md
@@ -114,6 +114,9 @@ winget install DenoLand.Deno
 > via npm. We recommend the official install script (shell or PowerShell) for
 > better performance.</small>
 
+Deno does not publish an official apt repository. On Debian or Ubuntu, use the
+shell installer above for the recommended installation path.
+
 ### Cross-platform package managers
 
 These version managers work on macOS, Linux, and Windows.

--- a/runtime/getting_started/installation.md
+++ b/runtime/getting_started/installation.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-21
+last_modified: 2026-06-01
 title: Installation
 description: "A Guide to installing Deno on different operating systems. Includes instructions for Windows, macOS, and Linux using various package managers, manual installation methods, and Docker containers."
 oldUrl:


### PR DESCRIPTION
## Summary

- Add a Linux installation note that Deno does not publish an official apt repository
- Point Debian and Ubuntu readers to the existing shell installer recommendation

## Verification

- deno fmt --check runtime/getting_started/installation.md
- deno task build
- Served _site locally and confirmed the new paragraph renders inside the Linux deno-tab
- Confirmed only runtime/getting_started/installation.md changed, with macOS and Windows tabs untouched

Closes #3126
Closes bartlomieju/orchid-inbox#70