### PR TITLE
docs: clarify first project run steps

### DIFF
--- a/runtime/getting_started/first_project.md
+++ b/runtime/getting_started/first_project.md
@@ -28,13 +28,12 @@ my_project
 └── main.ts
 ```
 
-A `deno.json` file is created to
-[configure your project](/runtime/fundamentals/configuration/), and two
-TypeScript files are created; `main.ts` and `main_test.ts`. The `main.ts` file
-contains a small HTTP server built on [`Deno.serve`](/api/deno/~/Deno.serve). It
-shows off Deno's built-in HTTP server, `Response.json()`, and TypeScript working
-out of the box. The handler is exported and guarded by `import.meta.main`, so
-`main_test.ts` can import and call it directly without binding to a port.
+[`deno.json`](/runtime/fundamentals/configuration/) holds your project
+configuration. `main.ts` contains a small HTTP server built on
+[`Deno.serve`](/api/deno/~/Deno.serve), showing off the built-in HTTP server,
+`Response.json()`, and TypeScript working out of the box. The handler is
+exported and guarded by `import.meta.main`, so `main_test.ts` can import and
+call it directly without binding to a port.
 
 ## Run your project
 

--- a/runtime/getting_started/first_project.md
+++ b/runtime/getting_started/first_project.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-03-10
+last_modified: 2026-05-28
 title: Making a Deno project
 description: "Step-by-step guide to creating your first Deno project. Learn how to initialize a project, understand the basic file structure, run TypeScript code, and execute tests using Deno's built-in test runner."
 oldUrl: /runtime/manual/getting_started/first_steps/
@@ -65,5 +65,4 @@ handler returns 404 for unknown route ... ok (1ms)
 ok | 2 passed | 0 failed (3ms)
 ```
 
-You're set. Browse our [examples and tutorials](/examples/) for ideas on what to
-build next.
+Browse our [examples and tutorials](/examples/) for ideas on what to build next.

--- a/runtime/getting_started/first_project.md
+++ b/runtime/getting_started/first_project.md
@@ -5,15 +5,10 @@ description: "Step-by-step guide to creating your first Deno project. Learn how 
 oldUrl: /runtime/manual/getting_started/first_steps/
 ---
 
