### PR TITLE
docs(fmt): document XML and SVG support in deno fmt

### DIFF
--- a/runtime/reference/cli/fmt.md
+++ b/runtime/reference/cli/fmt.md
@@ -116,6 +116,8 @@ deno fmt --ignore=dist/,build/
 | JSONC                | `.jsonc`                                               |                                                                                        |
 | CSS                  | `.css`                                                 |                                                                                        |
 | HTML                 | `.html`                                                |                                                                                        |
+| XML                  | `.xml`                                                 |                                                                                        |
+| SVG                  | `.svg`                                                 |                                                                                        |
 | [Nunjucks][Nunjucks] | `.njk`                                                 |                                                                                        |
 | [Vento][Vento]       | `.vto`                                                 |                                                                                        |
 | YAML                 | `.yml`, `.yaml`                                        |                                                                                        |


### PR DESCRIPTION
`deno fmt` formats `.xml` and `.svg` files by default. They are routed
through the same markup formatter as HTML (see `cli/tools/fmt.rs` in
`denoland/deno`, where `"html" | "xml" | "svg"` all dispatch to
`format_html`) and require no unstable flag, but they were missing from
the supported file types table on this page.

This adds XML and SVG rows alongside HTML so the documented capabilities
match the actual behavior.

Reported in denoland/deno#34309.
