### PR TITLE
docs: add Migrating from Node.js to Deno guide

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -40,6 +40,10 @@ export const sidebar = [
         href: "/runtime/fundamentals/node/",
       },
       {
+        title: "Migrating from Node",
+        href: "/runtime/fundamentals/migrate_from_node/",
+      },
+      {
         title: "Security",
         href: "/runtime/fundamentals/security/",
       },

--- a/runtime/fundamentals/migrate_from_node.md
+++ b/runtime/fundamentals/migrate_from_node.md
@@ -53,27 +53,53 @@ deno task start
 
 ## Node to Deno Cheatsheet
 
-| Node.js                                | Deno                          |
-| -------------------------------------- | ----------------------------- |
-| `node file.js`                         | `deno file.js`                |
-| `ts-node file.ts`                      | `deno file.ts`                |
-| `nodemon`                              | `deno run --watch`            |
-| `node -e`                              | `deno eval`                   |
-| `npm i` / `npm install`                | `deno install`                |
-| `npm install -g`                       | `deno install -g`             |
-| `npm run`                              | `deno task`                   |
-| `eslint`                               | `deno lint`                   |
-| `prettier`                             | `deno fmt`                    |
-| `package.json`                         | `deno.json` or `package.json` |
-| `tsc`                                  | `deno check` ¹                |
-| `typedoc`                              | `deno doc`                    |
-| `jest` / `ava` / `mocha` / `tap` / etc | `deno test`                   |
-| `nexe` / `pkg`                         | `deno compile`                |
-| `npm explain`                          | `deno info`                   |
-| `nvm` / `n` / `fnm`                    | `deno upgrade`                |
-| `tsserver`                             | `deno lsp`                    |
-| `nyc` / `c8` / `istanbul`              | `deno coverage`               |
-| benchmarks                             | `deno bench`                  |
+In a Node project, many of these are separate packages you install and configure
+— eslint, prettier, jest, ts-node, nodemon, nyc, tsc. In Deno they're the same
+binary, with no extra dependencies and no config files to maintain. You can keep
+your existing `package.json`, or move configuration into `deno.json`.
 
-¹ Type checking happens automatically, TypeScript compiler is built into the
-`deno` binary.
+### Run and watch
+
+| Node.js           | Deno               |
+| ----------------- | ------------------ |
+| `node file.js`    | `deno file.js`     |
+| `ts-node file.ts` | `deno file.ts`     |
+| `node -e "…"`     | `deno eval "…"`    |
+| `nodemon`         | `deno run --watch` |
+
+### Dependencies and scripts
+
+| Node.js                 | Deno                    |
+| ----------------------- | ----------------------- |
+| `npm install` / `npm i` | `deno install`          |
+| `npm install -g <pkg>`  | `deno install -g <pkg>` |
+| `npm run <script>`      | `deno task <script>`    |
+| `npm explain <pkg>`     | `deno why <pkg>`        |
+
+### Quality and testing — built in, no install or config
+
+| Node.js                          | Deno            |
+| -------------------------------- | --------------- |
+| `eslint`                         | `deno lint`     |
+| `prettier`                       | `deno fmt`      |
+| `jest` / `mocha` / `ava` / `tap` | `deno test`     |
+| `nyc` / `c8` / `istanbul`        | `deno coverage` |
+| benchmark libraries              | `deno bench`    |
+
+### TypeScript, docs, and builds
+
+| Node.js        | Deno           |
+| -------------- | -------------- |
+| `tsc`          | `deno check` ¹ |
+| `typedoc`      | `deno doc`     |
+| `nexe` / `pkg` | `deno compile` |
+
+¹ TypeScript runs directly — there's no build step. `deno check` type-checks
+without emitting, and the compiler is built into the `deno` binary.
+
+### Toolchain
+
+| Node.js             | Deno           |
+| ------------------- | -------------- |
+| `tsserver`          | `deno lsp`     |
+| `nvm` / `n` / `fnm` | `deno upgrade` |

