### PR TITLE
docs: fix invalid minimum dependency age example

### DIFF
--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -826,9 +826,9 @@ project:
 `deno.json` and `--minimum-dependency-age` accept an
 [ISO-8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) such as
 `P3D` (3 days) or `PT72H` (72 hours), an integer (interpreted as minutes), an
-absolute cutoff date (`2025-09-16`) or RFC3339 timestamp, or `0` to disable.
-See [`.npmrc` configuration](/runtime/fundamentals/node/#npmrc-configuration)
-for the other npm-registry options Deno reads.
+absolute cutoff date (`2025-09-16`) or RFC3339 timestamp, or `0` to disable. See
+[`.npmrc` configuration](/runtime/fundamentals/node/#npmrc-configuration) for
+the other npm-registry options Deno reads.
 
 ### Typical CI pattern
 

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -805,27 +805,30 @@ project:
 
   ```jsonc title="deno.json"
   {
-    "minimumDependencyAge": "72h"
+    "minimumDependencyAge": "P3D"
   }
   ```
 
 - **CLI flag**, apply ad-hoc, e.g. for a one-off install or in a CI step:
 
   ```sh
-  deno install --minimum-dependency-age=72h
+  deno install --minimum-dependency-age=P3D
   ```
 
 - **`.npmrc`** (Deno 2.8+), matches the npm convention, useful when sharing the
-  same `.npmrc` across npm and Deno tooling:
+  same `.npmrc` across npm and Deno tooling. The npm setting accepts a whole
+  number of days only:
 
   ```ini title=".npmrc"
-  min-release-age=72h
+  min-release-age=3
   ```
 
-Values accept human-friendly durations (`72h`, `P2D`), absolute cutoff dates
-(`2025-09-16`), or `0` to disable. See
-[`.npmrc` configuration](/runtime/fundamentals/node/#npmrc-configuration) for
-the other npm-registry options Deno reads.
+`deno.json` and `--minimum-dependency-age` accept an
+[ISO-8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) such as
+`P3D` (3 days) or `PT72H` (72 hours), an integer (interpreted as minutes), an
+absolute cutoff date (`2025-09-16`) or RFC3339 timestamp, or `0` to disable.
+See [`.npmrc` configuration](/runtime/fundamentals/node/#npmrc-configuration)
+for the other npm-registry options Deno reads.
 
 ### Typical CI pattern
 

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -896,7 +896,7 @@ fields. The ones most likely to matter:
   for the full picture.
 
   ```ini title=".npmrc"
-  min-release-age=72h
+  min-release-age=3
   ```
 
 - **`NPM_CONFIG_REGISTRY` env var**: overrides the registry set in `.npmrc`,


### PR DESCRIPTION
The example for `minimumDependencyAge` used `"72h"`, but neither the
`deno.json` parser nor the `--minimum-dependency-age` CLI flag accepts
that format. The parser only takes an ISO-8601 duration (`P3D`,
`PT72H`), an integer interpreted as minutes, an absolute date or
RFC3339 timestamp, or `0` to disable. The `.npmrc` `min-release-age`
setting is different again: it accepts only a whole number of days.

Updates the `deno.json` and CLI examples to `P3D`, the `.npmrc`
example to `3`, and rewrites the surrounding paragraph so the listed
formats actually match what's accepted.

Fixes denoland/docs#3161