### PR TITLE
fix: make lume/jsx-runtime import in types.ts type-only

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,8 @@
-import "lume/jsx-runtime";
+// Type-only import of Lume's JSX runtime (ssx), which declares the global
+// `JSX` namespace used by `TitleContent` below. It must stay type-only: this
+// file is also imported in contexts that build without the root import map
+// (e.g. the deployed middleware), where a value import fails to resolve.
+import type {} from "lume/jsx-runtime";
 
 export type Sidebar = SidebarSection[];
 export type Path = string;
@@ -47,9 +51,8 @@ export interface SidebarSectionProps {
 }
 
 // `JSX.Children` is the renderable-content type from Lume's JSX runtime (ssx),
-// which — unlike React — does not expose a `JSX.Element` type. The import pulls
-// in ssx's global `JSX` namespace so this resolves under `deno check`/`deno test`
-// (the site itself builds with --no-check).
+// which — unlike React — does not expose a `JSX.Element` type. The global `JSX`
+// namespace comes from the type-only import at the top of this file.
 export type TitleContent = string | JSX.Children;
 
 export interface SidebarItem {


### PR DESCRIPTION
The side-effect import of lume/jsx-runtime added to types.ts in #3198 put
the specifier in the file's runtime module graph. Builds that load types.ts
without the root import map (the deployed middleware imports it via
middleware/functions/feedback.ts) then fail with:

    error: Import "lume/jsx-runtime" not a dependency and not in import map
      at file:///tmp/build/src/types.ts:1:8

The import only exists to surface ssx's global JSX namespace for the
JSX.Children type, so making it type-only keeps deno check and deno test
working while erasing it from the runtime graph, the same way the existing
import("lume/core/searcher.ts") type position already behaves.