### PR TITLE
docs(workspaces): document publish: false to skip a member

### DIFF
--- a/runtime/fundamentals/workspaces.md
+++ b/runtime/fundamentals/workspaces.md
@@ -313,9 +313,9 @@ deno publish
 
 #### Excluding a workspace member from publish
 
-Workspaces often contain members that are not meant to be published — internal
-helpers, examples, or packages that only exist to host shared `tasks`. By
-default `deno publish` will try to publish every workspace member that has a
+Workspaces often contain members that are not meant to be published, such as
+internal helpers, examples, or packages that only exist to host shared `tasks`.
+By default `deno publish` will try to publish every workspace member that has a
 `name` and `exports`, and will error if any of them is missing a `version`.
 
 To opt a member out of `deno publish`, set `"publish": false` in that member's
@@ -331,8 +331,8 @@ To opt a member out of `deno publish`, set `"publish": false` in that member's
 }
 ```
 
-The member is still part of the workspace — its `tasks` run, its `imports` are
-resolved, and other members can depend on it — but `deno publish` skips it
+The member is still part of the workspace. Its `tasks` run, its `imports` are
+resolved, and other members can depend on it, but `deno publish` skips it
 entirely and won't complain about a missing `version`.
 
 This applies to `deno.json` members only. Workspace members defined solely by a

--- a/runtime/fundamentals/workspaces.md
+++ b/runtime/fundamentals/workspaces.md
@@ -311,6 +311,35 @@ cd my-package
 deno publish
 ```
 
+#### Excluding a workspace member from publish
+
+Workspaces often contain members that are not meant to be published — internal
+helpers, examples, or packages that only exist to host shared `tasks`. By
+default `deno publish` will try to publish every workspace member that has a
+`name` and `exports`, and will error if any of them is missing a `version`.
+
+To opt a member out of `deno publish`, set `"publish": false` in that member's
+`deno.json`:
+
+```jsonc title="internal-helpers/deno.json"
+{
+  "name": "@scope/internal-helpers",
+  "tasks": {
+    "build": "deno run -A scripts/build.ts"
+  },
+  "publish": false
+}
+```
+
+The member is still part of the workspace — its `tasks` run, its `imports` are
+resolved, and other members can depend on it — but `deno publish` skips it
+entirely and won't complain about a missing `version`.
+
+This applies to `deno.json` members only. Workspace members defined solely by a
+`package.json` are npm packages and are never candidates for `deno publish`
+(which targets JSR), so no opt-out is needed for them. `package.json`'s
+`"private": true` field is not read by Deno.
+
 #### Managing interdependent packages
 
 When publishing packages from a workspace with interdependencies, use consistent
@@ -469,6 +498,7 @@ root and its members:
 | test.include         | ✅        | ✅      |                                                                                                                                                                                                                 |
 | test.exclude         | ✅        | ✅      |                                                                                                                                                                                                                 |
 | test.files           | ⚠️        | ❌      | Deprecated                                                                                                                                                                                                      |
+| publish              | ❌        | ✅      | Set to `false` to exclude a member from `deno publish`. See [Excluding a workspace member from publish](#excluding-a-workspace-member-from-publish).                                                            |
 | publish.include      | ✅        | ✅      |                                                                                                                                                                                                                 |
 | publish.exclude      | ✅        | ✅      |                                                                                                                                                                                                                 |
 | bench.include        | ✅        | ✅      |                                                                                                                                                                                                                 |

--- a/runtime/reference/cli/publish.md
+++ b/runtime/reference/cli/publish.md
@@ -40,8 +40,8 @@ Before you publish your package, you must create it in the registry by visiting
 
 When run inside a [workspace](/runtime/fundamentals/workspaces/), `deno publish`
 tries to publish every member that has a `name` and `exports`, and errors if any
-of them is missing a `version`. To opt a member out — for example an internal
-helper package that only exists to host shared `tasks` — set `"publish": false`
+of them is missing a `version`. To opt a member out, for example an internal
+helper package that only exists to host shared `tasks`, set `"publish": false`
 in that member's `deno.json`:
 
 ```jsonc title="internal-helpers/deno.json"

--- a/runtime/reference/cli/publish.md
+++ b/runtime/reference/cli/publish.md
@@ -36,6 +36,25 @@ Example:
 Before you publish your package, you must create it in the registry by visiting
 [JSR - Publish a package](https://jsr.io/new).
 
+## Excluding a workspace member
+
+When run inside a [workspace](/runtime/fundamentals/workspaces/), `deno publish`
+tries to publish every member that has a `name` and `exports`, and errors if any
+of them is missing a `version`. To opt a member out — for example an internal
+helper package that only exists to host shared `tasks` — set `"publish": false`
+in that member's `deno.json`:
+
+```jsonc title="internal-helpers/deno.json"
+{
+  "name": "@scope/internal-helpers",
+  "publish": false
+}
+```
+
+The member stays part of the workspace but is skipped by `deno publish`. See
+[Excluding a workspace member from publish](/runtime/fundamentals/workspaces/#excluding-a-workspace-member-from-publish)
+for the full discussion.
+
 ## Examples
 
 Publish your current workspace


### PR DESCRIPTION
Workspaces often contain members that aren't meant to be published — internal
helpers, examples, or packages that exist only to host shared `tasks`. By
default `deno publish` tries to publish every workspace member with a `name`
and `exports`, and errors out if any of them is missing a `version`. The
supported escape hatch is `\"publish\": false` in that member's `deno.json`,
but this wasn't covered anywhere in the docs.

Adds an \"Excluding a workspace member from publish\" subsection in
runtime/fundamentals/workspaces.md, plus a row in the field-support table.
Also notes that `package.json`'s `\"private\": true` is not read by Deno, and
that no opt-out is needed for package.json-only members since `deno publish`
only targets JSR.

Motivated by denoland/deno#28096.