### PR TITLE
docs: note 3.66x faster cold npm installs in 2.8

### DIFF
--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -27,6 +27,18 @@ Use this command to install all dependencies defined in
 The dependencies will be installed in the global cache, but if your project has
 a `package.json` file, a local `node_modules` directory will be set up as well.
 
+:::info Faster cold installs in 2.8
+
+Cold `npm` installs are roughly **3.66x faster** in Deno 2.8 than in 2.7 — an
+entrypoint importing React, Vite, Babel parser, and ESLint goes from `3,319ms`
+to `906ms` on a fresh `DENO_DIR`. The change comes from abbreviated packument
+metadata, parallel resolution across the dependency tree, decompression moved
+off the async event loop, and a faster (`libdeflater`-backed) tarball
+extraction pipeline. Warm installs benefit from Deno's shared global cache
+across projects.
+
+:::
+
 ### deno install [PACKAGES]
 
 Use this command to install particular packages and add them to `deno.json` or


### PR DESCRIPTION
The install reference page didn't mention the performance characteristics of
deno install, which is a notable jump in 2.8: cold installs are 3.66x faster
than 2.7 thanks to abbreviated packument metadata, parallel resolution,
decompression off the async event loop, and a faster tarball pipeline. Adds a
short admonition under the deno install section so the number lives next to the
command users will reach for.