### PR TITLE
docs: mention non-Deno Deploy SvelteKit adapters

### DIFF
--- a/examples/tutorials/svelte.md
+++ b/examples/tutorials/svelte.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-09-29
+last_modified: 2026-05-17
 title: "Build a SvelteKit App"
 description: "A tutorial on building SvelteKit applications with Deno. Learn how to set up a SvelteKit project, implement file-based routing, manage state with load functions, and create a full-stack TypeScript application."
 url: /examples/svelte_tutorial/
@@ -293,6 +293,11 @@ This will:
 
 The built app will be ready for deployment on platforms that support Deno, such
 as Deno Deploy.
+
+If you do not plan to deploy to Deno Deploy or another Deno-compatible platform,
+visit the
+[SvelteKit adapter documentation](https://svelte.dev/docs/kit/adapters) to
+configure the right adapter for your hosting provider.
 
 You can deploy this app to your favorite cloud provider. We recommend using
 [Deno Deploy](https://deno.com/deploy) for a simple and easy deployment


### PR DESCRIPTION
## Summary

- Adds a short note to the SvelteKit tutorial for users who are not deploying to Deno Deploy or another Deno-compatible platform.
- Links those users to the SvelteKit adapter documentation at https://svelte.dev/docs/kit/adapters.

Fixes denoland/docs#2893
Closes bartlomieju/orchid-inbox#119

## Verification

- `deno fmt --check`
- `deno task test`
- Confirmed the new link points to `https://svelte.dev/docs/kit/adapters`.

I also attempted a Lume render with `SKIP_REFERENCE=1 BUILD_TYPE=FULL`, but this VM is running Deno canary `2.7.14+2d3f3f1` and the build failed on an unrelated MDX `lume/jsx-runtime` resolution error before reaching this page.
