### PR TITLE
docs: note that deno task ** recurses into node_modules

### DIFF
--- a/runtime/reference/cli/task.md
+++ b/runtime/reference/cli/task.md
@@ -580,6 +580,23 @@ echo data[0-9].csv
 
 The supported glob characters are `*`, `?`, and `[`/`]`.
 
+:::caution
+
+Because `globstar` is enabled by default (see [Shell options](#shell-options)),
+`**` recurses into **all** descendant directories, including `node_modules`.
+This differs from some interactive shells where `**` is not recursive unless
+explicitly enabled, so a task like `deno check **/*.ts` can expand to far more
+files than the same command typed in your terminal, sweeping in dependency
+files. That can lead to errors such as `Argument list too long` or type-checking
+files you didn't intend to.
+
+For `deno check` and `deno fmt`, prefer running them without glob arguments and
+using the [`exclude`](/runtime/fundamentals/configuration/) option in your
+`deno.json` (`node_modules` is excluded by default), or disable recursion for
+the task with `shopt -u globstar`.
+
+:::
+
 ### Shell options
 
 `deno task` supports shell options in Deno 2.6.6 and above to control glob

--- a/runtime/reference/cli/task.md
+++ b/runtime/reference/cli/task.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-20
+last_modified: 2026-06-15
 title: "deno task"
 oldUrl:
   - /runtime/tools/task_runner/
@@ -591,9 +591,9 @@ files. That can lead to errors such as `Argument list too long` or type-checking
 files you didn't intend to.
 
 For `deno check` and `deno fmt`, prefer running them without glob arguments and
-using the [`exclude`](/runtime/fundamentals/configuration/) option in your
-`deno.json` (`node_modules` is excluded by default), or disable recursion for
-the task with `shopt -u globstar`.
+using the [`exclude`](/runtime/reference/deno_json/#include-and-exclude) option
+in your `deno.json` (`node_modules` is excluded by default), or disable
+recursion for the task with `shopt -u globstar`.
 
 :::
 


### PR DESCRIPTION
Adds a caution note to the `deno task` glob expansion docs clarifying that,
because `globstar` is enabled by default, `**` recurses into all descendant
directories including `node_modules`. This surprises users coming from shells
where `**` is not recursive by default: a task like `deno check **/*.ts` can
expand to far more files than the same command typed in the terminal, leading to
errors like `Argument list too long` or type-checking unintended dependency
files.

The note points to running `deno check` / `deno fmt` without glob arguments plus
the `exclude` config (which excludes `node_modules` by default), or disabling
recursion per-task with `shopt -u globstar`.

Prompted by denoland/deno#31910.
