### PR TITLE
docs: frame deno install as drop-in for npm/yarn/pnpm

### DIFF
--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -17,6 +17,36 @@ description: "Install and cache dependencies for your project"
 on how Deno handles modules, see
 [Modules and dependencies](/runtime/fundamentals/modules/).
 
+## Drop-in replacement for `npm install`, `yarn`, and `pnpm install`
+
+Starting in Deno 2.8, `deno install` is a drop-in replacement for
+`npm install`, `yarn`, or `pnpm install` in an existing Node project. Point it
+at a directory that already contains a `package.json` and Deno will:
+
+- Read `dependencies`, `devDependencies`, `peerDependencies`, and
+  `optionalDependencies` from `package.json` (plus a `package-lock.json`,
+  `yarn.lock`, or `pnpm-lock.yaml` if present).
+- Write a compatible `node_modules` layout — `isolated` by default, or
+  `hoisted` if you set
+  [`"nodeModulesLinker": "hoisted"`](/runtime/fundamentals/node/#node_modules-layout-isolated-vs-hoisted)
+  in `deno.json`.
+- Respect `.npmrc` for registry configuration, scoped auth, and
+  [`min-release-age`](/runtime/fundamentals/node/#npmrc-configuration).
+
+```sh
+# In an existing Node project
+deno install
+```
+
+You can keep running `node`, `npm run <script>`, or any other Node tooling
+against the resulting `node_modules` afterward — using Deno as the package
+manager doesn't lock you into using Deno as the runtime.
+
+The npm-side ergonomics also align with the Node CLIs in 2.8: the `npm:`
+prefix is optional at the command line (`deno install express` works), and
+[`deno install --prod`](#deno-install---prod) skips `devDependencies` and
+`@types/*` for production deploys.
+
 ## Examples
 
 ### deno install


### PR DESCRIPTION
The deno install reference didn't explicitly position the command as a
replacement for npm install / yarn / pnpm install, which is the main framing the
2.8 release uses to recruit Node users. Adds a dedicated section near the top of
the page that calls out the drop-in behavior, what Deno reads from the project,
how node_modules is laid out, and which other 2.8 changes (optional npm: prefix,
--prod) round out the workflow.