### PR TITLE
docs: fill v2.7 coverage gaps across multiple pages

### DIFF
--- a/runtime/fundamentals/cron.md
+++ b/runtime/fundamentals/cron.md
@@ -76,9 +76,9 @@ up yourself.
 ## OpenTelemetry
 
 When [OpenTelemetry](/runtime/fundamentals/open_telemetry/) is enabled
-(`OTEL_DENO=true`), each `Deno.cron()` invocation automatically produces an
-OpenTelemetry span. This lets you trace cron execution alongside your other
-instrumented code:
+(`OTEL_DENO=true`), each [`Deno.cron()`](/api/deno/~/Deno.cron) invocation
+automatically produces an OpenTelemetry span. This lets you trace cron execution
+alongside your other instrumented code:
 
 ```sh
 OTEL_DENO=true deno run --unstable-cron main.ts

--- a/runtime/fundamentals/cron.md
+++ b/runtime/fundamentals/cron.md
@@ -72,3 +72,18 @@ of this runtime API: it discovers your [`Deno.cron()`](/api/deno/~/Deno.cron)
 definitions at deployment time, schedules and invokes them, handles retries, and
 surfaces runs in a dashboard — so you don't need to keep a long-running process
 up yourself.
+
+## OpenTelemetry
+
+When [OpenTelemetry](/runtime/fundamentals/open_telemetry/) is enabled
+(`OTEL_DENO=true`), each `Deno.cron()` invocation automatically produces an
+OpenTelemetry span. This lets you trace cron execution alongside your other
+instrumented code:
+
+```sh
+OTEL_DENO=true deno run --unstable-cron main.ts
+```
+
+Each cron invocation creates a span named after the cron job. The span covers
+the duration of the handler function, and any spans created inside the handler
+are nested under it as children.

--- a/runtime/fundamentals/debugging.md
+++ b/runtime/fundamentals/debugging.md
@@ -31,6 +31,34 @@ step through your code.
 deno run --inspect your_script.ts
 ```
 
+You can optionally specify a host and port for the inspector server. Both the
+full address and a bare port number are accepted:
+
+```sh
+# Default: listen on 127.0.0.1:9229
+deno run --inspect your_script.ts
+
+# Custom port
+deno run --inspect=9230 your_script.ts
+
+# Custom host and port
+deno run --inspect=0.0.0.0:9229 your_script.ts
+```
+
+### --inspect-publish-uid
+
+By default, Deno prints the inspector WebSocket URL to stderr when it starts
+listening. You can control this with `--inspect-publish-uid`:
+
+- `stderr` (default) — prints the URL to stderr on startup
+- `http` — exposes the URL via the `/json/list` HTTP endpoint on the inspector
+  port, instead of printing it; useful for programmatic tooling that polls for
+  available targets
+
+```sh
+deno run --inspect --inspect-publish-uid=http your_script.ts
+```
+
 :::note
 
 If you use the `--inspect` flag, the code will start executing immediately. If
@@ -511,6 +539,39 @@ including:
 For full details on Deno's OpenTelemetry integration, including custom metrics,
 traces, and configuration options, see the
 [OpenTelemetry documentation](/runtime/fundamentals/open_telemetry).
+
+## Debugging Web Workers
+
+Starting with Deno 2.7, Web Workers can be debugged through Chrome DevTools and
+VS Code. When you run your program with any `--inspect` flag, each spawned
+worker appears as a separate target in `chrome://inspect` alongside the main
+thread.
+
+```ts title="main.ts"
+const worker = new Worker(import.meta.resolve("./worker.ts"), {
+  type: "module",
+});
+worker.postMessage("start");
+```
+
+```ts title="worker.ts"
+self.onmessage = (e) => {
+  console.log("Worker received:", e.data);
+  // Set breakpoints here in DevTools
+};
+```
+
+```sh
+deno run --inspect-brk --allow-read main.ts
+```
+
+Open `chrome://inspect`, and you will see both `main.ts` and `worker.ts` listed
+as separate inspectable targets. Click **Inspect** on the worker target to open
+a dedicated DevTools panel for that worker where you can set breakpoints, step
+through code, and inspect variables independently of the main thread.
+
+In VS Code with the Deno extension, workers appear as separate threads in the
+**Call Stack** panel of the debugger.
 
 ## TLS session debugging
 

