### PR TITLE
docs: text imports are stable in 2.8 (bytes still require flag)

### DIFF
--- a/examples/scripts/importing_text.ts
+++ b/examples/scripts/importing_text.ts
@@ -2,14 +2,15 @@
  * @title Importing text files
  * @difficulty beginner
  * @tags cli
- * @run --unstable-raw-imports https://docs.deno.com/examples/scripts/importing_text.ts
+ * @run <url>
  * @resource {https://github.com/whatwg/html/issues/9444} HTML specification proposal
- * @group Unstable APIs
+ * @group Basics
  *
  * Text files can be imported in JS and TS files using the `import` keyword.
  * This makes including static data in a library much easier.
  *
- * Using this feature requires `--unstable-raw-imports` CLI flag.
+ * Stable as of Deno 2.8 — no flag required. (Binary `bytes` imports are still
+ * experimental and require `--unstable-raw-imports`.)
  */
 
 // File: ./main.ts

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -78,14 +78,6 @@ console.log(data.property); // Access JSON data as an object
 
 Starting with Deno 2.4 it's possible to import `text` and `bytes` modules too.
 
-:::info
-
-Support for importing `text` and `bytes` modules is experimental and requires
-`--unstable-raw-imports` CLI flag or `unstable.raw-import` option in
-[`deno.json`](/runtime/fundamentals/configuration/).
-
-:::
-
 ```ts
 import text from "./log.txt" with { type: "text" };
 
@@ -94,6 +86,16 @@ console.log(typeof text === "string");
 console.log(text);
 // Hello from a text file
 ```
+
+:::info Deno 2.8
+
+`text` imports are stable in Deno 2.8 and no longer require a flag.
+
+`bytes` imports are still experimental and require the `--unstable-raw-imports`
+CLI flag or the `unstable.raw-import` option in
+[`deno.json`](/runtime/fundamentals/configuration/).
+
+:::
 
 ```ts
 import bytes from "./image.png" with { type: "bytes" };

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -87,13 +87,9 @@ console.log(text);
 // Hello from a text file
 ```
 
-:::info Deno 2.8
+:::info `text` imports
 
-`text` imports are stable in Deno 2.8 and no longer require a flag.
-
-`bytes` imports are still experimental and require the `--unstable-raw-imports`
-CLI flag or the `unstable.raw-import` option in
-[`deno.json`](/runtime/fundamentals/configuration/).
+Stable in Deno 2.8 and no longer require a flag.
 
 :::
 
@@ -109,6 +105,14 @@ Uint8Array(12) [
 //   111,  33
 // ]
 ```
+
+:::info `bytes` imports
+
+Still experimental. Enable with the `--unstable-raw-imports` CLI flag or the
+`unstable.raw-import` option in
+[`deno.json`](/runtime/fundamentals/configuration/).
+
+:::
 
 ## Deferred module evaluation
 


### PR DESCRIPTION
In Deno 2.8, \`with { type: \"text\" }\` imports are stable and no longer require \`--unstable-raw-imports\`. Binary \`with { type: \"bytes\" }\` imports remain experimental and still need the flag.

- \`runtime/fundamentals/modules.md\`: split the Import attributes admonition so it documents the new state. The \`text\` example moves above the admonition; the \`bytes\` example stays after it.
- \`examples/scripts/importing_text.ts\`: drop \`--unstable-raw-imports\` from \`@run\` and the prose; move from \`@group Unstable APIs\` to \`@group Basics\`; mention that \`bytes\` imports still require the flag.

Left \`examples/scripts/importing_bytes.ts\` unchanged.