### PR TITLE
ci: unpin Deno version in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,6 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           cache: true
-          deno-version: v2.x
 
       - run: deno fmt --check
       - run: deno task test


### PR DESCRIPTION
The lint workflow pinned Deno to v2.x via setup-deno, which is no longer
necessary now that v2 is the default stable channel. Dropping the pin
lets CI track the latest stable Deno release automatically and keeps the
workflow consistent with the other workflows in this repo, which already
omit deno-version.