--- a/runtime/fundamentals/migrate_from_node.md
+++ b/runtime/fundamentals/migrate_from_node.md
@@ -1,0 +1,97 @@
+---
+last_modified: 2026-06-08
+title: "Migrating from Node.js to Deno"
+description: "How to migrate an existing Node.js project to Deno: most projects run unchanged. Covers the rare compatibility points, running npm scripts with deno task, adopting Deno's toolchain, and a Node-to-Deno command cheatsheet."
+oldUrl:
+  - /runtime/manual/node/migrate/
+  - /runtime/manual/references/cheatsheet/
+  - /runtime/manual/node/cheatsheet/
+---
+
+Most Node.js projects run in Deno **with no changes at all**. Point Deno at your
+entry file or your `package.json` scripts and it just works: Deno reads
+`package.json`, resolves your npm and `node:` dependencies, and runs both ES
+modules and CommonJS out of the box.
+
+```sh
+# An existing Node project — no migration step required
+deno run main.js
+deno task start
+```
+
+If something doesn't run immediately, it's almost always one of a few
+well-defined compatibility points rather than a real porting effort:
+
+- **Bare built-in imports need the `node:` prefix** — `import os from "node:os"`
+  rather than `import os from "os"`. Modern Node code already uses the prefix,
+  and Deno's error messages tell you exactly which import to update.
+- **A few Node globals must be imported explicitly** — for example `Buffer` is
+  imported from `node:buffer` (see
+  [Node.js global objects](/runtime/fundamentals/node/#nodejs-global-objects)).
+  The most common one, `process`, is available globally.
+- **CommonJS-only APIs** such as `require()` are available in `.cjs` files or
+  via `createRequire` (see
+  [CommonJS support](/runtime/fundamentals/node/#commonjs-support)).
+
+For the complete picture of what's supported, see
+[Node and npm compatibility](/runtime/fundamentals/node/).
+
+## Running scripts
+
+Deno supports running npm scripts natively with the
+[`deno task`](/runtime/reference/cli/task/) subcommand (If you're migrating from
+Node.js, this is similar to the `npm run script` command). Consider the
+following Node.js project with a script called `start` inside its
+`package.json`:
+
+```json title="package.json"
+{
+  "name": "my-project",
+  "scripts": {
+    "start": "eslint"
+  }
+}
+```
+
+You can execute this script with Deno by running:
+
+```sh
+deno task start
+```
+
+## Optional improvements
+
+Deno ships a unified toolchain (configuration, linter, formatter, test runner)
+that can simplify your setup when migrating:
+
+- [Configuration](/runtime/fundamentals/configuration/)
+- [Linter](/runtime/reference/cli/lint/)
+- [Formatter](/runtime/reference/cli/fmt/)
+- [Test runner](/runtime/reference/cli/test/)
+
+## Node to Deno Cheatsheet
+
+| Node.js                                | Deno                          |
+| -------------------------------------- | ----------------------------- |
+| `node file.js`                         | `deno file.js`                |
+| `ts-node file.ts`                      | `deno file.ts`                |
+| `nodemon`                              | `deno run --watch`            |
+| `node -e`                              | `deno eval`                   |
+| `npm i` / `npm install`                | `deno install`                |
+| `npm install -g`                       | `deno install -g`             |
+| `npm run`                              | `deno task`                   |
+| `eslint`                               | `deno lint`                   |
+| `prettier`                             | `deno fmt`                    |
+| `package.json`                         | `deno.json` or `package.json` |
+| `tsc`                                  | `deno check` ¹                |
+| `typedoc`                              | `deno doc`                    |
+| `jest` / `ava` / `mocha` / `tap` / etc | `deno test`                   |
+| `nexe` / `pkg`                         | `deno compile`                |
+| `npm explain`                          | `deno info`                   |
+| `nvm` / `n` / `fnm`                    | `deno upgrade`                |
+| `tsserver`                             | `deno lsp`                    |
+| `nyc` / `c8` / `istanbul`              | `deno coverage`               |
+| benchmarks                             | `deno bench`                  |
+
+¹ Type checking happens automatically, TypeScript compiler is built into the
+`deno` binary.

--- a/runtime/fundamentals/migrate_from_node.md
+++ b/runtime/fundamentals/migrate_from_node.md
@@ -1,55 +1,110 @@
 ---
 last_modified: 2026-06-08
 title: "Migrating from Node.js to Deno"
-description: "How to migrate an existing Node.js project to Deno: most projects run unchanged. Covers the rare compatibility points, running npm scripts with deno task, adopting Deno's toolchain, and a Node-to-Deno command cheatsheet."
+description: "How to move a Node.js project to Deno: use Deno as a drop-in package manager, run your existing project and package.json scripts, understand how CommonJS and ES modules are resolved, and map your Node commands to Deno."
 oldUrl:
   - /runtime/manual/node/migrate/
   - /runtime/manual/references/cheatsheet/
   - /runtime/manual/node/cheatsheet/
 ---
 
-Most Node.js projects run in Deno **with no changes at all**. Point Deno at your
-entry file or your `package.json` scripts and it just works: Deno reads
-`package.json`, resolves your npm and `node:` dependencies, and runs both ES
-modules and CommonJS out of the box.
+Most Node.js projects run in Deno **with no changes at all**. Deno reads your
+`package.json`, installs and resolves the same npm dependencies, runs both
+CommonJS and ES modules, and exposes Node's built-in modules through `node:`
+specifiers — so in most cases you point Deno at your existing project and it
+just works.
+
+You can also adopt Deno incrementally: use it purely as a faster, drop-in
+package manager for an app you still run with Node, run your existing
+`package.json` scripts with `deno task`, or switch to Deno as the runtime and
+pick up its built-in toolchain. This guide walks through each step.
+
+## Use Deno as your package manager
+
+Deno is fully compatible with npm and `package.json`, so the easiest place to
+start is dependency management — without changing how you run your code at all.
+`deno install` reads your existing `package.json`, resolves the same npm
+packages, and writes a `node_modules` directory, just like `npm install`:
 
 ```sh
-# An existing Node project — no migration step required
-deno run main.js
-deno task start
+cd my-node-app
+deno install
 ```
 
-The main thing to be aware of is CommonJS interop: it's well supported but
-doesn't cover every situation. `require()` is available in `.cjs` files or via
-`createRequire`, and you can mix CommonJS and ES modules — see
-[CommonJS support](/runtime/fundamentals/node/#commonjs-support) for the cases
-that need attention.
+You can keep running the app with Node from here — using Deno only as a faster
+package manager — or manage dependencies with Deno's built-in commands:
 
-For the complete picture of what's supported, see
-[Node and npm compatibility](/runtime/fundamentals/node/).
+```sh
+deno add    npm:express   # add a dependency
+deno remove express       # remove one
+deno outdated             # see what has newer versions
+```
 
-## Running scripts
+Deno understands dependencies declared in both `package.json` and `deno.json`,
+and individual npm packages can also be imported inline with `npm:` specifiers.
+See [Modules and dependencies](/runtime/fundamentals/modules/) for the full
+picture.
 
-Deno supports running npm scripts natively with the
-[`deno task`](/runtime/reference/cli/task/) subcommand (If you're migrating from
-Node.js, this is similar to the `npm run script` command). Consider the
-following Node.js project with a script called `start` inside its
-`package.json`:
+## Run your project with Deno
+
+To run an existing Node project with Deno, install its dependencies and run the
+entrypoint:
+
+```sh
+cd my-node-app
+deno install
+deno run main.js
+```
+
+If your `package.json` defines scripts, run them with
+[`deno task`](/runtime/reference/cli/task/) — the equivalent of `npm run`:
 
 ```json title="package.json"
 {
   "name": "my-project",
   "scripts": {
-    "start": "eslint"
+    "start": "node server.js"
   }
 }
 ```
 
-You can execute this script with Deno by running:
-
 ```sh
 deno task start
 ```
+
+Most code runs unchanged. The main thing to understand is how Deno decides
+whether a file is CommonJS or an ES module, which follows your `package.json` —
+covered next.
+
+## CommonJS and ES modules
+
+Deno runs both ES modules and CommonJS, and decides how to treat a file using
+the same rules as Node.js:
+
+- A `.cjs` file is **always** CommonJS, and a `.mjs` file is **always** an ES
+  module — the extension is enough.
+- A `.js`, `.ts`, `.jsx`, or `.tsx` file is loaded as **CommonJS** when the
+  nearest `package.json` sets `"type": "commonjs"`, and as an **ES module**
+  otherwise. Deno walks up the directory tree to find that `package.json`, just
+  like Node.
+
+```json title="package.json"
+{
+  "type": "commonjs"
+}
+```
+
+So an existing CommonJS project keeps working: with `"type": "commonjs"` in
+`package.json`, your `require()`-based `.js` files run under both Node and Deno.
+CommonJS code needs its dependencies present in `node_modules` (set
+`"nodeModulesDir": "auto"` in `deno.json`) and the usual
+[permission flags](/runtime/fundamentals/security/).
+
+You can also mix the two module systems: `require()` is available in `.cjs`
+files or via `createRequire`, Deno's `require()` can load synchronous ES
+modules, and you can `import` CommonJS files from ES modules. See
+[CommonJS support](/runtime/fundamentals/node/#commonjs-support) for the details
+and edge cases.
 
 ## Node to Deno Cheatsheet
 

--- a/runtime/fundamentals/migrate_from_node.md
+++ b/runtime/fundamentals/migrate_from_node.md
@@ -25,10 +25,6 @@ well-defined compatibility points rather than a real porting effort:
 - **Bare built-in imports need the `node:` prefix** — `import os from "node:os"`
   rather than `import os from "os"`. Modern Node code already uses the prefix,
   and Deno's error messages tell you exactly which import to update.
-- **A few Node globals must be imported explicitly** — for example `Buffer` is
-  imported from `node:buffer` (see
-  [Node.js global objects](/runtime/fundamentals/node/#nodejs-global-objects)).
-  The most common one, `process`, is available globally.
 - **CommonJS-only APIs** such as `require()` are available in `.cjs` files or
   via `createRequire` (see
   [CommonJS support](/runtime/fundamentals/node/#commonjs-support)).

--- a/runtime/fundamentals/migrate_from_node.md
+++ b/runtime/fundamentals/migrate_from_node.md
@@ -112,6 +112,8 @@ configure: eslint, prettier, jest, ts-node, nodemon, nyc, tsc. In Deno they're
 the same binary, with no extra dependencies and no config files to maintain. You
 can keep your existing `package.json`, or move configuration into `deno.json`.
 
+<div class="cheatsheet">
+
 ### Run and watch
 
 | Node.js           | Deno               |
@@ -157,3 +159,5 @@ without emitting, and the compiler is built into the `deno` binary.
 | ------------------- | -------------- |
 | `tsserver`          | `deno lsp`     |
 | `nvm` / `n` / `fnm` | `deno upgrade` |
+
+</div>

--- a/runtime/fundamentals/migrate_from_node.md
+++ b/runtime/fundamentals/migrate_from_node.md
@@ -9,10 +9,9 @@ oldUrl:
 ---
 
 Most Node.js projects run in Deno **with no changes at all**. Deno reads your
-`package.json`, installs and resolves the same npm dependencies, runs both
-CommonJS and ES modules, and exposes Node's built-in modules through `node:`
-specifiers — so in most cases you point Deno at your existing project and it
-just works.
+`package.json`, installs and resolves the same npm dependencies, and runs both
+CommonJS and ES modules — so in most cases you point Deno at your existing
+project and it just works.
 
 You can also adopt Deno incrementally: use it purely as a faster, drop-in
 package manager for an app you still run with Node, run your existing

--- a/runtime/fundamentals/migrate_from_node.md
+++ b/runtime/fundamentals/migrate_from_node.md
@@ -19,15 +19,11 @@ deno run main.js
 deno task start
 ```
 
-If something doesn't run immediately, it's almost always one of a few
-well-defined compatibility points rather than a real porting effort:
-
-- **Bare built-in imports need the `node:` prefix** — `import os from "node:os"`
-  rather than `import os from "os"`. Modern Node code already uses the prefix,
-  and Deno's error messages tell you exactly which import to update.
-- **CommonJS-only APIs** such as `require()` are available in `.cjs` files or
-  via `createRequire` (see
-  [CommonJS support](/runtime/fundamentals/node/#commonjs-support)).
+The main thing to be aware of is CommonJS interop: it's well supported but
+doesn't cover every situation. `require()` is available in `.cjs` files or via
+`createRequire`, and you can mix CommonJS and ES modules — see
+[CommonJS support](/runtime/fundamentals/node/#commonjs-support) for the cases
+that need attention.
 
 For the complete picture of what's supported, see
 [Node and npm compatibility](/runtime/fundamentals/node/).
@@ -54,16 +50,6 @@ You can execute this script with Deno by running:
 ```sh
 deno task start
 ```
-
-## Optional improvements
-
-Deno ships a unified toolchain (configuration, linter, formatter, test runner)
-that can simplify your setup when migrating:
-
-- [Configuration](/runtime/fundamentals/configuration/)
-- [Linter](/runtime/reference/cli/lint/)
-- [Formatter](/runtime/reference/cli/fmt/)
-- [Test runner](/runtime/reference/cli/test/)
 
 ## Node to Deno Cheatsheet
 

--- a/runtime/fundamentals/migrate_from_node.md
+++ b/runtime/fundamentals/migrate_from_node.md
@@ -10,7 +10,7 @@ oldUrl:
 
 Most Node.js projects run in Deno **with no changes at all**. Deno reads your
 `package.json`, installs and resolves the same npm dependencies, and runs both
-CommonJS and ES modules — so in most cases you point Deno at your existing
+CommonJS and ES modules, so in most cases you point Deno at your existing
 project and it just works.
 
 You can also adopt Deno incrementally: use it purely as a faster, drop-in
@@ -21,7 +21,7 @@ pick up its built-in toolchain. This guide walks through each step.
 ## Use Deno as your package manager
 
 Deno is fully compatible with npm and `package.json`, so the easiest place to
-start is dependency management — without changing how you run your code at all.
+start is dependency management, without changing how you run your code at all.
 `deno install` reads your existing `package.json`, resolves the same npm
 packages, and writes a `node_modules` directory, just like `npm install`:
 
@@ -30,8 +30,8 @@ cd my-node-app
 deno install
 ```
 
-You can keep running the app with Node from here — using Deno only as a faster
-package manager — or manage dependencies with Deno's built-in commands:
+You can keep running the app with Node from here, using Deno only as a faster
+package manager, or manage dependencies with Deno's built-in commands:
 
 ```sh
 deno add    npm:express   # add a dependency
@@ -56,7 +56,7 @@ deno run main.js
 ```
 
 If your `package.json` defines scripts, run them with
-[`deno task`](/runtime/reference/cli/task/) — the equivalent of `npm run`:
+[`deno task`](/runtime/reference/cli/task/), the equivalent of `npm run`:
 
 ```json title="package.json"
 {
@@ -72,8 +72,8 @@ deno task start
 ```
 
 Most code runs unchanged. The main thing to understand is how Deno decides
-whether a file is CommonJS or an ES module, which follows your `package.json` —
-covered next.
+whether a file is CommonJS or an ES module, which follows your `package.json`.
+That is covered next.
 
 ## CommonJS and ES modules
 
@@ -81,7 +81,7 @@ Deno runs both ES modules and CommonJS, and decides how to treat a file using
 the same rules as Node.js:
 
 - A `.cjs` file is **always** CommonJS, and a `.mjs` file is **always** an ES
-  module — the extension is enough.
+  module. The extension is enough.
 - A `.js`, `.ts`, `.jsx`, or `.tsx` file is loaded as **CommonJS** when the
   nearest `package.json` sets `"type": "commonjs"`, and as an **ES module**
   otherwise. Deno walks up the directory tree to find that `package.json`, just
@@ -107,10 +107,10 @@ and edge cases.
 
 ## Node to Deno Cheatsheet
 
-In a Node project, many of these are separate packages you install and configure
-— eslint, prettier, jest, ts-node, nodemon, nyc, tsc. In Deno they're the same
-binary, with no extra dependencies and no config files to maintain. You can keep
-your existing `package.json`, or move configuration into `deno.json`.
+In a Node project, many of these are separate packages you install and
+configure: eslint, prettier, jest, ts-node, nodemon, nyc, tsc. In Deno they're
+the same binary, with no extra dependencies and no config files to maintain. You
+can keep your existing `package.json`, or move configuration into `deno.json`.
 
 ### Run and watch
 
@@ -130,7 +130,7 @@ your existing `package.json`, or move configuration into `deno.json`.
 | `npm run <script>`      | `deno task <script>`    |
 | `npm explain <pkg>`     | `deno why <pkg>`        |
 
-### Quality and testing — built in, no install or config
+### Quality and testing (built in, no install or config)
 
 | Node.js                          | Deno            |
 | -------------------------------- | --------------- |
@@ -148,7 +148,7 @@ your existing `package.json`, or move configuration into `deno.json`.
 | `typedoc`      | `deno doc`     |
 | `nexe` / `pkg` | `deno compile` |
 
-¹ TypeScript runs directly — there's no build step. `deno check` type-checks
+¹ TypeScript runs directly: there's no build step. `deno check` type-checks
 without emitting, and the compiler is built into the `deno` binary.
 
 ### Toolchain

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -10,9 +10,6 @@ oldUrl:
   - /runtime/manual/using_deno_with_other_technologies/node/cdns/
   - /runtime/manual/node/node_specifiers
   - /runtime/manual/node/package_json
-  - /runtime/manual/node/migrate/
-  - /runtime/manual/references/cheatsheet/
-  - /runtime/manual/node/cheatsheet/
   - /runtime/manual/node/faqs
   - /runtime/manual/node/npm_specifiers
   - /runtime/manual/node/private_registries
@@ -749,51 +746,11 @@ Like all native FFI, pass `--allow-ffi` to grant explicit permission. Review
 
 ## Migrating from Node to Deno
 
-Running your Node.js project with Deno is a straightforward process. In most
-cases you can expect little to no changes to be required, if your project is
-written using ES modules.
-
-Main points to be aware of:
-
-1. Use the `node:` specifier for built-in modules (see Using Node's built-in
-   modules above).
-2. Some Node globals like `Buffer` must be imported from `node:buffer` (see
-   Node.js global objects).
-3. `require()` is available in `.cjs` files or via `createRequire` (see CommonJS
-   support).
-
-### Running scripts
-
-Deno supports running npm scripts natively with the
-[`deno task`](/runtime/reference/cli/task_runner/) subcommand (If you're
-migrating from Node.js, this is similar to the `npm run script` command).
-Consider the following Node.js project with a script called `start` inside its
-`package.json`:
-
-```json title="package.json"
-{
-  "name": "my-project",
-  "scripts": {
-    "start": "eslint"
-  }
-}
-```
-
-You can execute this script with Deno by running:
-
-```sh
-deno task start
-```
-
-### Optional improvements
-
-Deno ships a unified toolchain (configuration, linter, formatter, test runner)
-that can simplify your setup when migrating:
-
-- Configuration: /runtime/fundamentals/configuration/
-- Linter: /runtime/reference/cli/linter/
-- Formatter: /runtime/reference/cli/formatter/
-- Test runner: /runtime/reference/cli/test/
+Running a Node.js project with Deno usually requires little to no change. See
+the
+[Migrating from Node.js to Deno guide](/runtime/fundamentals/migrate_from_node/)
+for the details, optional toolchain improvements, and a Node-to-Deno command
+cheatsheet.
 
 ## Private registries
 
@@ -921,30 +878,3 @@ Starting in Deno 2.8, those `file:` and `link:` entries are silently skipped
 while resolving npm metadata, so packages that carry a stray local-path
 dependency install cleanly instead of failing with an "Invalid version
 requirement" error.
-
-## Node to Deno Cheatsheet
-
-| Node.js                                | Deno                          |
-| -------------------------------------- | ----------------------------- |
-| `node file.js`                         | `deno file.js`                |
-| `ts-node file.ts`                      | `deno file.ts`                |
-| `nodemon`                              | `deno run --watch`            |
-| `node -e`                              | `deno eval`                   |
-| `npm i` / `npm install`                | `deno install`                |
-| `npm install -g`                       | `deno install -g`             |
-| `npm run`                              | `deno task`                   |
-| `eslint`                               | `deno lint`                   |
-| `prettier`                             | `deno fmt`                    |
-| `package.json`                         | `deno.json` or `package.json` |
-| `tsc`                                  | `deno check` ¹                |
-| `typedoc`                              | `deno doc`                    |
-| `jest` / `ava` / `mocha` / `tap` / etc | `deno test`                   |
-| `nexe` / `pkg`                         | `deno compile`                |
-| `npm explain`                          | `deno info`                   |
-| `nvm` / `n` / `fnm`                    | `deno upgrade`                |
-| `tsserver`                             | `deno lsp`                    |
-| `nyc` / `c8` / `istanbul`              | `deno coverage`               |
-| benchmarks                             | `deno bench`                  |
-
-¹ Type checking happens automatically, TypeScript compiler is built into the
-`deno` binary.

--- a/runtime/fundamentals/web_dev.md
+++ b/runtime/fundamentals/web_dev.md
@@ -199,4 +199,4 @@ deno run --allow-net server.ts
 ## Node projects
 
 Deno will run your Node.js projects out the box. Check out our guide on
-[migrating your Node.js project to Deno](/runtime/fundamentals/node/#migrating-from-node.js-to-deno).
+[migrating your Node.js project to Deno](/runtime/fundamentals/migrate_from_node/).

--- a/style.css
+++ b/style.css
@@ -489,6 +489,7 @@
     .cheatsheet table {
       width: 100%;
       display: table;
+      table-layout: fixed;
     }
     img {
       box-sizing: content-box;

--- a/style.css
+++ b/style.css
@@ -486,6 +486,9 @@
         background-color: transparent;
       }
     }
+    .cheatsheet table {
+      width: 100%;
+    }
     img {
       box-sizing: content-box;
       background-color: var(--bgColor-default, var(--color-canvas-default));

--- a/style.css
+++ b/style.css
@@ -488,6 +488,7 @@
     }
     .cheatsheet table {
       width: 100%;
+      display: table;
     }
     img {
       box-sizing: content-box;


### PR DESCRIPTION
The "Migrating from Node" content lived as a couple of sections buried
inside the Node and npm compatibility page, and it opened with a list of
caveats that undersold Deno's actual drop-in compatibility — leading with
"expect little to no changes" and three things to watch out for.

This moves it into its own Migrating from Node.js to Deno guide and
rewrites the introduction to lead with the real expectation: most Node
projects run in Deno with no changes at all. The `node:` prefix, explicit
`Buffer` import, and CommonJS notes are demoted to the rare exceptions
they are, framed as "if something doesn't run immediately" rather than
required migration steps.

The guide is extracted from node.md (which keeps a short pointer to it),
carries the migration and cheatsheet oldUrl redirects, fixes a few stale
links in the moved content, and updates the inbound link from the web
development page. A sidebar entry is added next to the Node page.

This branches from main and overlaps the runtime IA restructure in #3190
on _data.ts; once #3190 lands I will rebase this and move the sidebar
entry into the new Guides group.