### PR TITLE
docs: fix Next.js deploy callout typo

### DIFF
--- a/examples/tutorials/next.md
+++ b/examples/tutorials/next.md
@@ -22,8 +22,8 @@ You can see the
 :::info Deploy your own
 
 Want to skip the tutorial and deploy the finished app right now? Click the
-button below to instantly deploy your own copy of the complete Next.js
-dinosaur app to Deno Deploy. You'll get a live, working application that you can
+button below to instantly deploy your own copy of the complete Next.js dinosaur
+app to Deno Deploy. You'll get a live, working application that you can
 customize and modify as you learn!
 
 [![Deploy on Deno](https://deno.com/button)](https://console.deno.com/new?clone=https://github.com/denoland/tutorial-with-next)

--- a/examples/tutorials/next.md
+++ b/examples/tutorials/next.md
@@ -22,7 +22,7 @@ You can see the
 :::info Deploy your own
 
 Want to skip the tutorial and deploy the finished app right now? Click the
-button below to instantly deploy your own copy of the complete SvelteKit
+button below to instantly deploy your own copy of the complete Next.js
 dinosaur app to Deno Deploy. You'll get a live, working application that you can
 customize and modify as you learn!
 


### PR DESCRIPTION
## Summary
- Corrects the Next.js tutorial deploy callout to say Next.js instead of SvelteKit.
- Keeps the existing Deno Deploy button and tutorial-with-next link unchanged.

## Verification
- deno task build:light
- Confirmed _site/examples/next_tutorial/index.html contains complete Next.js dinosaur app in the deploy callout.
- Confirmed the rendered deploy button still links to https://github.com/denoland/tutorial-with-next.

Fixes denoland/docs#2663.
Closes bartlomieju/orchid-inbox#137