### PR TITLE
docs: note 2.8 deno doc HTML polish (Prism JSX/TSX, dark mode)

### DIFF
--- a/runtime/reference/cli/doc.md
+++ b/runtime/reference/cli/doc.md
@@ -213,6 +213,12 @@ deployed to any static site hosting service.
 A client-side search is included in the generated site, but is not available if
 user's browser has JavaScript disabled.
 
+Starting in Deno 2.8 the HTML renderer ships two visual improvements:
+[Prism](https://prismjs.com/) syntax highlighting now covers JSX and TSX code
+blocks in examples (previously they fell back to plain text), and operators
+inside type signatures render with the right foreground color when the site is
+viewed in dark mode.
+
 ## JSON output
 
 Use the `--json` flag to output the documentation in JSON format. This JSON


### PR DESCRIPTION
deno doc's HTML output picked up Prism syntax highlighting for JSX/TSX code
blocks and cleaner operator rendering in dark mode in 2.8 (#33255, #33267).
These are user-visible improvements to a documented surface, so adds a short
paragraph at the end of the HTML output section of the deno doc reference page.