### PR TITLE
docs(security): clarify static-graph exemption covers string-literal import()

### DIFF
--- a/runtime/fundamentals/security.md
+++ b/runtime/fundamentals/security.md
@@ -53,10 +53,13 @@ the key principles of Deno's security model:
   All modules that are imported in the initial static module graph (local files,
   npm packages, jsr packages, and remote URLs) are loaded by the runtime without
   consulting the permission system. No `--allow-read` is required to load local
-  files, and no `--allow-net` is required to fetch remote modules. This
+  files, and no `--allow-net` is required to fetch remote modules. The static
+  graph includes static `import` statements and `import()` calls whose specifier
+  is a string literal — anything that can be resolved without running code. This
   exemption applies only to loading. Once code runs, anything it does still goes
-  through the permission system, and dynamic imports are not covered by the
-  exemption.
+  through the permission system, and `import()` calls with non-literal
+  specifiers (e.g. `import(someVariable)`) are checked against `--allow-read` /
+  `--allow-import` at runtime.
 
 These key principles are designed to provide an environment where a user can
 execute code with minimal risk of harm to the host machine or network. The


### PR DESCRIPTION
The high-level principle in the security model section currently reads:

> This exemption applies only to loading. Once code runs, anything it does
> still goes through the permission system, and dynamic imports are not
> covered by the exemption.

That last clause is ambiguous: read literally it suggests every `await
import(...)` is permission-checked, but the detailed "Module loading"
section a bit further down correctly says only non-statically-analyzable
imports are checked — `import("file:///literal")` is still part of the
initial static graph and exempt.

This came up while reviewing a couple of security advisories where the
reporters read the principle as a strong invariant ("dynamic imports
require permissions") and treated literal-specifier `import()` calls as
bypasses. The runtime classifies them as `CheckSpecifierKind::Static` and
exempts them by design, matching the detailed section — so the principle
just needs to spell out the same distinction.

Wording change:

- name the two things in the static graph (static `import` and
  literal-specifier `import()`) so the carve-out is unambiguous,
- replace "dynamic imports are not covered by the exemption" with
  "`import()` calls with non-literal specifiers (e.g.
  `import(someVariable)`) are checked against `--allow-read` /
  `--allow-import` at runtime," which is the actual runtime behavior.

No semantic change to the model — just aligning the high-level principle
with the detailed section.