### PR TITLE
docs: npm prefix optional, .npmrc additions, file:/link: skip (2.8)

### DIFF
--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -295,6 +295,11 @@ $ deno add jsr:@luca/cases@1.0.0
 Add @luca/cases - jsr:@luca/cases@1.0.0
 ```
 
+Starting in Deno 2.8, unprefixed package names passed to `deno add` /
+`deno install` are treated as npm packages by default — `deno add express` is
+now equivalent to `deno add npm:express`. JSR packages still need the `jsr:`
+prefix to stay unambiguous.
+
 Read more in [`deno add` reference](/runtime/reference/cli/add/).
 
 You can also remove dependencies using `deno remove`:
@@ -768,6 +773,45 @@ local workspaces). Good supply chain management helps you achieve four goals:
    codebases to centralize version changes.
 6. Periodically unfreeze and update consciously (for example on a weekly or
    sprint cadence) instead of ad‑hoc updates during feature work.
+7. Set a [minimum dependency age](#minimum-dependency-age) so freshly published
+   versions can't slip into an install before the ecosystem has had time to spot
+   a compromised release.
+
+### Minimum dependency age
+
+Deno can refuse to install any package version that is younger than a configured
+age. This is a cheap, broad defence against npm supply-chain attacks: malicious
+versions are usually detected and yanked within days, so delaying installs by a
+similar window catches the bulk of them.
+
+You can configure the same control in three places — pick whichever fits the
+project:
+
+- **`deno.json`** — apply project-wide:
+
+  ```jsonc title="deno.json"
+  {
+    "minimumDependencyAge": "72h"
+  }
+  ```
+
+- **CLI flag** — apply ad-hoc, e.g. for a one-off install or in a CI step:
+
+  ```sh
+  deno install --minimum-dependency-age=72h
+  ```
+
+- **`.npmrc`** (Deno 2.8+) — matches the npm convention, useful when sharing the
+  same `.npmrc` across npm and Deno tooling:
+
+  ```ini title=".npmrc"
+  min-release-age=72h
+  ```
+
+Values accept human-friendly durations (`72h`, `P2D`), absolute cutoff dates
+(`2025-09-16`), or `0` to disable. See
+[`.npmrc` configuration](/runtime/fundamentals/node/#npmrc-configuration) for
+the other npm-registry options Deno reads.
 
 ### Typical CI pattern
 

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -298,7 +298,7 @@ Add @luca/cases - jsr:@luca/cases@1.0.0
 :::info Deno 2.8
 
 Unprefixed package names passed to `deno add` / `deno install` are treated as
-npm packages by default — `deno add express` is now equivalent to
+npm packages by default. `deno add express` is now equivalent to
 `deno add npm:express`. JSR packages still need the `jsr:` prefix to stay
 unambiguous.
 
@@ -788,10 +788,10 @@ age. This is a cheap, broad defence against npm supply-chain attacks: malicious
 versions are usually detected and yanked within days, so delaying installs by a
 similar window catches the bulk of them.
 
-You can configure the same control in three places — pick whichever fits the
+You can configure the same control in three places; pick whichever fits the
 project:
 
-- **`deno.json`** — apply project-wide:
+- **`deno.json`**, apply project-wide:
 
   ```jsonc title="deno.json"
   {
@@ -799,13 +799,13 @@ project:
   }
   ```
 
-- **CLI flag** — apply ad-hoc, e.g. for a one-off install or in a CI step:
+- **CLI flag**, apply ad-hoc, e.g. for a one-off install or in a CI step:
 
   ```sh
   deno install --minimum-dependency-age=72h
   ```
 
-- **`.npmrc`** (Deno 2.8+) — matches the npm convention, useful when sharing the
+- **`.npmrc`** (Deno 2.8+), matches the npm convention, useful when sharing the
   same `.npmrc` across npm and Deno tooling:
 
   ```ini title=".npmrc"

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -295,10 +295,14 @@ $ deno add jsr:@luca/cases@1.0.0
 Add @luca/cases - jsr:@luca/cases@1.0.0
 ```
 
-Starting in Deno 2.8, unprefixed package names passed to `deno add` /
-`deno install` are treated as npm packages by default — `deno add express` is
-now equivalent to `deno add npm:express`. JSR packages still need the `jsr:`
-prefix to stay unambiguous.
+:::info Deno 2.8
+
+Unprefixed package names passed to `deno add` / `deno install` are treated as
+npm packages by default — `deno add express` is now equivalent to
+`deno add npm:express`. JSR packages still need the `jsr:` prefix to stay
+unambiguous.
+
+:::
 
 Read more in [`deno add` reference](/runtime/reference/cli/add/).
 

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -237,9 +237,9 @@ subclasses instead.
   [`Timeout`](https://nodejs.org/api/timers.html#class-timeout) object instead
   of a number, matching Node.js semantics. The returned object exposes methods
   like `.ref()`, `.unref()`, `.refresh()`, and `.hasRef()`. It still coerces to
-  a number (via `Symbol.toPrimitive`), so existing code that stores the timer
-  ID as a number or passes it to `clearTimeout`/`clearInterval` continues to
-  work unchanged.
+  a number (via `Symbol.toPrimitive`), so existing code that stores the timer ID
+  as a number or passes it to `clearTimeout`/`clearInterval` continues to work
+  unchanged.
 
   ```ts
   const t = setTimeout(() => {}, 1000);
