### PR TITLE
docs: explain newLineKind auto and system

### DIFF
--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -176,6 +176,10 @@ The newline character to use
 - **Default:** `lf`
 - **Possible values:** `auto`, `crlf`, `lf`, `system`
 
+Use `auto` to preserve the file's existing newline style when Deno can detect
+one. Use `system` to use the current operating system's default newline style,
+which is `crlf` on Windows and `lf` on Unix-like systems.
+
 #### `nextControlFlowPosition`
 
 Define position of next control flow

--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-12-16
+last_modified: 2026-05-17
 title: "Linting and formatting"
 description: "A guide to Deno's built-in code quality tools. Learn how to use deno lint and deno fmt commands, configure rules, integrate with CI/CD pipelines, and maintain consistent code style across your projects."
 ---


### PR DESCRIPTION
## Summary
- Explain how `newLineKind: auto` and `newLineKind: system` differ in the formatting option docs.

## Verification
- `deno fmt --check runtime/fundamentals/linting_and_formatting.md`
- `deno task build:light` (completed; this checkout warns about missing generated `reference_gen/gen/deno.json`, but the build exits successfully)

Fixes denoland/docs#2864
Closes bartlomieju/orchid-inbox#123