--- a/runtime/fundamentals/open_telemetry.md
+++ b/runtime/fundamentals/open_telemetry.md
@@ -107,6 +107,7 @@ Deno automatically creates spans for various operations, such as:
 
 - Incoming HTTP requests served with [`Deno.serve`](/api/deno/~/Deno.serve).
 - Outgoing HTTP requests made with [`fetch`](/api/web/~/fetch).
+- [`Deno.cron()`](/api/deno/~/Deno.cron) job invocations (added in Deno 2.7).
 
 #### [`Deno.serve`](/api/deno/~/Deno.serve)
 

--- a/runtime/reference/node_apis.md
+++ b/runtime/reference/node_apis.md
@@ -166,8 +166,8 @@ db.setAuthorizer((_action, _table) => {
   which prevents potentially dangerous database operations such as schema
   modifications at runtime.
 
-- `DatabaseSync.createTagStore()` — creates a prepared-statement cache that
-  maps SQL strings to compiled statements for efficient repeated execution.
+- `DatabaseSync.createTagStore()` — creates a prepared-statement cache that maps
+  SQL strings to compiled statements for efficient repeated execution.
 
 ## Node test results
 

--- a/runtime/reference/node_apis.md
+++ b/runtime/reference/node_apis.md
@@ -98,6 +98,77 @@ importing them from the relevant `node:` module.
 | [`WritableStreamDefaultController`](https://nodejs.org/api/globals.html#class-writablestreamdefaultcontroller)   | ✅                                 |
 | [`WritableStreamDefaultWriter`](https://nodejs.org/api/globals.html#class-writablestreamdefaultwriter)           | ✅                                 |
 
+## Module notes
+
+### node:worker_threads
+
+Deno 2.7 significantly improved `node:worker_threads` compatibility:
+
+- `stdout` and `stderr` streams are forwarded correctly from workers to the
+  parent process.
+- `worker.terminate()` now resolves with the correct exit code.
+- `workerData`, `execArgv`, and `threadName` options are supported.
+- `worker.performance.eventLoopUtilization()` and `worker.cpuUsage()` are
+  implemented.
+- `BroadcastChannel` from worker threads is properly ref'd/unref'd.
+
+### node:child_process
+
+Deno 2.7 improved `node:child_process` compatibility:
+
+- `stdio` streams (`stdin`, `stdout`, `stderr`) are exposed as `Socket`
+  instances, matching Node.js behavior.
+- Shell redirection (`>`, `<`, `>>`) works in `exec()` and `execSync()`.
+- `fork()` accepts a `URL` as the module path.
+- `timeout` and `killSignal` options are supported in `exec()` and `spawn()`.
+- `NODE_OPTIONS` environment variable is respected for `fork()`'d processes.
+
+### node:zlib
+
+Deno 2.7 added Zstd compression support to `node:zlib`:
+
+```ts
+import zlib from "node:zlib";
+import { promisify } from "node:util";
+
+const compress = promisify(zlib.zstdCompress);
+const decompress = promisify(zlib.zstdDecompress);
+
+const compressed = await compress(Buffer.from("Hello, Deno!"));
+const result = await decompress(compressed);
+console.log(result.toString()); // "Hello, Deno!"
+```
+
+The synchronous variants `zlib.zstdCompressSync()` and
+`zlib.zstdDecompressSync()` are also available.
+
+### node:sqlite
+
+Deno 2.7 added several new APIs to `node:sqlite`:
+
+- `DatabaseSync.setAuthorizer(callback)` — registers a callback invoked for
+  every SQL operation, enabling fine-grained access control over which tables
+  and operations are permitted:
+
+```ts
+import { constants, DatabaseSync } from "node:sqlite";
+
+const db = new DatabaseSync(":memory:");
+db.exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)");
+
+// Allow reads, deny everything else
+db.setAuthorizer((_action, _table) => {
+  return constants.SQLITE_OK;
+});
+```
+
+- `DatabaseSync.enableDefensive(enabled)` — enables or disables defensive mode,
+  which prevents potentially dangerous database operations such as schema
+  modifications at runtime.
+
+- `DatabaseSync.createTagStore()` — creates a prepared-statement cache that
+  maps SQL strings to compiled statements for efficient repeated execution.
+
 ## Node test results
 
 If you're interested in a more detailed view of compatibility on a per-test-case

--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -664,12 +664,12 @@ for streaming compression and decompression.
 
 ### Supported formats
 
-| Format       | String          | Notes              |
-| ------------ | --------------- | ------------------ |
-| gzip         | `"gzip"`        | RFC 1952           |
-| deflate      | `"deflate"`     | zlib (RFC 1950)    |
-| deflate-raw  | `"deflate-raw"` | raw DEFLATE (1951) |
-| Brotli       | `"brotli"`      | Added in Deno 2.7  |
+| Format      | String          | Notes              |
+| ----------- | --------------- | ------------------ |
+| gzip        | `"gzip"`        | RFC 1952           |
+| deflate     | `"deflate"`     | zlib (RFC 1950)    |
+| deflate-raw | `"deflate-raw"` | raw DEFLATE (1951) |
+| Brotli      | `"brotli"`      | Added in Deno 2.7  |
 
 ```ts
 // Compress with Brotli

--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -615,6 +615,149 @@ These types are useful for graphics work; applying transforms to canvas
 drawings, computing layout math, or porting browser code that depends on
 geometry types.
 
+## navigator
+
+Deno implements a subset of the
+[`navigator`](https://developer.mozilla.org/en-US/docs/Web/API/Navigator)
+global. The following properties are available:
+
+- `navigator.userAgent` — always `"Deno/<version>"`
+- `navigator.platform` — the underlying OS platform (e.g. `"Linux x86_64"`,
+  `"MacIntel"`, `"Win32"`). Added in Deno 2.7.
+- `navigator.hardwareConcurrency` — number of logical CPU cores
+
+```ts
+console.log(navigator.userAgent); // "Deno/2.7.0"
+console.log(navigator.platform); // e.g. "Linux x86_64", "MacIntel", "Win32"
+console.log(navigator.hardwareConcurrency); // e.g. 8
+```
+
+## Temporal
+
+The [Temporal API](https://tc39.es/proposal-temporal/docs/) is a modern
+date/time library that replaces `Date` for most use cases. It was stabilized in
+Deno 2.7 and is available as a global without any flags.
+
+```ts
+// Current date/time in local timezone
+const now = Temporal.Now.plainDateTimeISO();
+console.log(now.toString()); // e.g. "2025-03-12T10:30:00"
+
+// Parse a date
+const date = Temporal.PlainDate.from("2025-03-12");
+console.log(date.month); // 3
+
+// Timezone-aware
+const zonedNow = Temporal.Now.zonedDateTimeISO("America/New_York");
+console.log(zonedNow.timeZoneId); // "America/New_York"
+```
+
+Prior to Deno 2.7, Temporal required the `--unstable-temporal` flag.
+
+## CompressionStream and DecompressionStream
+
+Deno supports
+[`CompressionStream`](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream)
+and
+[`DecompressionStream`](https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream)
+for streaming compression and decompression.
+
+### Supported formats
+
+| Format       | String          | Notes              |
+| ------------ | --------------- | ------------------ |
+| gzip         | `"gzip"`        | RFC 1952           |
+| deflate      | `"deflate"`     | zlib (RFC 1950)    |
+| deflate-raw  | `"deflate-raw"` | raw DEFLATE (1951) |
+| Brotli       | `"brotli"`      | Added in Deno 2.7  |
+
+```ts
+// Compress with Brotli
+const input = new TextEncoder().encode("Hello, Deno!");
+const cs = new CompressionStream("brotli");
+const writer = cs.writable.getWriter();
+writer.write(input);
+writer.close();
+const compressed = await new Response(cs.readable).arrayBuffer();
+
+// Decompress
+const ds = new DecompressionStream("brotli");
+const writer2 = ds.writable.getWriter();
+writer2.write(new Uint8Array(compressed));
+writer2.close();
+const result = await new Response(ds.readable).text();
+console.log(result); // "Hello, Deno!"
+```
+
+## Web Crypto
+
+Deno supports the
+[Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API)
+via `crypto.subtle`. Starting with Deno 2.7, SHA-3 hash algorithms are
+supported:
+
+- `SHA3-256`
+- `SHA3-384`
+- `SHA3-512`
+
+```ts
+const data = new TextEncoder().encode("Hello, Deno!");
+const hash = await crypto.subtle.digest("SHA3-256", data);
+console.log(new Uint8Array(hash));
+```
+
+## createImageBitmap
+
+Deno supports
+[`createImageBitmap()`](https://developer.mozilla.org/en-US/docs/Web/API/createImageBitmap)
+for decoding images into `ImageBitmap` objects that can be used with
+[`OffscreenCanvas`](#offscreencanvas).
+
+### Supported input formats
+
+| Format | Notes             |
+| ------ | ----------------- |
+| PNG    |                   |
+| JPEG   |                   |
+| BMP    |                   |
+| GIF    | Added in Deno 2.7 |
+| WebP   | Added in Deno 2.7 |
+
+```ts
+const data = await Deno.readFile("./image.gif");
+const bitmap = await createImageBitmap(new Blob([data]));
+console.log(bitmap.width, bitmap.height);
+```
+
+## File locking
+
+[`Deno.FsFile`](/api/deno/~/Deno.FsFile) supports advisory file locking to
+coordinate access between processes:
+
+- [`lock(exclusive?)`](/api/deno/~/Deno.FsFile.prototype.lock) — acquires a
+  lock. Shared (read) by default; pass `true` for exclusive (write). Blocks if
+  an incompatible lock is held.
+- [`lockSync(exclusive?)`](/api/deno/~/Deno.FsFile.prototype.lockSync) —
+  synchronous variant of `lock()`.
+- [`tryLock(exclusive?)`](/api/deno/~/Deno.FsFile.prototype.tryLock) —
+  non-blocking. Returns `true` if the lock was acquired, `false` otherwise.
+  Added in Deno 2.7.
+- [`tryLockSync(exclusive?)`](/api/deno/~/Deno.FsFile.prototype.tryLockSync) —
+  synchronous variant of `tryLock()`.
+
+```ts
+const file = await Deno.open("./data.txt", { read: true, write: true });
+
+const locked = await file.tryLock(true); // exclusive
+if (locked) {
+  await file.write(new TextEncoder().encode("hello"));
+  await file.unlock();
+} else {
+  console.log("File is locked by another process, skipping.");
+}
+file.close();
+```
+
 ## Deviations of other APIs from spec
 
 ### Cache API


### PR DESCRIPTION
Addresses documentation gaps identified by cross-referencing the [Deno v2.7 blog post](https://deno.com/blog/v2.7) against the docs.

## Changes

### `runtime/reference/web_platform_apis.md`
- **`navigator`** — new section documenting `navigator.platform` (added in 2.7), `navigator.userAgent`, `navigator.hardwareConcurrency`
- **`Temporal`** — new section; was only on the `unstable_flags` page before, now documented as a stable API
- **`CompressionStream` / `DecompressionStream`** — new section with supported formats table including Brotli (`"brotli"` string, added 2.7)
- **Web Crypto** — new section documenting SHA3-256/384/512 support added in 2.7
- **`createImageBitmap`** — new section listing supported input formats (PNG, JPEG, BMP, GIF, WebP), noting GIF and WebP were added in 2.7
- **File locking** — new section documenting `FsFile.tryLock()` / `tryLockSync()` alongside existing `lock()` / `lockSync()`

### `runtime/fundamentals/debugging.md`
- **`--inspect` bare host/port** — documents that `--inspect=9229` and `--inspect=host:port` are valid (matching Node.js behavior)
- **`--inspect-publish-uid`** — new subsection documenting `stderr` (default) and `http` modes
- **Web Worker debugging** — new section explaining that workers appear as separate DevTools targets when `--inspect` is active (new in 2.7)

### `runtime/fundamentals/cron.md`
- **OpenTelemetry** — new section noting that `Deno.cron()` invocations produce OTel spans when `OTEL_DENO=true`

### `runtime/fundamentals/open_telemetry.md`
- Adds `Deno.cron()` to the list of auto-instrumented operations

### `runtime/reference/node_apis.md`
- **`node:worker_threads`** — documents 2.7 improvements: stdout/stderr forwarding, correct exit codes, `workerData`/`execArgv`/`threadName`, CPU usage, `BroadcastChannel` ref/unref
- **`node:child_process`** — documents 2.7 improvements: Socket stdio, shell redirection, `fork()` URL support, `timeout`/`killSignal`, `NODE_OPTIONS`
- **`node:zlib`** — documents Zstd compression support (`zstdCompress`, `zstdDecompress`)
- **`node:sqlite`** — documents `setAuthorizer()`, `enableDefensive()`, and `createTagStore()`