### PR TITLE
docs: clarify 2.8 watcher restart timing and --watch-exclude scope

### DIFF
--- a/runtime/getting_started/command_line_interface.md
+++ b/runtime/getting_started/command_line_interface.md
@@ -130,6 +130,10 @@ from expanding the glob:
 deno run --watch --watch-exclude='*.js' main.ts
 ```
 
+Starting in Deno 2.8, `--watch-exclude` patterns are applied to every file
+change event, not just the initial scan, so excluded paths stay excluded as the
+watched tree changes during the run.
+
 ### Hot Module Replacement mode
 
 You can use `--watch-hmr` flag with `deno run` to enable the hot module

--- a/runtime/reference/cli/run.md
+++ b/runtime/reference/cli/run.md
@@ -77,7 +77,12 @@ The same `--watch` flag is also accepted by
 When the watcher restarts the process, Deno sends `SIGTERM` first so `unload`
 event listeners and `process.exit` hooks run, then waits 500ms before the hard
 kill. This gives graceful-shutdown code time to flush resources between
-restarts.
+restarts — previously the grace period was 5 seconds, which made restarts feel
+sluggish.
+
+`--watch-exclude` patterns are also now applied to every file change event, not
+just the initial scan, so excluded paths stay excluded as the watched tree
+changes during the run.
 
 :::
 


### PR DESCRIPTION
Two watch-mode behavior changes in 2.8 weren't fully reflected in the docs: the
grace period between SIGTERM and the hard kill on a restart dropped from 5
seconds to 500ms (existing callout in run.md mentions the 500ms but not the
change from 5s), and --watch-exclude patterns are now applied to every file
change event rather than just the initial scan. Updates the run.md admonition
and the --watch-exclude section in command_line_interface.md to call out both.