@@ -839,6 +839,62 @@ and run it using the `deno run` command:
 ```sh
 deno run main.ts
 ```
+
+### `.npmrc` configuration
+
+Beyond the basic registry / token setup above, Deno reads several other `.npmrc`
+fields. The ones most likely to matter:
+
+- **Mutual-TLS authentication** (Deno 2.8+): `certfile` and `keyfile` point at
+  PEM files used to authenticate the client when the registry requires mTLS.
+
+  ```ini title=".npmrc"
+  //registry.mycompany.com/:certfile=/etc/deno/client.crt
+  //registry.mycompany.com/:keyfile=/etc/deno/client.key
+  ```
+
+- **`email` on `_auth` entries** (Deno 2.8+): some legacy on-prem registries
+  require an `email` alongside the auth token.
+
+  ```ini title=".npmrc"
+  //registry.mycompany.com/:_auth=secretToken
+  //registry.mycompany.com/:email=ci@mycompany.com
+  ```
+
+- **`min-release-age`** (Deno 2.8+): refuses to install package versions younger
+  than the configured age. Useful as a default supply-chain guard for all
+  installs. The same control is also available as the CLI flag
+  `--minimum-dependency-age` and the `minimumDependencyAge` field in
+  `deno.json`. See
+  [Minimum dependency age](/runtime/fundamentals/modules/#minimum-dependency-age)
+  for the full picture.
+
+  ```ini title=".npmrc"
+  min-release-age=72h
+  ```
+
+- **`NPM_CONFIG_REGISTRY` env var**: overrides the registry set in `.npmrc`,
+  matching npm's precedence (handy in CI when you want to redirect installs
+  without editing the checked-in `.npmrc`).
+
+### `file:` and `link:` dependencies in published packages
+
+Some published npm packages accidentally ship a `file:` or `link:` specifier in
+their `package.json` that points at a path on the publisher's machine:
+
+```jsonc title="some-package/package.json"
+{
+  "dependencies": {
+    "lodash": "^4.17.0",
+    "local-helpers": "file:../local-helpers"
+  }
+}
+```
+
+Starting in Deno 2.8, those `file:` and `link:` entries are silently skipped
+while resolving npm metadata, so packages that carry a stray local-path
+dependency install cleanly instead of failing with an "Invalid version
+requirement" error.
 
 ## Node to Deno Cheatsheet
 

--- a/runtime/reference/cli/add.md
+++ b/runtime/reference/cli/add.md
@@ -15,21 +15,21 @@ For more on how Deno handles dependencies, see
 
 ## Examples
 
-Add packages from JSR and npm. Starting in Deno 2.8, unprefixed package names
-are treated as npm packages by default, so the `npm:` prefix is no longer
-required at the CLI:
+Add packages from JSR and npm:
 
 ```sh
-# Deno 2.8+ — unprefixed names install from npm
-deno add express
-deno add express hono zod
-
-# JSR packages still need the jsr: prefix
+deno add npm:express hono zod
 deno add jsr:@std/path
-
-# The npm: prefix still works and remains required in `import` specifiers
-deno add npm:express
 ```
+
+:::info Deno 2.8
+
+Unprefixed package names are treated as npm packages by default, so the `npm:`
+prefix is no longer required at the CLI — `deno add express` is equivalent to
+`deno add npm:express`. JSR packages still need the `jsr:` prefix to stay
+unambiguous. The `npm:` prefix remains required in `import` specifiers.
+
+:::
 
 By default, dependencies are added with a caret (`^`) version range. Use
 `--save-exact` to pin to an exact version:

--- a/runtime/reference/cli/add.md
+++ b/runtime/reference/cli/add.md
@@ -15,10 +15,20 @@ For more on how Deno handles dependencies, see
 
 ## Examples
 
-Add packages from JSR and npm:
+Add packages from JSR and npm. Starting in Deno 2.8, unprefixed package names
+are treated as npm packages by default, so the `npm:` prefix is no longer
+required at the CLI:
 
 ```sh
-deno add @std/path npm:express
+# Deno 2.8+ — unprefixed names install from npm
+deno add express
+deno add express hono zod
+
+# JSR packages still need the jsr: prefix
+deno add jsr:@std/path
+
+# The npm: prefix still works and remains required in `import` specifiers
+deno add npm:express
 ```
 
 By default, dependencies are added with a caret (`^`) version range. Use
