### PR TITLE
docs: document set -e/errexit and : null command in deno task shell

### DIFF
--- a/runtime/reference/cli/task.md
+++ b/runtime/reference/cli/task.md
@@ -595,6 +595,10 @@ enabled.
 - **pipefail** - When enabled, the exit code of a pipeline is the exit code of
   the last command to exit with a non-zero status, or zero if all commands exit
   successfully. Enable with `set -o pipefail`.
+- **errexit** (Deno 2.8+) - When enabled, a sequential list aborts on the first
+  command that exits non-zero. Enable with `set -e` or `set -o errexit`;
+  disable again with `set +e` or `set +o errexit`. Useful when porting a shell
+  script that relies on `set -e` semantics into a `tasks` block.
 
 Examples:
 
@@ -608,7 +612,9 @@ Examples:
     // disable globstar
     "task3": "shopt -u globstar && echo **/*.ts",
     // enable pipefail
-    "task4": "set -o pipefail && cat missing.txt | echo 'hello'"
+    "task4": "set -o pipefail && cat missing.txt | echo 'hello'",
+    // abort the sequential list on the first failing command
+    "task5": "set -e; build_step_one; build_step_two; build_step_three"
   }
 }
 ```
@@ -654,6 +660,10 @@ box on Windows, Mac, and Linux.
   environment variables.
 - [`xargs`](https://man7.org/linux/man-pages/man1/xargs.1p.html) - Builds
   arguments from stdin and executes a command.
+- [`:`](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/colon.html) -
+  The POSIX null command. Does nothing and always exits with status `0`
+  (Deno 2.8+). Handy as a no-op placeholder in conditionals or for
+  parameter-expansion side effects.
 
 If you find a useful flag missing on a command or have any suggestions for
 additional commands that should be supported out of the box, then please


### PR DESCRIPTION
The deno task shell picked up two POSIX features in 2.8 that weren't reflected
in the docs: set -e / set -o errexit (with set +e to turn it back off) aborts a
sequential list on the first non-zero exit, and : is now a built-in null
command. Both are useful when porting shell scripts into tasks blocks without
falling back to sh -c. Adds errexit to the shell options list with an example
and lists : alongside the other built-in commands.