### PR TITLE
docs: move deno fmt options catalog into the deno.json reference

### DIFF
--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -129,81 +129,96 @@ The formatter is configured with the `fmt` field in your
 [all formatting options](/runtime/reference/deno_json/#formatting) for the full
 list of settings and their defaults.
 
-## Deno support for other linters and formatters
+## Using other linters and formatters
+
+Deno's built-in [`deno lint`](#linting) and [`deno fmt`](#formatting) cover most
+projects, but you can also run popular third-party tools without installing them
+globally. Because Deno runs npm packages directly, `deno run -A npm:<tool>` runs
+any of them with no separate `npm install` step. To save typing, add the command
+as a [task](/runtime/reference/deno_json/#tasks) in your `deno.json` and run it
+with `deno task`.
 
 ### ESLint
 
-To use the VSCode ESLint extension in your Deno projects, your project will need
-a `node_modules` directory in your project that VSCode extensions can pick up.
+[ESLint](https://eslint.org/) needs a flat config file, `eslint.config.js`.
+Reference its packages with `npm:` specifiers so Deno can resolve them:
 
-In your [`deno.json`](/runtime/fundamentals/configuration/) ensure a
-`node_modules` folder is created, so the editor can resolve packages:
-
-```jsonc
-{
-  "nodeModulesDir": "auto"
-}
-```
-
-(Optional) Run an ESLint command to download it:
-
-```sh
-deno run -A npm:eslint --version
-# or
-deno run -A npm:eslint --init
-```
-
-Create an `eslint.config.js`:
-
-```js
-// eslint.config.js
-import js from "@eslint/js";
-import importPlugin from "eslint-plugin-import"; // example plugin
+```js title="eslint.config.js"
+import js from "npm:@eslint/js";
+import globals from "npm:globals";
 
 export default [
   js.configs.recommended,
   {
     files: ["**/*.ts", "**/*.js"],
-    languageOptions: { globals: { Deno: "readonly" } },
-    plugins: { import: importPlugin },
-    rules: {
-      // e.g. "import/order": "warn"
+    languageOptions: {
+      globals: { ...globals.node, Deno: "readonly" },
     },
   },
 ];
 ```
 
-To run ESLint run:
+Then run it over your project:
 
 ```sh
 deno run -A npm:eslint .
 ```
 
-Optionally, you can add a task in your `deno.json` to run ESLint:
+Declaring the Node and `Deno` globals prevents false `no-undef` errors for
+globals such as `console`. For type-aware linting of TypeScript, add
+[typescript-eslint](https://typescript-eslint.io/) to the config.
 
-```json
-{
-  "tasks": { "eslint": "eslint . --ext .ts,.js" }
-}
-```
+:::note
 
-And run it with:
+The VS Code ESLint extension needs a real `node_modules` directory to resolve
+ESLint and its plugins. Set `"nodeModulesDir": "auto"` in your `deno.json` and
+run `deno install` so the packages are materialized on disk.
+
+:::
+
+### oxlint
+
+[oxlint](https://oxc.rs) is a fast Rust-based linter that runs with no
+configuration:
 
 ```sh
-deno task eslint
+deno run -A npm:oxlint@latest
+```
+
+It lints the current directory and prints any problems it finds:
+
+```console
+sample.ts:3:5: warning eslint(no-unused-vars): Variable 'unused' is declared but never used.
 ```
 
 ### Prettier
 
-To use Prettier in your Deno projects, your project will need a `node_modules`
-directory in your project that VSCode extensions can pick up.
+[Prettier](https://prettier.io/) formats your code with no configuration
+required:
 
-Then install the Prettier extension for VSCode and configure it to be your
-default formatter:
+```sh
+# report files that need formatting
+deno run -A npm:prettier --check .
 
-In VSCode:
+# format files in place
+deno run -A npm:prettier --write .
+```
 
-1. Open the Command Palette (with <kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>)
-2. Select **Format Document With...**
-3. Select **Configure Default Formatter...**
-4. Select **Prettier - Code formatter**
+### Biome
+
+[Biome](https://biomejs.dev/) is a fast Rust-based linter and formatter in one,
+and also works with zero configuration:
+
+```sh
+# lint and check formatting
+deno run -A npm:@biomejs/biome check .
+
+# format files in place
+deno run -A npm:@biomejs/biome format --write .
+
+# lint only
+deno run -A npm:@biomejs/biome lint .
+```
+
+To customize Biome, generate a `biome.json` with
+`deno run -A npm:@biomejs/biome init`.

--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -22,7 +22,7 @@ building amazing applications.
 
 Linting is the process of analyzing your code for potential errors, bugs, and
 stylistic issues. Deno's built-in linter,
-[`deno lint`](/runtime/reference/cli/linter/), supports recommended set of rules
+[`deno lint`](/runtime/reference/cli/lint/), supports recommended set of rules
 from [ESLint](https://eslint.org/) to provide comprehensive feedback on your
 code. This includes identifying syntax errors, enforcing coding conventions, and
 highlighting potential issues that could lead to bugs.
@@ -122,168 +122,12 @@ in the root of your project with the following configuration:
 If your `deno.json(c)` file is located in a subdirectory of your project,
 provide the correct relative path to it instead.
 
-### Available options
-
-#### `bracePosition`
-
-Define brace position for blocks
-
-- **Default:** `sameLine`
-- **Possible values:** `maintain`, `sameLine`, `nextLine`,
-  `sameLineUnlessHanging`
-
-#### `jsx.bracketPosition`
-
-Define bracket position for JSX
-
-- **Default:** `nextLine`
-- **Possible values:** `maintain`, `sameLine`, `nextLine`
-
-#### `jsx.forceNewLinesSurroundingContent`
-
-Forces newlines surrounding the content of JSX elements
-
-- **Default:** `false`
-- **Possible values:** `true`, `false`
-
-#### `jsx.multiLineParens`
-
-Surrounds the top-most JSX element or fragment in parentheses when it spans
-multiple lines
-
-- **Default:** `prefer`
-- **Possible values:** `never`, `prefer`, `always`
-
-#### `indentWidth`
-
-Define indentation width
-
-- **Default:** `2`
-- **Possible values:** `number`
-
-#### `lineWidth`
-
-Define maximum line width
-
-- **Default:** `80`
-- **Possible values:** `number`
-
-#### `newLineKind`
-
-The newline character to use
-
-- **Default:** `lf`
-- **Possible values:** `auto`, `crlf`, `lf`, `system`
-
-Use `auto` to preserve the file's existing newline style when Deno can detect
-one. Use `system` to use the current operating system's default newline style,
-which is `crlf` on Windows and `lf` on Unix-like systems.
-
-#### `nextControlFlowPosition`
-
-Define position of next control flow
-
-- **Default:** `sameLine`
-- **Possible values:** `sameLine`, `nextLine`, `maintain`
-
-#### `semiColons`
-
-Whether to prefer using semicolons.
-
-- **Default:** `true`
-- **Possible values:** `true`, `false`
-
-#### `operatorPosition`
-
-Where to place the operator for expressions that span multiple lines
-
-- **Default:** `sameLine`
-- **Possible values:** `sameLine`, `nextLine`, `maintain`
-
-#### `proseWrap`
-
-Define how prose should be wrapped
-
-- **Default:** `always`
-- **Possible values:** `always`, `never`, `preserve`
-
-#### `quoteProps`
-
-Control quoting of object properties
-
-- **Default:** `asNeeded`
-- **Possible values:** `asNeeded`, `consistent`, `preserve`
-
-#### `singleBodyPosition`
-
-The position of the body in single body blocks
-
-- **Default:** `sameLineUnlessHanging`
-- **Possible values:** `sameLine`, `nextLine`, `maintain`,
-  `sameLineUnlessHanging`
-
-#### `singleQuote`
-
-Use single quotes
-
-- **Default:** `false`
-- **Possible values:** `true`, `false`
-
-#### `spaceAround`
-
-Control spacing around enclosed expressions
-
-- **Default:** `false`
-- **Possible values:** `true`, `false`
-
-#### `spaceSurroundingProperties`
-
-Control spacing surrounding single line object-like nodes
-
-- **Default:** `true`
-- **Possible values:** `true`, `false`
-
-#### `trailingCommas`
-
-Control trailing commas in multi-line arrays/objects
-
-- **Default:** `always`
-- **Possible values:** `always`, `never`
-
-#### `typeLiteral.separatorKind`
-
-Define separator kind for type literals
-
-- **Default:** `semiColon`
-- **Possible values:** `comma`, `semiColon`
-
-#### `unstable-component`
-
-Enable formatting Svelte, Vue, Astro and Angular files
-
-#### `unstable-sql`
-
-Enable formatting SQL files
-
-#### `useTabs`
-
-Use tabs instead of spaces for indentation
-
-- **Default:** `false`
-- **Possible values:** `true`, `false`
-
-#### `useBraces`
-
-Whether to use braces for if statements, for statements, and while statements
-
-- **Default:** `whenNotSingleLine`
-- **Possible values:** `maintain`, `whenNotSingleLine`, `always`, `preferNone`
-
 ### Configuration
 
-The formatter can be configured in a
-[`deno.json`](/runtime/reference/deno_json/#formatting) file. You can specify
-custom settings to tailor the formatting process to your needs.
+The formatter is configured with the `fmt` field in your
+[`deno.json`](/runtime/reference/deno_json/#formatting) file. See
+[all formatting options](/runtime/reference/deno_json/#available-options) for
+the full list of settings and their defaults.
 
 ## Deno support for other linters and formatters
 

--- a/runtime/fundamentals/linting_and_formatting.md
+++ b/runtime/fundamentals/linting_and_formatting.md
@@ -126,8 +126,8 @@ provide the correct relative path to it instead.
 
 The formatter is configured with the `fmt` field in your
 [`deno.json`](/runtime/reference/deno_json/#formatting) file. See
-[all formatting options](/runtime/reference/deno_json/#available-options) for
-the full list of settings and their defaults.
+[all formatting options](/runtime/reference/deno_json/#formatting) for the full
+list of settings and their defaults.
 
 ## Deno support for other linters and formatters
 

--- a/runtime/reference/deno_json.md
+++ b/runtime/reference/deno_json.md
@@ -245,6 +245,163 @@ This configuration will:
 - exclude files in the `src/testdata/` directory and any TypeScript files in the
   `src/fixtures/` directory.
 
+### Available options
+
+#### `bracePosition`
+
+Define brace position for blocks
+
+- **Default:** `sameLine`
+- **Possible values:** `maintain`, `sameLine`, `nextLine`,
+  `sameLineUnlessHanging`
+
+#### `jsx.bracketPosition`
+
+Define bracket position for JSX
+
+- **Default:** `nextLine`
+- **Possible values:** `maintain`, `sameLine`, `nextLine`
+
+#### `jsx.forceNewLinesSurroundingContent`
+
+Forces newlines surrounding the content of JSX elements
+
+- **Default:** `false`
+- **Possible values:** `true`, `false`
+
+#### `jsx.multiLineParens`
+
+Surrounds the top-most JSX element or fragment in parentheses when it spans
+multiple lines
+
+- **Default:** `prefer`
+- **Possible values:** `never`, `prefer`, `always`
+
+#### `indentWidth`
+
+Define indentation width
+
+- **Default:** `2`
+- **Possible values:** `number`
+
+#### `lineWidth`
+
+Define maximum line width
+
+- **Default:** `80`
+- **Possible values:** `number`
+
+#### `newLineKind`
+
+The newline character to use
+
+- **Default:** `lf`
+- **Possible values:** `auto`, `crlf`, `lf`, `system`
+
+Use `auto` to preserve the file's existing newline style when Deno can detect
+one. Use `system` to use the current operating system's default newline style,
+which is `crlf` on Windows and `lf` on Unix-like systems.
+
+#### `nextControlFlowPosition`
+
+Define position of next control flow
+
+- **Default:** `sameLine`
+- **Possible values:** `sameLine`, `nextLine`, `maintain`
+
+#### `semiColons`
+
+Whether to prefer using semicolons.
+
+- **Default:** `true`
+- **Possible values:** `true`, `false`
+
+#### `operatorPosition`
+
+Where to place the operator for expressions that span multiple lines
+
+- **Default:** `sameLine`
+- **Possible values:** `sameLine`, `nextLine`, `maintain`
+
+#### `proseWrap`
+
+Define how prose should be wrapped
+
+- **Default:** `always`
+- **Possible values:** `always`, `never`, `preserve`
+
+#### `quoteProps`
+
+Control quoting of object properties
+
+- **Default:** `asNeeded`
+- **Possible values:** `asNeeded`, `consistent`, `preserve`
+
+#### `singleBodyPosition`
+
+The position of the body in single body blocks
+
+- **Default:** `sameLineUnlessHanging`
+- **Possible values:** `sameLine`, `nextLine`, `maintain`,
+  `sameLineUnlessHanging`
+
+#### `singleQuote`
+
+Use single quotes
+
+- **Default:** `false`
+- **Possible values:** `true`, `false`
+
+#### `spaceAround`
+
+Control spacing around enclosed expressions
+
+- **Default:** `false`
+- **Possible values:** `true`, `false`
+
+#### `spaceSurroundingProperties`
+
+Control spacing surrounding single line object-like nodes
+
+- **Default:** `true`
+- **Possible values:** `true`, `false`
+
+#### `trailingCommas`
+
+Control trailing commas in multi-line arrays/objects
+
+- **Default:** `always`
+- **Possible values:** `always`, `never`
+
+#### `typeLiteral.separatorKind`
+
+Define separator kind for type literals
+
+- **Default:** `semiColon`
+- **Possible values:** `comma`, `semiColon`
+
+#### `unstable-component`
+
+Enable formatting Svelte, Vue, Astro and Angular files
+
+#### `unstable-sql`
+
+Enable formatting SQL files
+
+#### `useTabs`
+
+Use tabs instead of spaces for indentation
+
+- **Default:** `false`
+- **Possible values:** `true`, `false`
+
+#### `useBraces`
+
+Whether to use braces for if statements, for statements, and while statements
+
+- **Default:** `whenNotSingleLine`
+- **Possible values:** `maintain`, `whenNotSingleLine`, `always`, `preferNone`
+
 Read more about
 [formatting your code with Deno](/runtime/fundamentals/linting_and_formatting/).
 

--- a/runtime/reference/deno_json.md
+++ b/runtime/reference/deno_json.md
@@ -245,162 +245,32 @@ This configuration will:
 - exclude files in the `src/testdata/` directory and any TypeScript files in the
   `src/fixtures/` directory.
 
-### Available options
-
-#### `bracePosition`
-
-Define brace position for blocks
-
-- **Default:** `sameLine`
-- **Possible values:** `maintain`, `sameLine`, `nextLine`,
-  `sameLineUnlessHanging`
-
-#### `jsx.bracketPosition`
-
-Define bracket position for JSX
-
-- **Default:** `nextLine`
-- **Possible values:** `maintain`, `sameLine`, `nextLine`
-
-#### `jsx.forceNewLinesSurroundingContent`
-
-Forces newlines surrounding the content of JSX elements
-
-- **Default:** `false`
-- **Possible values:** `true`, `false`
-
-#### `jsx.multiLineParens`
-
-Surrounds the top-most JSX element or fragment in parentheses when it spans
-multiple lines
-
-- **Default:** `prefer`
-- **Possible values:** `never`, `prefer`, `always`
-
-#### `indentWidth`
-
-Define indentation width
-
-- **Default:** `2`
-- **Possible values:** `number`
-
-#### `lineWidth`
-
-Define maximum line width
-
-- **Default:** `80`
-- **Possible values:** `number`
-
-#### `newLineKind`
-
-The newline character to use
-
-- **Default:** `lf`
-- **Possible values:** `auto`, `crlf`, `lf`, `system`
-
-Use `auto` to preserve the file's existing newline style when Deno can detect
-one. Use `system` to use the current operating system's default newline style,
-which is `crlf` on Windows and `lf` on Unix-like systems.
-
-#### `nextControlFlowPosition`
-
-Define position of next control flow
-
-- **Default:** `sameLine`
-- **Possible values:** `sameLine`, `nextLine`, `maintain`
-
-#### `semiColons`
-
-Whether to prefer using semicolons.
-
-- **Default:** `true`
-- **Possible values:** `true`, `false`
-
-#### `operatorPosition`
-
-Where to place the operator for expressions that span multiple lines
-
-- **Default:** `sameLine`
-- **Possible values:** `sameLine`, `nextLine`, `maintain`
-
-#### `proseWrap`
-
-Define how prose should be wrapped
-
-- **Default:** `always`
-- **Possible values:** `always`, `never`, `preserve`
-
-#### `quoteProps`
-
-Control quoting of object properties
-
-- **Default:** `asNeeded`
-- **Possible values:** `asNeeded`, `consistent`, `preserve`
-
-#### `singleBodyPosition`
-
-The position of the body in single body blocks
-
-- **Default:** `sameLineUnlessHanging`
-- **Possible values:** `sameLine`, `nextLine`, `maintain`,
-  `sameLineUnlessHanging`
-
-#### `singleQuote`
-
-Use single quotes
-
-- **Default:** `false`
-- **Possible values:** `true`, `false`
-
-#### `spaceAround`
-
-Control spacing around enclosed expressions
-
-- **Default:** `false`
-- **Possible values:** `true`, `false`
-
-#### `spaceSurroundingProperties`
-
-Control spacing surrounding single line object-like nodes
-
-- **Default:** `true`
-- **Possible values:** `true`, `false`
-
-#### `trailingCommas`
-
-Control trailing commas in multi-line arrays/objects
-
-- **Default:** `always`
-- **Possible values:** `always`, `never`
-
-#### `typeLiteral.separatorKind`
-
-Define separator kind for type literals
-
-- **Default:** `semiColon`
-- **Possible values:** `comma`, `semiColon`
-
-#### `unstable-component`
-
-Enable formatting Svelte, Vue, Astro and Angular files
-
-#### `unstable-sql`
-
-Enable formatting SQL files
-
-#### `useTabs`
-
-Use tabs instead of spaces for indentation
-
-- **Default:** `false`
-- **Possible values:** `true`, `false`
-
-#### `useBraces`
-
-Whether to use braces for if statements, for statements, and while statements
-
-- **Default:** `whenNotSingleLine`
-- **Possible values:** `maintain`, `whenNotSingleLine`, `always`, `preferNone`
+All `fmt` options for the `fmt` field:
+
+| Option                                | Description                                                                                                                       | Default                 | Possible values                                             |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------- |
+| `bracePosition`                       | Brace position for blocks                                                                                                         | `sameLine`              | `maintain`, `sameLine`, `nextLine`, `sameLineUnlessHanging` |
+| `indentWidth`                         | Indentation width                                                                                                                 | `2`                     | a number                                                    |
+| `lineWidth`                           | Maximum line width                                                                                                                | `80`                    | a number                                                    |
+| `newLineKind`                         | Newline character to use (`auto` keeps the file's existing style; `system` uses the OS default, CRLF on Windows and LF elsewhere) | `lf`                    | `auto`, `crlf`, `lf`, `system`                              |
+| `nextControlFlowPosition`             | Position of the next control flow keyword                                                                                         | `sameLine`              | `sameLine`, `nextLine`, `maintain`                          |
+| `operatorPosition`                    | Where to place the operator for expressions that span multiple lines                                                              | `sameLine`              | `sameLine`, `nextLine`, `maintain`                          |
+| `proseWrap`                           | How prose (e.g. Markdown) is wrapped                                                                                              | `always`                | `always`, `never`, `preserve`                               |
+| `quoteProps`                          | Quoting of object properties                                                                                                      | `asNeeded`              | `asNeeded`, `consistent`, `preserve`                        |
+| `semiColons`                          | Prefer semicolons                                                                                                                 | `true`                  | `true`, `false`                                             |
+| `singleBodyPosition`                  | Position of the body in single-body blocks                                                                                        | `sameLineUnlessHanging` | `sameLine`, `nextLine`, `maintain`, `sameLineUnlessHanging` |
+| `singleQuote`                         | Use single quotes                                                                                                                 | `false`                 | `true`, `false`                                             |
+| `spaceAround`                         | Spacing around enclosed expressions                                                                                               | `false`                 | `true`, `false`                                             |
+| `spaceSurroundingProperties`          | Spacing surrounding single-line object-like nodes                                                                                 | `true`                  | `true`, `false`                                             |
+| `trailingCommas`                      | Trailing commas in multi-line arrays and objects                                                                                  | `always`                | `always`, `never`                                           |
+| `typeLiteral.separatorKind`           | Separator kind for type literals                                                                                                  | `semiColon`             | `comma`, `semiColon`                                        |
+| `useBraces`                           | Use braces for `if` / `for` / `while` statements                                                                                  | `whenNotSingleLine`     | `maintain`, `whenNotSingleLine`, `always`, `preferNone`     |
+| `useTabs`                             | Use tabs instead of spaces for indentation                                                                                        | `false`                 | `true`, `false`                                             |
+| `jsx.bracketPosition`                 | Bracket position for JSX                                                                                                          | `nextLine`              | `maintain`, `sameLine`, `nextLine`                          |
+| `jsx.forceNewLinesSurroundingContent` | Force newlines surrounding the content of JSX elements                                                                            | `false`                 | `true`, `false`                                             |
+| `jsx.multiLineParens`                 | Wrap the top-most JSX element or fragment in parentheses when it spans multiple lines                                             | `prefer`                | `never`, `prefer`, `always`                                 |
+| `unstable-component`                  | Enable formatting Svelte, Vue, Astro, and Angular files                                                                           | `false`                 | `true`, `false`                                             |
+| `unstable-sql`                        | Enable formatting SQL files                                                                                                       | `false`                 | `true`, `false`                                             |
 
 Read more about
 [formatting your code with Deno](/runtime/fundamentals/linting_and_formatting/).

--- a/runtime/reference/deno_json.md
+++ b/runtime/reference/deno_json.md
@@ -245,49 +245,37 @@ This configuration will:
 - exclude files in the `src/testdata/` directory and any TypeScript files in the
   `src/fixtures/` directory.
 
-The `fmt` field supports these options:
+The `fmt` field accepts the following options, each shown with its default and
+allowed values:
 
-- **`bracePosition`** — brace position for blocks. Default `sameLine`; one of
-  `maintain`, `sameLine`, `nextLine`, `sameLineUnlessHanging`.
-- **`indentWidth`** — indentation width (a number). Default `2`.
-- **`lineWidth`** — maximum line width (a number). Default `80`.
-- **`newLineKind`** — newline character to use: `auto` (keep the file's existing
-  style), `crlf`, `lf`, or `system` (OS default, CRLF on Windows and LF
-  elsewhere). Default `lf`.
-- **`nextControlFlowPosition`** — position of the next control-flow keyword.
-  Default `sameLine`; one of `sameLine`, `nextLine`, `maintain`.
-- **`operatorPosition`** — where to place the operator for expressions that span
-  multiple lines. Default `sameLine`; one of `sameLine`, `nextLine`, `maintain`.
-- **`proseWrap`** — how prose (for example Markdown) is wrapped. Default
-  `always`; one of `always`, `never`, `preserve`.
-- **`quoteProps`** — quoting of object properties. Default `asNeeded`; one of
-  `asNeeded`, `consistent`, `preserve`.
-- **`semiColons`** — prefer semicolons. Default `true`.
-- **`singleBodyPosition`** — position of the body in single-body blocks. Default
-  `sameLineUnlessHanging`; one of `sameLine`, `nextLine`, `maintain`,
-  `sameLineUnlessHanging`.
-- **`singleQuote`** — use single quotes. Default `false`.
-- **`spaceAround`** — spacing around enclosed expressions. Default `false`.
-- **`spaceSurroundingProperties`** — spacing surrounding single-line object-like
-  nodes. Default `true`.
-- **`trailingCommas`** — trailing commas in multi-line arrays and objects.
-  Default `always`; one of `always`, `never`.
-- **`typeLiteral.separatorKind`** — separator for type literals. Default
-  `semiColon`; one of `comma`, `semiColon`.
-- **`useBraces`** — use braces for `if` / `for` / `while` statements. Default
-  `whenNotSingleLine`; one of `maintain`, `whenNotSingleLine`, `always`,
-  `preferNone`.
-- **`useTabs`** — use tabs instead of spaces for indentation. Default `false`.
-- **`jsx.bracketPosition`** — bracket position for JSX. Default `nextLine`; one
-  of `maintain`, `sameLine`, `nextLine`.
-- **`jsx.forceNewLinesSurroundingContent`** — force newlines surrounding the
-  content of JSX elements. Default `false`.
-- **`jsx.multiLineParens`** — wrap the top-most JSX element or fragment in
-  parentheses when it spans multiple lines. Default `prefer`; one of `never`,
-  `prefer`, `always`.
-- **`unstable-component`** — enable formatting Svelte, Vue, Astro, and Angular
-  files. Default `false`.
-- **`unstable-sql`** — enable formatting SQL files. Default `false`.
+<div class="fmt-options">
+
+| Option                                | Default                 | Possible values                                             |
+| ------------------------------------- | ----------------------- | ----------------------------------------------------------- |
+| `bracePosition`                       | `sameLine`              | `maintain`, `sameLine`, `nextLine`, `sameLineUnlessHanging` |
+| `indentWidth`                         | `2`                     | a number                                                    |
+| `lineWidth`                           | `80`                    | a number                                                    |
+| `newLineKind`                         | `lf`                    | `auto`, `crlf`, `lf`, `system`                              |
+| `nextControlFlowPosition`             | `sameLine`              | `sameLine`, `nextLine`, `maintain`                          |
+| `operatorPosition`                    | `sameLine`              | `sameLine`, `nextLine`, `maintain`                          |
+| `proseWrap`                           | `always`                | `always`, `never`, `preserve`                               |
+| `quoteProps`                          | `asNeeded`              | `asNeeded`, `consistent`, `preserve`                        |
+| `semiColons`                          | `true`                  | `true`, `false`                                             |
+| `singleBodyPosition`                  | `sameLineUnlessHanging` | `sameLine`, `nextLine`, `maintain`, `sameLineUnlessHanging` |
+| `singleQuote`                         | `false`                 | `true`, `false`                                             |
+| `spaceAround`                         | `false`                 | `true`, `false`                                             |
+| `spaceSurroundingProperties`          | `true`                  | `true`, `false`                                             |
+| `trailingCommas`                      | `always`                | `always`, `never`                                           |
+| `typeLiteral.separatorKind`           | `semiColon`             | `comma`, `semiColon`                                        |
+| `useBraces`                           | `whenNotSingleLine`     | `maintain`, `whenNotSingleLine`, `always`, `preferNone`     |
+| `useTabs`                             | `false`                 | `true`, `false`                                             |
+| `jsx.bracketPosition`                 | `nextLine`              | `maintain`, `sameLine`, `nextLine`                          |
+| `jsx.forceNewLinesSurroundingContent` | `false`                 | `true`, `false`                                             |
+| `jsx.multiLineParens`                 | `prefer`                | `never`, `prefer`, `always`                                 |
+| `unstable-component`                  | `false`                 | `true`, `false`                                             |
+| `unstable-sql`                        | `false`                 | `true`, `false`                                             |
+
+</div>
 
 Read more about
 [formatting your code with Deno](/runtime/fundamentals/linting_and_formatting/).

--- a/runtime/reference/deno_json.md
+++ b/runtime/reference/deno_json.md
@@ -245,32 +245,49 @@ This configuration will:
 - exclude files in the `src/testdata/` directory and any TypeScript files in the
   `src/fixtures/` directory.
 
-All `fmt` options for the `fmt` field:
+The `fmt` field supports these options:
 
-| Option                                | Description                                                                                                                       | Default                 | Possible values                                             |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ----------------------------------------------------------- |
-| `bracePosition`                       | Brace position for blocks                                                                                                         | `sameLine`              | `maintain`, `sameLine`, `nextLine`, `sameLineUnlessHanging` |
-| `indentWidth`                         | Indentation width                                                                                                                 | `2`                     | a number                                                    |
-| `lineWidth`                           | Maximum line width                                                                                                                | `80`                    | a number                                                    |
-| `newLineKind`                         | Newline character to use (`auto` keeps the file's existing style; `system` uses the OS default, CRLF on Windows and LF elsewhere) | `lf`                    | `auto`, `crlf`, `lf`, `system`                              |
-| `nextControlFlowPosition`             | Position of the next control flow keyword                                                                                         | `sameLine`              | `sameLine`, `nextLine`, `maintain`                          |
-| `operatorPosition`                    | Where to place the operator for expressions that span multiple lines                                                              | `sameLine`              | `sameLine`, `nextLine`, `maintain`                          |
-| `proseWrap`                           | How prose (e.g. Markdown) is wrapped                                                                                              | `always`                | `always`, `never`, `preserve`                               |
-| `quoteProps`                          | Quoting of object properties                                                                                                      | `asNeeded`              | `asNeeded`, `consistent`, `preserve`                        |
-| `semiColons`                          | Prefer semicolons                                                                                                                 | `true`                  | `true`, `false`                                             |
-| `singleBodyPosition`                  | Position of the body in single-body blocks                                                                                        | `sameLineUnlessHanging` | `sameLine`, `nextLine`, `maintain`, `sameLineUnlessHanging` |
-| `singleQuote`                         | Use single quotes                                                                                                                 | `false`                 | `true`, `false`                                             |
-| `spaceAround`                         | Spacing around enclosed expressions                                                                                               | `false`                 | `true`, `false`                                             |
-| `spaceSurroundingProperties`          | Spacing surrounding single-line object-like nodes                                                                                 | `true`                  | `true`, `false`                                             |
-| `trailingCommas`                      | Trailing commas in multi-line arrays and objects                                                                                  | `always`                | `always`, `never`                                           |
-| `typeLiteral.separatorKind`           | Separator kind for type literals                                                                                                  | `semiColon`             | `comma`, `semiColon`                                        |
-| `useBraces`                           | Use braces for `if` / `for` / `while` statements                                                                                  | `whenNotSingleLine`     | `maintain`, `whenNotSingleLine`, `always`, `preferNone`     |
-| `useTabs`                             | Use tabs instead of spaces for indentation                                                                                        | `false`                 | `true`, `false`                                             |
-| `jsx.bracketPosition`                 | Bracket position for JSX                                                                                                          | `nextLine`              | `maintain`, `sameLine`, `nextLine`                          |
-| `jsx.forceNewLinesSurroundingContent` | Force newlines surrounding the content of JSX elements                                                                            | `false`                 | `true`, `false`                                             |
-| `jsx.multiLineParens`                 | Wrap the top-most JSX element or fragment in parentheses when it spans multiple lines                                             | `prefer`                | `never`, `prefer`, `always`                                 |
-| `unstable-component`                  | Enable formatting Svelte, Vue, Astro, and Angular files                                                                           | `false`                 | `true`, `false`                                             |
-| `unstable-sql`                        | Enable formatting SQL files                                                                                                       | `false`                 | `true`, `false`                                             |
+- **`bracePosition`** — brace position for blocks. Default `sameLine`; one of
+  `maintain`, `sameLine`, `nextLine`, `sameLineUnlessHanging`.
+- **`indentWidth`** — indentation width (a number). Default `2`.
+- **`lineWidth`** — maximum line width (a number). Default `80`.
+- **`newLineKind`** — newline character to use: `auto` (keep the file's existing
+  style), `crlf`, `lf`, or `system` (OS default, CRLF on Windows and LF
+  elsewhere). Default `lf`.
+- **`nextControlFlowPosition`** — position of the next control-flow keyword.
+  Default `sameLine`; one of `sameLine`, `nextLine`, `maintain`.
+- **`operatorPosition`** — where to place the operator for expressions that span
+  multiple lines. Default `sameLine`; one of `sameLine`, `nextLine`, `maintain`.
+- **`proseWrap`** — how prose (for example Markdown) is wrapped. Default
+  `always`; one of `always`, `never`, `preserve`.
+- **`quoteProps`** — quoting of object properties. Default `asNeeded`; one of
+  `asNeeded`, `consistent`, `preserve`.
+- **`semiColons`** — prefer semicolons. Default `true`.
+- **`singleBodyPosition`** — position of the body in single-body blocks. Default
+  `sameLineUnlessHanging`; one of `sameLine`, `nextLine`, `maintain`,
+  `sameLineUnlessHanging`.
+- **`singleQuote`** — use single quotes. Default `false`.
+- **`spaceAround`** — spacing around enclosed expressions. Default `false`.
+- **`spaceSurroundingProperties`** — spacing surrounding single-line object-like
+  nodes. Default `true`.
+- **`trailingCommas`** — trailing commas in multi-line arrays and objects.
+  Default `always`; one of `always`, `never`.
+- **`typeLiteral.separatorKind`** — separator for type literals. Default
+  `semiColon`; one of `comma`, `semiColon`.
+- **`useBraces`** — use braces for `if` / `for` / `while` statements. Default
+  `whenNotSingleLine`; one of `maintain`, `whenNotSingleLine`, `always`,
+  `preferNone`.
+- **`useTabs`** — use tabs instead of spaces for indentation. Default `false`.
+- **`jsx.bracketPosition`** — bracket position for JSX. Default `nextLine`; one
+  of `maintain`, `sameLine`, `nextLine`.
+- **`jsx.forceNewLinesSurroundingContent`** — force newlines surrounding the
+  content of JSX elements. Default `false`.
+- **`jsx.multiLineParens`** — wrap the top-most JSX element or fragment in
+  parentheses when it spans multiple lines. Default `prefer`; one of `never`,
+  `prefer`, `always`.
+- **`unstable-component`** — enable formatting Svelte, Vue, Astro, and Angular
+  files. Default `false`.
+- **`unstable-sql`** — enable formatting SQL files. Default `false`.
 
 Read more about
 [formatting your code with Deno](/runtime/fundamentals/linting_and_formatting/).

--- a/style.css
+++ b/style.css
@@ -491,6 +491,18 @@
       display: table;
       table-layout: fixed;
     }
+    .fmt-options table {
+      width: 100%;
+      display: table;
+      table-layout: fixed;
+    }
+    .fmt-options td {
+      overflow-wrap: anywhere;
+    }
+    .fmt-options th:nth-child(2),
+    .fmt-options td:nth-child(2) {
+      width: 6rem;
+    }
     img {
       box-sizing: content-box;
       background-color: var(--bgColor-default, var(--color-canvas-default));


### PR DESCRIPTION
The linting and formatting guide carried a ~150-line catalog of every
deno fmt option, each with its default and possible values. That is
reference material, and it duplicated the fmt field that the deno.json
reference already documents, so the guide read as a how-to that suddenly
turned into a settings table.

This moves the options catalog into the Formatting section of the
deno.json reference, where the fmt field lives, so there is one place to
look up a formatting option. The guide keeps the how-to (running the
formatter, checking, CI, VS Code, the ESLint and Prettier notes) and its
Configuration subsection now links to the full options list in the
reference. A stale cli/linter link in the guide is corrected to cli/lint
along the way.