### PR TITLE
docs: misc 2.8 gaps (lib.node, task prefixes, watch, Cache keys, compat)

### DIFF
--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -33,9 +33,8 @@ That's all you really need to know to get started! However, there are some key
 differences between the two runtimes that you can take advantage of to make your
 code simpler and smaller when migrating your Node.js projects to Deno.
 
-Compatibility against Node's own test suite jumped from ~42% at the start of
-2026 to **over 75% in Deno 2.8**, covering nearly every `node:` module. You can
-track the current state at
+As of Deno 2.8, **over 75% of Node's own test suite passes** in Deno, covering
+nearly every `node:` module. You can track the current state at
 [node-test-viewer.deno.dev](https://node-test-viewer.deno.dev/).
 
 We provide a [list of supported Node.js APIs](/runtime/reference/node_apis/)

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -33,6 +33,11 @@ That's all you really need to know to get started! However, there are some key
 differences between the two runtimes that you can take advantage of to make your
 code simpler and smaller when migrating your Node.js projects to Deno.
 
+Compatibility against Node's own test suite jumped from ~42% at the start of
+2026 to **over 75% in Deno 2.8**, covering nearly every `node:` module. You can
+track the current state at
+[node-test-viewer.deno.dev](https://node-test-viewer.deno.dev/).
+
 We provide a [list of supported Node.js APIs](/runtime/reference/node_apis/)
 that you can use in Deno.
 
@@ -487,17 +492,35 @@ resolution, you can:
 
 ## Including Node types
 
-Node ships with many built-in types like `Buffer` that might be referenced in an
-npm package's types. To load these you must add a types reference directive to
-the `@types/node` package:
+Starting in Deno 2.8, `deno check` and the LSP include `lib.node` in every
+type-check by default, so Node ambient types like `Buffer`, `NodeJS.Timeout`,
+and `process` resolve without any configuration:
+
+```ts
+// 2.8+: type-checks with no extra setup
+const buf: Buffer = Buffer.from("hello");
+const t: NodeJS.Timeout = setTimeout(() => {}, 0);
+```
+
+The bundled `lib.node` tracks the major version of `@types/node` that matches
+the Node release Deno reports in `process.versions.node`. If you need to pin a
+specific `@types/node` version (for example to match the Node version your
+project standardises on), add it as an explicit dependency:
+
+```jsonc title="deno.json"
+{
+  "imports": {
+    "@types/node": "npm:@types/node@^22"
+  }
+}
+```
+
+On versions before 2.8 — or if you've opted out of `lib.node` — you can still
+load the types with a reference directive:
 
 ```ts
 /// <reference types="npm:@types/node" />
 ```
-
-Note that it is fine to not specify a version for this in most cases because
-Deno will try to keep it in sync with its internal Node code, but you can always
-override the version used if necessary.
 
 ## Run npm binaries
 

--- a/runtime/reference/cli/run.md
+++ b/runtime/reference/cli/run.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-12
+last_modified: 2026-05-20
 title: "deno run"
 oldUrl: /runtime/manual/tools/run/
 command: run
@@ -66,6 +66,20 @@ deno run --allow-net --watch server.ts
 
 Deno's watcher will notify you of changes in the console, and will warn in the
 console if there are errors while you work.
+
+The same `--watch` flag is also accepted by
+[`deno test`](/runtime/reference/cli/test/),
+[`deno serve`](/runtime/reference/cli/serve/), and
+[`deno bench`](/runtime/reference/cli/bench/).
+
+:::info Deno 2.8
+
+When the watcher restarts the process, Deno sends `SIGTERM` first so `unload`
+event listeners and `process.exit` hooks run, then waits 500ms before the hard
+kill. This gives graceful-shutdown code time to flush resources between
+restarts.
+
+:::
 
 ## Running a package.json script
 

--- a/runtime/reference/cli/task.md
+++ b/runtime/reference/cli/task.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-12
+last_modified: 2026-05-20
 title: "deno task"
 oldUrl:
   - /runtime/tools/task_runner/
@@ -141,6 +141,15 @@ Listening on http://localhost:8000/
 Dependency tasks are executed in parallel, with the default parallel limit being
 equal to number of cores on your machine. To change this limit, use the
 `DENO_JOBS` environmental variable.
+
+:::info Deno 2.8
+
+When tasks run in parallel, each output line is prefixed with the task name that
+produced it (color-coded per task). Prefixes stay attached even when a task
+forks subprocesses, so a parallel `build` + `test` + `lint` run stays legible
+without an external multiplexer.
+
+:::
 
 Dependencies are tracked and if multiple tasks depend on the same task, that
 task will only be run once:

--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -624,9 +624,13 @@ Only the following APIs are implemented:
 - [CacheStorage::open()](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/open)
 - [CacheStorage::has()](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/has)
 - [CacheStorage::delete()](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/delete)
+- [CacheStorage::keys()](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/keys)
+  (Deno 2.8+)
 - [Cache::match()](https://developer.mozilla.org/en-US/docs/Web/API/Cache/match)
 - [Cache::put()](https://developer.mozilla.org/en-US/docs/Web/API/Cache/put)
 - [Cache::delete()](https://developer.mozilla.org/en-US/docs/Web/API/Cache/delete)
+- [Cache::keys()](https://developer.mozilla.org/en-US/docs/Web/API/Cache/keys)
+  (Deno 2.8+)
 
 A few things that are different compared to browsers:
 


### PR DESCRIPTION
Bundle of small 2.8 doc updates from the audit against the 2.8 blog post.

### `runtime/fundamentals/node.md`

- Intro: noted that Node test-suite compat jumped from ~42% at the start of 2026 to **>75% in Deno 2.8**, with a link to node-test-viewer.deno.dev.
- \"Including Node types\": rewrote to lead with the 2.8 default (\`lib.node\` included automatically; \`Buffer\`, \`NodeJS.*\`, \`process\` resolve with no setup). Added the pinning escape hatch via \`imports\` for \`@types/node\`. Kept the \`/// <reference types=\"npm:@types/node\" />\` form as the older fallback.

### \`runtime/reference/cli/task.md\`

Added a \`:::info Deno 2.8\` admonition under \"Task dependencies\" noting that parallel-task output is prefixed with the task name (color-coded), and that prefixes stay attached through subprocesses.

### \`runtime/reference/cli/run.md\`

- Cross-linked \`--watch\` to \`deno test\` / \`deno serve\` / \`deno bench\`.
- Added a \`:::info Deno 2.8\` admonition about the new \`SIGTERM\` + 500ms grace period when the watcher restarts the process, so \`unload\` listeners and \`process.exit\` hooks get to run.

(Per a quick post-audit pass, I dropped the \`--watch-exclude\` write-up — keeping the doc trim.)

### \`runtime/reference/web_platform_apis.md\`

Added \`CacheStorage::keys()\` and \`Cache::keys()\` to the Cache API implemented-APIs list (the deviations section listed only 6 APIs before; these two land in 2.8).

### Skipped from the original list

- TypeScript 6.0.3 version — pure implementation detail; no page references the TS version.
- \`deno compile\` progress bar — pure UX, nothing to configure.
- Web Crypto SHA3 / P-521 — algorithm support belongs in reference docs (auto-generated); no deviations text to update.
- \`Deno.upgradeWebSocket\` + \`node:http\` upgrade events — \`Deno.upgradeWebSocket\` is already covered; the Node compat side belongs in the auto-generated \`node_apis.md\`.