@@ -30,12 +40,6 @@ deno add --save-exact @std/path
 
 This saves the dependency without the `^` prefix (e.g., `1.0.0` instead of
 `^1.0.0`).
-
-Treat unprefixed package names as npm packages:
-
-```sh
-deno add --npm express
-```
 
 ## Where dependencies are stored
 

--- a/runtime/reference/cli/add.md
+++ b/runtime/reference/cli/add.md
@@ -25,7 +25,7 @@ deno add jsr:@std/path
 :::info Deno 2.8
 
 Unprefixed package names are treated as npm packages by default, so the `npm:`
-prefix is no longer required at the CLI — `deno add express` is equivalent to
+prefix is no longer required at the CLI. `deno add express` is equivalent to
 `deno add npm:express`. JSR packages still need the `jsr:` prefix to stay
 unambiguous. The `npm:` prefix remains required in `import` specifiers.
 

--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -30,10 +30,18 @@ a `package.json` file, a local `node_modules` directory will be set up as well.
 ### deno install [PACKAGES]
 
 Use this command to install particular packages and add them to `deno.json` or
-`package.json`.
+`package.json`. Starting in Deno 2.8, unprefixed package names are treated as
+npm packages by default, so the `npm:` prefix is no longer required at the CLI:
 
 ```sh
-deno install jsr:@std/testing npm:express
+# Deno 2.8+ — unprefixed names install from npm
+deno install hono zod
+
+# JSR packages still need the jsr: prefix
+deno install jsr:@std/testing
+
+# The npm: prefix still works and remains required in `import` specifiers
+deno install npm:express
 ```
 
 :::tip

--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -39,8 +39,8 @@ deno install jsr:@std/testing npm:express
 :::info Deno 2.8
 
 Unprefixed package names are treated as npm packages by default, so the `npm:`
-prefix is no longer required at the CLI — `deno install express` is equivalent
-to `deno install npm:express`. JSR packages still need the `jsr:` prefix to stay
+prefix is no longer required at the CLI. `deno install express` is equivalent to
+`deno install npm:express`. JSR packages still need the `jsr:` prefix to stay
 unambiguous. The `npm:` prefix remains required in `import` specifiers.
 
 :::

--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -30,19 +30,20 @@ a `package.json` file, a local `node_modules` directory will be set up as well.
 ### deno install [PACKAGES]
 
 Use this command to install particular packages and add them to `deno.json` or
-`package.json`. Starting in Deno 2.8, unprefixed package names are treated as
-npm packages by default, so the `npm:` prefix is no longer required at the CLI:
+`package.json`.
 
 ```sh
-# Deno 2.8+ — unprefixed names install from npm
-deno install hono zod
-
-# JSR packages still need the jsr: prefix
-deno install jsr:@std/testing
-
-# The npm: prefix still works and remains required in `import` specifiers
-deno install npm:express
+deno install jsr:@std/testing npm:express
 ```
+
+:::info Deno 2.8
+
+Unprefixed package names are treated as npm packages by default, so the `npm:`
+prefix is no longer required at the CLI — `deno install express` is equivalent
+to `deno install npm:express`. JSR packages still need the `jsr:` prefix to stay
+unambiguous. The `npm:` prefix remains required in `import` specifiers.
+
+:::
 
 :::tip
 


### PR DESCRIPTION
Three related 2.8 npm-handling items, bundled because they touch overlapping
pages and cross-link.

### `deno add` / `deno install` — unprefixed npm names

Per denoland/deno#33246, the `npm:` prefix is no longer required at the CLI;
unprefixed names are treated as npm packages by default. JSR packages still
need the `jsr:` prefix. Updated:

- `runtime/reference/cli/add.md`
- `runtime/reference/cli/install.md`
- `runtime/fundamentals/modules.md` (Adding dependencies)

### `.npmrc` configuration additions

Extended `runtime/fundamentals/node.md`'s "Private registries" section with a
new `.npmrc configuration` subsection covering:

- `certfile` / `keyfile` for mutual-TLS authentication (denoland/deno#32655)
- `email` on `_auth` entries for legacy on-prem registries (denoland/deno#32616)
- `NPM_CONFIG_REGISTRY` env-var override precedence (denoland/deno#32394)
- `min-release-age` via `.npmrc` (denoland/deno#33983) — cross-linked to the
  new modules.md Minimum dependency age section

### `file:` / `link:` dependencies in published npm packages

Stray `file:` / `link:` specifiers in a published package's `package.json`
are now silently skipped instead of failing with "Invalid version requirement"
(denoland/deno#32876). Added a short note in `runtime/fundamentals/node.md`.

### Minimum dependency age (cross-cutting)

Added a `### Minimum dependency age` subsection under `modules.md` Supply
chain management, consolidating all three configuration paths (CLI flag,
`deno.json`, and the new `.npmrc` form) with a back-reference to `node.md`.

All four touched files have `last_modified: 2026-05-20` and `deno fmt` is
clean.