-Deno has many [built in tools](/runtime/reference/cli/) to make your development
-experience as smooth as possible. One of these tools is the
-[project initializer](/runtime/reference/cli/init), which creates a new Deno
-project with a basic file structure and configuration.
-
-While you are welcome to use JavaScript, Deno has built-in support for
-[TypeScript](https://www.typescriptlang.org/) as well, so we'll be using
-TypeScript in this guide. If you'd prefer to use JavaScript, you can rename the
-files to `.js` and remove the type annotations.
+In this guide, you'll create your first Deno project, run it, and execute its
+tests. We'll use [TypeScript](https://www.typescriptlang.org/) throughout. To
+follow along in JavaScript instead, rename the files to `.js` and remove the
+type annotations.
 
 ## Initialize a new project
 
@@ -36,11 +31,10 @@ my_project
 A `deno.json` file is created to
 [configure your project](/runtime/fundamentals/configuration/), and two
 TypeScript files are created; `main.ts` and `main_test.ts`. The `main.ts` file
-contains a small HTTP server built on [`Deno.serve`](/api/deno/~/Deno.serve) —
-it shows off Deno's built-in HTTP server, `Response.json()`, and TypeScript
-working out of the box. The handler is exported and guarded by
-`import.meta.main`, so `main_test.ts` can import and call it directly without
-binding to a port.
+contains a small HTTP server built on [`Deno.serve`](/api/deno/~/Deno.serve). It
+shows off Deno's built-in HTTP server, `Response.json()`, and TypeScript working
+out of the box. The handler is exported and guarded by `import.meta.main`, so
+`main_test.ts` can import and call it directly without binding to a port.
 
 ## Run your project
 

--- a/runtime/getting_started/first_project.md
+++ b/runtime/getting_started/first_project.md
@@ -29,11 +29,8 @@ my_project
 ```
 
 [`deno.json`](/runtime/fundamentals/configuration/) holds your project
-configuration. `main.ts` contains a small HTTP server built on
-[`Deno.serve`](/api/deno/~/Deno.serve), showing off the built-in HTTP server,
-`Response.json()`, and TypeScript working out of the box. The handler is
-exported and guarded by `import.meta.main`, so `main_test.ts` can import and
-call it directly without binding to a port.
+configuration. `main.ts` is a small HTTP server built on
+[`Deno.serve`](/api/deno/~/Deno.serve), and `main_test.ts` has the tests for it.
 
 ## Run your project
 
@@ -46,7 +43,7 @@ cd my_project
 You can run this program with the following command:
 
 ```bash
-$ deno main.ts
+$ deno -N main.ts
 Listening on http://localhost:8000/
 ```
 

--- a/runtime/getting_started/first_project.md
+++ b/runtime/getting_started/first_project.md
@@ -47,16 +47,14 @@ $ deno -N main.ts
 Listening on http://localhost:8000/
 ```
 
-When you pass a file path directly, Deno infers the `run` subcommand, so
-`deno main.ts` is equivalent to `deno run main.ts`.
+The server needs network permission, granted here via `-N` (short for
+`--allow-net`). See [security](/runtime/fundamentals/security/) for more.
 
 Open the URL in your browser to see the response.
 
 ## Run your tests
 
-Deno has a [built in test runner](/runtime/fundamentals/testing/). You can write
-tests for your code and run them with the `deno test` command. Run the tests in
-your new project with:
+Run the tests with [`deno test`](/runtime/fundamentals/testing/):
 
 ```bash
 $ deno test
@@ -67,9 +65,7 @@ handler returns 404 for unknown route ... ok (1ms)
 ok | 2 passed | 0 failed (3ms)
 ```
 
-Now that you have a basic project set up you can start building your
-application. Check out our [examples and tutorials](/examples/) for more ideas
-on what to build with Deno.
+You're set. Browse our [examples and tutorials](/examples/) for ideas on what to
+build next.
 
-You can
-[learn more about using TypeScript in Deno here](/runtime/fundamentals/typescript).
+To go deeper, see [Using TypeScript in Deno](/runtime/fundamentals/typescript/).

--- a/runtime/getting_started/first_project.md
+++ b/runtime/getting_started/first_project.md
@@ -67,5 +67,3 @@ ok | 2 passed | 0 failed (3ms)
 
 You're set. Browse our [examples and tutorials](/examples/) for ideas on what to
 build next.
-
-To go deeper, see [Using TypeScript in Deno](/runtime/fundamentals/typescript/).

--- a/runtime/getting_started/first_project.md
+++ b/runtime/getting_started/first_project.md
@@ -35,14 +35,20 @@ my_project
 
 A `deno.json` file is created to
 [configure your project](/runtime/fundamentals/configuration/), and two
-TypeScript files are created; `main.ts` and `main_test.ts`. As of Deno 2.8 the
-`main.ts` file contains a small HTTP server built on
-[`Deno.serve`](/api/deno/~/Deno.serve) — it shows off Deno's built-in HTTP
-server, `Response.json()`, and TypeScript working out of the box. The handler is
-exported and guarded by `import.meta.main`, so `main_test.ts` can import and
-call it directly without binding to a port.
+TypeScript files are created; `main.ts` and `main_test.ts`. The `main.ts` file
+contains a small HTTP server built on [`Deno.serve`](/api/deno/~/Deno.serve) —
+it shows off Deno's built-in HTTP server, `Response.json()`, and TypeScript
+working out of the box. The handler is exported and guarded by
+`import.meta.main`, so `main_test.ts` can import and call it directly without
+binding to a port.
 
 ## Run your project
+
+Move into the new project directory:
+
+```bash
+cd my_project
+```
 
 You can run this program with the following command:
 
@@ -50,6 +56,9 @@ You can run this program with the following command:
 $ deno main.ts
 Listening on http://localhost:8000/
 ```
+
+When you pass a file path directly, Deno infers the `run` subcommand, so
+`deno main.ts` is equivalent to `deno run main.ts`.
 
 Open the URL in your browser to see the response.
 


### PR DESCRIPTION
This tightens up `runtime/getting_started/first_project.md` so that a reader
following along from a clean shell can actually run the freshly initialized
project without hitting a confusing error.

Previously the page ran `deno init my_project` and then jumped straight to
`deno main.ts`, which fails from the parent directory because `main.ts`
lives inside `my_project/`. An explicit `cd my_project` step is now shown
between init and run so the example works end to end.

The page also explained the `main.ts` contents with an "As of Deno 2.8…"
preamble, which silently goes stale every time a new release ships. The
sentence has been rephrased to describe what `main.ts` contains without
anchoring to a particular version, so the doc doesn't need a yearly bump.

While reading the run section it wasn't obvious why `deno main.ts` works
without an explicit `run` subcommand. A single sentence has been added
next to the first example noting that Deno infers `run` when given a file
path, which should head off the "is this a typo?" reaction from newcomers.

The brittle `deno test` output block listing specific test names
("handler returns hello", etc.) was considered but left as-is: the
specific names still carry real pedagogical value by showing readers
what's being tested against the handler, and the `deno init` template
changes rarely enough that the drift risk is low. Happy to soften it in
a follow-up if reviewers disagree.

Ran `deno fmt` on the file after editing.