### PR TITLE
Clarify ClientRequestArgs.timeout units

### DIFF
--- a/reference_gen/node-types.ts
+++ b/reference_gen/node-types.ts
@@ -1,4 +1,4 @@
-import { Node, Project, ts } from "ts-morph";
+import { Node, Project, SourceFile, ts } from "ts-morph";
 import EXCLUDE_MAP from "./node-exclude-map.json" with { type: "json" };
 import { Description, generateDescriptions } from "../runtime/_data.ts";
 
@@ -216,6 +216,15 @@ function getNote(description: Description) {
   return `:::${description.kind} Deno compatibility\n\n${description.description}\n\n:::\n`;
 }
 
+function annotateHttpClientRequestArgs(file: SourceFile) {
+  const clientRequestArgs = file.getInterface("ClientRequestArgs");
+  const timeout = clientRequestArgs?.getProperty("timeout");
+
+  if (timeout && timeout.getJsDocs().length === 0) {
+    timeout.addJsDoc("Timeout in milliseconds.");
+  }
+}
+
 for (const file of importRewriteProject.getSourceFiles()) {
   const moduleName = file.getFilePath().slice(Deno.cwd().length + 1, -5);
 
@@ -275,6 +284,10 @@ for (const file of importRewriteProject.getSourceFiles()) {
         }
       }
     }
+  }
+
+  if (moduleName === "node__http") {
+    annotateHttpClientRequestArgs(file);
   }
 
   modules[moduleName] = file.getFullText();


### PR DESCRIPTION
## Summary
- Adds a focused Node reference generation annotation for `http.ClientRequestArgs.timeout`.
- Documents the timeout value as milliseconds on the generated property page.

## Validation
- `cd reference_gen && deno task types:node && deno task doc:node`
- `cd reference_gen && deno eval 'const files = JSON.parse(await Deno.readTextFile("gen/node.json")); const page = files["http/~/ClientRequestArgs.timeout.json"]; if (!page) throw new Error("missing page"); const text = JSON.stringify(page); if (!text.includes("Timeout in milliseconds.")) throw new Error("missing timeout docs"); console.log("verified ClientRequestArgs.timeout docs include milliseconds");'`

Closes denoland/docs#3147

Closes bartlomieju/orchid-inbox#143
