### PR TITLE
docs: redesign examples landing page with described cards

### DIFF
--- a/_components/LandingPage.tsx
+++ b/_components/LandingPage.tsx
@@ -1,16 +1,43 @@
 import { ExampleIcon } from "../examples/_components/ExampleIcon.tsx";
-import { LearningList } from "../examples/_components/LearningList.tsx";
+import {
+  LearningList,
+  TypeIcon,
+} from "../examples/_components/LearningList.tsx";
 import { TutorialIcon } from "../examples/_components/TutorialIcon.tsx";
 import { VideoIcon } from "../examples/_components/VideoIcon.tsx";
-import { sidebar } from "../examples/_data.ts";
+import { featuredItems, sidebar } from "../examples/_data.ts";
 
-export default function LandingPage() {
+function FeaturedStar() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="0.95rem"
+      height="0.95rem"
+      className="inline-block align-baseline fill-primary shrink-0"
+      aria-hidden="true"
+    >
+      <path d="M12 2l2.92 6.26 6.58.84-4.84 4.57 1.26 6.53L12 17l-5.92 3.2 1.26-6.53L2.5 9.1l6.58-.84z" />
+    </svg>
+  );
+}
+
+export default function LandingPage(
+  { descriptions }: { descriptions?: Record<string, string> },
+) {
+  const counts = { example: 0, tutorial: 0, video: 0 };
+  for (const category of sidebar) {
+    for (const item of category.items) {
+      counts[item.type as keyof typeof counts]++;
+    }
+  }
+  const total = counts.example + counts.tutorial + counts.video;
   const componentsPerSidebarItem = sidebar.map(
     (item: { title: string; items: any[] }) => {
       return (
         <LearningList
           title={item.title}
           items={item.items}
+          descriptions={descriptions}
         />
       );
     },
@@ -36,13 +63,75 @@ export default function LandingPage() {
             src="/examples.png"
           />
         </div>
-        <div className="flex flex-col gap-4 w-full mb-8 p-4 border border-blue-100 dark:border-background-tertiary bg-blue-50 dark:bg-background-secondary rounded md:flex-wrap md:justify-start md:items-center md:flex-row">
+        <details
+          id="guide-request-box"
+          className="mb-8 p-4 border border-blue-100 dark:border-background-tertiary bg-blue-50 dark:bg-background-secondary rounded"
+        >
+          <summary className="cursor-pointer">
+            <span className="font-semibold">
+              Can't find what you're looking for?
+            </span>{" "}
+            <span className="text-primary underline underline-offset-4">
+              Request a new guide
+            </span>
+          </summary>
+          <form id="guide-request-form" className="mt-4 max-w-prose space-y-3">
+            <textarea
+              className="block w-full p-2 border border-foreground-tertiary bg-white dark:bg-background-primary rounded"
+              name="guide-request-comment"
+              required
+              minLength={3}
+              placeholder="What would you like a guide or example for?"
+            >
+            </textarea>
+            <input
+              type="text"
+              className="block w-full p-2 border border-foreground-tertiary bg-white dark:bg-background-primary rounded"
+              name="guide-request-contact"
+              placeholder="GitHub username (optional, you'll be @mentioned)"
+            />
+            <p className="text-xs text-gray-600 dark:text-gray-400 italic">
+              Your request will be posted as an issue in the denoland/docs
+              GitHub repo.
+            </p>
+            <button type="submit" className="btn">Request guide</button>
+          </form>
+        </details>
+
+        <section className="mb-10">
+          <h2 className="text-lg md:text-xl font-semibold mb-4">Featured</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {featuredItems.map((item) => (
+              <a
+                key={item.href}
+                href={item.href}
+                className="group relative flex flex-col gap-1 p-4 pr-12 rounded-lg border border-foreground-tertiary bg-background-secondary !no-underline hover:border-primary transition-colors duration-150"
+              >
+                <span
+                  className="absolute top-4 right-4"
+                  title={item.type}
+                  aria-label={item.type}
+                >
+                  <TypeIcon type={item.type} />
+                </span>
+                <span className="font-semibold !text-foreground-primary group-hover:underline underline-offset-4 decoration-primary">
+                  <FeaturedStar /> {item.title}
+                </span>
+                <span className="text-sm text-foreground-secondary">
+                  {item.description}
+                </span>
+              </a>
+            ))}
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-4 w-full mb-8 p-4 border border-blue-100 dark:border-background-tertiary bg-blue-50 dark:bg-background-secondary rounded md:flex-wrap md:justify-start md:items-center md:flex-row">
           <h2 className="font-semibold">
             Filter by type:
           </h2>
           <label for="example" className="flex gap-2 items-center mr-4">
-            <ExampleIcon />
-            <span>Examples:</span>
+            <ExampleIcon size="1.5rem" />
+            <span>Examples ({counts.example})</span>
             <span className="switch">
               <input
                 type="checkbox"
@@ -56,8 +145,8 @@ export default function LandingPage() {
           </label>
 
           <label for="tutorial" className="flex gap-2 items-center mr-4">
-            <TutorialIcon />
-            <span>Tutorials:</span>
+            <TutorialIcon size="1.5rem" />
+            <span>Tutorials ({counts.tutorial})</span>
             <span className="switch">
               <input
                 type="checkbox"
@@ -71,8 +160,8 @@ export default function LandingPage() {
           </label>
 
           <label for="video" className="flex gap-2 items-center mr-4">
-            <VideoIcon />
-            <span>Videos:</span>
+            <VideoIcon size="1.5rem" />
+            <span>Videos ({counts.video})</span>
             <span className="switch">
               <input
                 type="checkbox"
@@ -84,11 +173,15 @@ export default function LandingPage() {
               <span className="slider"></span>
             </span>
           </label>
-        </div>
 
-        <div className="unfiltered columns-1 sm:columns-2 lg:columns-3 gap-8 mb-8 w-[100%] markdown-body">
+          <span className="md:ml-auto text-sm text-foreground-secondary">
+            {total} items total
+          </span>
+        </section>
+
+        <section className="unfiltered mb-8 w-full markdown-body">
           {componentsPerSidebarItem}
-        </div>
+        </section>
         <div className="fully-filtered">
           <h2 class="text-2xl font-semibold sm:text-3xl md:text-4xl">
             Oops! You've filtered everything
@@ -102,29 +195,6 @@ export default function LandingPage() {
           />
         </div>
       </main>
-      <aside class="px-8 xl:px-0 max-w-7xl mb-24 space-y-4 border-t pt-8">
-        <h2 class="text-2xl md:text-3xl font-bold">
-          We welcome contributions!
-        </h2>
-        <p class="text-balance pt-4 mt-3">
-          Looking for an example that isn't here? Or want to add one of your
-          own? Check out our{" "}
-          <a
-            href="https://github.com/denoland/deno-docs?tab=readme-ov-file#examples"
-            class="text-primary underline"
-          >
-            GitHub repository
-          </a>.
-        </p>
-        <p>
-          <a
-            href="/runtime/contributing/"
-            class="text-primary underline mt-4 font-bold"
-          >
-            Commit an example and we'll send you stickers!
-          </a>
-        </p>
-      </aside>
     </>
   );
 }

--- a/examples/_components/ExampleIcon.tsx
+++ b/examples/_components/ExampleIcon.tsx
@@ -1,9 +1,9 @@
-export function ExampleIcon() {
+export function ExampleIcon({ size = "1rem" }: { size?: string } = {}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 328 258"
-      width="1rem"
+      width={size}
     >
       <path
         d="m86 58-71 70 71 72M186 15l-46 228M242 59l71 71-71 72"

--- a/examples/_components/LearningList.tsx
+++ b/examples/_components/LearningList.tsx
@@ -3,40 +3,62 @@ import { ExampleIcon } from "./ExampleIcon.tsx";
 import { TutorialIcon } from "./TutorialIcon.tsx";
 import { VideoIcon } from "./VideoIcon.tsx";
 
+export function TypeIcon({ type }: { type: string }) {
+  switch (type) {
+    case "tutorial":
+      return <TutorialIcon size="1.25rem" />;
+    case "video":
+      return <VideoIcon size="1.25rem" />;
+    default:
+      return <ExampleIcon size="1.25rem" />;
+  }
+}
+
 export function LearningList(
   props: {
     title: string;
     items: SidebarItem[];
+    descriptions?: Record<string, string>;
   },
 ) {
   const anchor = props.title.toLowerCase().replace(/\s+/g, "-");
   return (
-    <section className="break-inside-avoid-column">
-      <h2 id={anchor} className="text-lg md:text-xl font-semibold mb-3 mt-0">
+    <section className="mb-10">
+      <h2 id={anchor} className="text-lg md:text-xl font-semibold mb-4 mt-0">
         {props.title}&nbsp;
         <a class="header-anchor" href={`#${anchor}`}>
           <span class="sr-only">Jump to heading</span>
           <span aria-hidden="true" class="anchor-end">#</span>
         </a>
       </h2>
-      <ul className="mb-12 pl-2">
-        {props.items.map((item) => (
-          <li
-            className="learning-list-item"
-            data-category={item.type}
-          >
-            <a
-              className="flex dark:text-foreground-primary gap-3 items-center font-normal no-underline underline-offset-4 text-inherit decoration-0 hover:underline hover:decoration-primary hover:decoration-1 hover:text-primary hover:[&_path]:stroke-primary hover:[&_circle]:stroke-primary hover:[&_rect]:stroke-primary"
-              href={item.href}
-            >
-              {item.type === "tutorial" && <TutorialIcon />}
-              {item.type === "example" && <ExampleIcon />}
-              {item.type === "video" && <VideoIcon />}
-
-              {item.title}
-            </a>
-          </li>
-        ))}
+      <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 !pl-0 !list-none">
+        {props.items.map((item) => {
+          const description = props.descriptions?.[item.href];
+          return (
+            <li className="!mt-0" data-category={item.type}>
+              <a
+                className="group relative flex h-full flex-col gap-1 p-4 pr-12 rounded-lg border border-foreground-tertiary bg-background-secondary !no-underline font-normal hover:border-primary transition-colors duration-150"
+                href={item.href}
+              >
+                <span
+                  className="absolute top-4 right-4"
+                  title={item.type}
+                  aria-label={item.type}
+                >
+                  <TypeIcon type={item.type} />
+                </span>
+                <span className="font-semibold !text-foreground-primary group-hover:underline underline-offset-4 decoration-primary">
+                  {item.title}
+                </span>
+                {description && (
+                  <span className="text-sm text-foreground-secondary line-clamp-2">
+                    {description}
+                  </span>
+                )}
+              </a>
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/examples/_components/TutorialIcon.tsx
+++ b/examples/_components/TutorialIcon.tsx
@@ -1,9 +1,9 @@
-export function TutorialIcon() {
+export function TutorialIcon({ size = "1rem" }: { size?: string } = {}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 502 384"
-      width="1rem"
+      width={size}
     >
       <path
         d="M59 45H15v304h200s10 20 36 20 36-20 36-20h200V45h-40"

--- a/examples/_components/VideoIcon.tsx
+++ b/examples/_components/VideoIcon.tsx
@@ -1,9 +1,9 @@
-export function VideoIcon() {
+export function VideoIcon({ size = "1rem" }: { size?: string } = {}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 416 368"
-      width="1rem"
+      width={size}
     >
       <rect
         x="25"

--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -1106,5 +1106,44 @@ export const sidebar = [
   },
 ];
 
+export const featuredItems = [
+  {
+    title: "HTTP Server: Hello world",
+    href: "/examples/http_server/",
+    type: "example",
+    description: "Spin up a web server with Deno.serve in a few lines.",
+  },
+  {
+    title: "Writing tests",
+    href: "/examples/writing_tests/",
+    type: "example",
+    description: "Use the built-in test runner, no dependencies needed.",
+  },
+  {
+    title: "Build a Next.js app",
+    href: "/examples/next_tutorial/",
+    type: "tutorial",
+    description: "Run a full-stack React framework on Deno.",
+  },
+  {
+    title: "Connecting to databases",
+    href: "/examples/connecting_to_databases_tutorial/",
+    type: "tutorial",
+    description: "Postgres, MySQL, MongoDB, SQLite and more.",
+  },
+  {
+    title: "Deploy with Deno Deploy",
+    href: "/examples/deno_deploy_tutorial/",
+    type: "tutorial",
+    description: "Ship your app to the edge in minutes.",
+  },
+  {
+    title: "Built in TypeScript support",
+    href: "/examples/typescript_support/",
+    type: "video",
+    description: "Run TypeScript directly, with zero configuration.",
+  },
+];
+
 export const sectionTitle = "Examples";
 export const sectionHref = "/examples/";

--- a/examples/index.page.tsx
+++ b/examples/index.page.tsx
@@ -1,13 +1,64 @@
+import { walkSync } from "@std/fs/walk";
+import { parseExample } from "./utils/parseExample.ts";
+
 export const layout = "raw.tsx";
 
 export const toc = [];
 
+/** First sentence of a description, for the landing page cards. Strips any
+ * HTML markup, and skips a leading "Warning: ..." sentence (used by unstable
+ * API examples) when a real description follows it. */
+function firstSentence(text: string | undefined): string | undefined {
+  if (!text) return undefined;
+  const normalized = text
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (normalized.length === 0) return undefined;
+
+  let rest = normalized;
+  const sentences = [];
+  while (rest.length > 0) {
+    const sentence = rest.match(/^.*?[.!?](?=\s|$)/)?.[0];
+    if (!sentence) {
+      sentences.push(rest);
+      break;
+    }
+    sentences.push(sentence);
+    rest = rest.slice(sentence.length).trim();
+  }
+
+  const informative = sentences.find((s) => !/^warning[:\s]/i.test(s));
+  return informative ?? sentences[0];
+}
+
 export default function* (
   data: Lume.Data,
 ) {
+  // One-sentence description per item href, sourced from the example
+  // scripts' doc comments and the tutorial/video pages' frontmatter.
+  const descriptions: Record<string, string> = {};
+
+  for (const file of walkSync("./examples/scripts/", { exts: [".ts"] })) {
+    const content = Deno.readTextFileSync(file.path);
+    const label = file.name.replace(".ts", "");
+    const parsed = parseExample(file.name, content);
+    const description = firstSentence(parsed.description);
+    if (description) {
+      descriptions[`/examples/${label}/`] = description;
+    }
+  }
+
+  for (const page of data.search.pages("url^=/examples/")) {
+    const description = firstSentence(page.description as string | undefined);
+    if (description && typeof page.url === "string") {
+      descriptions[page.url] = description;
+    }
+  }
+
   yield {
     url: `/examples/`,
     title: `Deno examples and tutorials`,
-    content: <data.comp.LandingPage />,
+    content: <data.comp.LandingPage descriptions={descriptions} />,
   };
 }

--- a/examples/scripts/pid.ts
+++ b/examples/scripts/pid.ts
@@ -4,6 +4,8 @@
  * @tags cli
  * @run <url>
  * @group System
+ *
+ * An example of how to access the current process ID and parent process ID.
  */
 
 // The current process's process ID is available in the `Deno.pid` variable.

--- a/examples/scripts/temporal.ts
+++ b/examples/scripts/temporal.ts
@@ -6,6 +6,8 @@
  * @resource {https://docs.deno.com/api/web/~/Temporal} Temporal API reference documentation
  * @resource {https://tc39.es/proposal-temporal/docs} Temporal API proposal documentation
  * @group Web APIs
+ *
+ * An example of using the Temporal API to work with dates, times, and timestamps.
  */
 
 // Get the current date

--- a/examples/tutorials/simple_api.md
+++ b/examples/tutorials/simple_api.md
@@ -1,6 +1,7 @@
 ---
 last_modified: 2025-09-24
 title: "Simple API server"
+description: "Build a simple link shortener API with Deno KV and web standard primitives, then deploy it to Deno Deploy."
 url: /examples/simple_api_tutorial/
 oldUrl:
   - /deploy/tutorials/simple-api/

--- a/examples/videos/backward_compat_with_node_npm.md
+++ b/examples/videos/backward_compat_with_node_npm.md
@@ -1,5 +1,6 @@
 ---
 title: "Compatibility with Node & npm"
+description: "Learn how to integrate Deno into existing Node.js projects using npm modules and Node standard libraries, without major rewrites."
 url: /examples/backward_compat_with_node_npm/
 videoUrl: https://www.youtube.com/watch?v=QPLchkJ7eas&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=12
 layout: video.tsx

--- a/examples/videos/byte_and_text_imports.md
+++ b/examples/videos/byte_and_text_imports.md
@@ -1,5 +1,6 @@
 ---
 title: "Byte and text imports"
+description: "Learn how to import bytes and text files directly into your module graph for automatic tree shaking and more."
 url: /examples/byte_and_text_imports/
 videoUrl: https://www.youtube.com/watch?v=PAEI6mdlXwc
 layout: video.tsx

--- a/examples/videos/command_line_utility.md
+++ b/examples/videos/command_line_utility.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Command Line Utility"
+description: "Learn to build a command line tool with Deno's standard library, parse flags, handle errors, and compile cross-platform executables."
 url: /examples/command_line_utility/
 videoUrl: https://www.youtube.com/watch?v=TUxj2TS5pNo&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=14
 layout: video.tsx

--- a/examples/videos/configuration_with_deno_json.md
+++ b/examples/videos/configuration_with_deno_json.md
@@ -1,5 +1,6 @@
 ---
 title: "Configuration with Deno JSON"
+description: "Learn how to use deno.json to manage dependencies, configure tasks, customize formatting and linting, and work with import maps."
 url: /examples/configuration_with_deno_json/
 videoUrl: https://www.youtube.com/watch?v=bTmO5Tfgke4
 layout: video.tsx

--- a/examples/videos/deno_fmt.md
+++ b/examples/videos/deno_fmt.md
@@ -1,5 +1,6 @@
 ---
 title: "Formatting with Deno fmt"
+description: "Learn tips and tricks for using deno fmt, Deno's fast, customizable built-in code formatter, in any workflow."
 url: /examples/deno_fmt/
 videoUrl: https://www.youtube.com/watch?v=Ouzso9gQqnc
 layout: video.tsx

--- a/examples/videos/deno_test.md
+++ b/examples/videos/deno_test.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting started with Deno test"
+description: "Learn the basics of writing and running tests with Deno's built-in test runner."
 url: /examples/deno_test/
 videoUrl: https://www.youtube.com/watch?v=gDtDVfsgHgs
 layout: video.tsx

--- a/examples/videos/deploy_deno_to_aws_lambda.md
+++ b/examples/videos/deploy_deno_to_aws_lambda.md
@@ -1,5 +1,6 @@
 ---
 title: "Deploy Deno to AWS Lambda"
+description: "Learn how to deploy a Deno application to AWS Lambda using a Dockerfile and the aws-lambda-adapter community runtime."
 url: /examples/deploy_deno_to_aws_lambda/
 videoUrl: https://www.youtube.com/watch?v=_xLOrT3cWK4&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=17
 layout: video.tsx

--- a/examples/videos/deploying_deno_with_docker.md
+++ b/examples/videos/deploying_deno_with_docker.md
@@ -1,5 +1,6 @@
 ---
 title: "Deploying Deno with Docker"
+description: "Learn how to containerize a Deno application with Docker and deploy it to a compatible cloud environment."
 url: /examples/deploying_deno_with_docker/
 videoUrl: https://www.youtube.com/watch?v=VRryNeYm6yw&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=16
 layout: video.tsx

--- a/examples/videos/esmodules.md
+++ b/examples/videos/esmodules.md
@@ -1,5 +1,6 @@
 ---
 title: "ECMAScript Modules"
+description: "Learn how Deno uses standard ECMAScript modules to import and share JavaScript and TypeScript code."
 url: /examples/esmodules/
 videoUrl: https://www.youtube.com/watch?v=cTFBiwYY3vs&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=9
 layout: video.tsx

--- a/examples/videos/image_bundling_deno_compile.md
+++ b/examples/videos/image_bundling_deno_compile.md
@@ -1,5 +1,6 @@
 ---
 title: "Image bundling with deno compile"
+description: "Learn how to embed image assets in a deno compile executable using bytes imports, demonstrated with a Flappybird game."
 url: /examples/image_bundling_deno_compile/
 videoUrl: https://www.youtube.com/watch?v=qg_M0deBlfQ
 layout: video.tsx

--- a/examples/videos/interoperability_with_nodejs.md
+++ b/examples/videos/interoperability_with_nodejs.md
@@ -1,5 +1,6 @@
 ---
 title: "Interoperability with Node.js"
+description: "Learn how to use Node.js built-in APIs, npm modules, and JSR packages in your Deno projects."
 url: /examples/interoperability_with_nodejs/
 videoUrl: https://www.youtube.com/watch?v=mgX1ymfqPSQ&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=2
 layout: video.tsx

--- a/examples/videos/intro_to_deno_apis.md
+++ b/examples/videos/intro_to_deno_apis.md
@@ -1,5 +1,6 @@
 ---
 title: "Introduction to Deno APIs"
+description: "Explore Deno's built-in APIs for file system operations, command line arguments, environment variables, and serving HTTP requests."
 url: /examples/intro_to_deno_apis/
 videoUrl: https://www.youtube.com/watch?v=p28ujFMrdA0&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=7
 layout: video.tsx

--- a/examples/videos/mongoose.md
+++ b/examples/videos/mongoose.md
@@ -1,5 +1,6 @@
 ---
 title: "Connect to Mongoose and MongoDB"
+description: "Learn how to connect a Deno application to MongoDB using the Mongoose library."
 url: /examples/mongoose/
 videoUrl: https://www.youtube.com/watch?v=dmZ9Ih0CR9g
 layout: video.tsx

--- a/examples/videos/prisma.md
+++ b/examples/videos/prisma.md
@@ -1,5 +1,6 @@
 ---
 title: "Connect to Prisma"
+description: "Learn how to use the Prisma ORM to connect to and query a database from a Deno application."
 url: /examples/prisma/
 videoUrl: https://www.youtube.com/watch?v=P8VzA_XSF8w
 layout: video.tsx

--- a/examples/videos/publishing_modules_with_jsr.md
+++ b/examples/videos/publishing_modules_with_jsr.md
@@ -1,5 +1,6 @@
 ---
 title: "Publishing Modules with JSR"
+description: "Discover JSR, the TypeScript-first registry for modern JavaScript, and learn how to install and publish packages with it."
 url: /examples/publishing_modules_with_jsr/
 videoUrl: https://www.youtube.com/watch?v=7uiL4WYvZVs&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=8
 layout: video.tsx

--- a/examples/videos/react_app_video.md
+++ b/examples/videos/react_app_video.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a React app"
+description: "Watch how to build a React app with a Deno backend, from project setup to a working application."
 url: /examples/react_app_video/
 videoUrl: https://www.youtube.com/watch?v=eStwt_2THd8
 layout: video.tsx

--- a/examples/videos/realtime_websocket_app.md
+++ b/examples/videos/realtime_websocket_app.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Realtime WebSocket Application"
+description: "Learn how to build a realtime application in Deno using the standard WebSocket API."
 url: /examples/realtime_websocket_app/
 videoUrl: https://www.youtube.com/watch?v=FC4IrkHEg4A&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=15
 layout: video.tsx

--- a/examples/videos/ts_jsx.md
+++ b/examples/videos/ts_jsx.md
@@ -1,5 +1,6 @@
 ---
 title: "TypeScript and JSX"
+description: "Learn how Deno runs TypeScript and JSX out of the box, with zero configuration or extra tooling required."
 url: /examples/ts_jsx/
 videoUrl: https://www.youtube.com/watch?v=KoM8ahe8O74&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=11
 layout: video.tsx

--- a/examples/videos/vue_app_video.md
+++ b/examples/videos/vue_app_video.md
@@ -1,5 +1,6 @@
 ---
 title: "Build a Vue app"
+description: "Watch how to build a Vue app with a Deno backend, from project setup to a working application."
 url: /examples/vue_app_video/
 videoUrl: https://www.youtube.com/watch?v=MDPauM8fZDE
 layout: video.tsx

--- a/examples/videos/what_is_deno.md
+++ b/examples/videos/what_is_deno.md
@@ -1,5 +1,6 @@
 ---
 title: "What is Deno?"
+description: "A short introduction to Deno, the secure JavaScript, TypeScript, and WebAssembly runtime built on web standards, and its history."
 url: /examples/what_is_deno/
 videoUrl: https://www.youtube.com/watch?v=KPTOo4k8-GE&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe
 layout: video.tsx

--- a/js/feedback.ts
+++ b/js/feedback.ts
@@ -35,6 +35,28 @@ feedbackForm?.addEventListener("submit", (event) => {
   }
 });
 
+// "Request a new guide" box on the Examples landing page; reuses the
+// feedback endpoint, which files a GitHub issue when a comment is present.
+const guideRequestForm = document.getElementById("guide-request-form");
+const guideRequestBox = document.getElementById("guide-request-box");
+
+guideRequestForm?.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const formData = new FormData(guideRequestForm as HTMLFormElement);
+  const form = Object.fromEntries(formData.entries());
+  const comment = (form["guide-request-comment"] as string)?.trim();
+  if (!comment) return;
+  sendFeedback({
+    sentiment: "no",
+    comment: `[Guide request] ${comment}`,
+    contact: form["guide-request-contact"] as string,
+  });
+  if (guideRequestBox) {
+    guideRequestBox.innerHTML =
+      "<p>Thanks! Your request has been filed — we'll take a look.</p>";
+  }
+});
+
 async function sendFeedback(feedback: Partial<FeedbackSubmission>) {
   feedback.path = feedback.path || new URL(window.location.href).pathname;
   feedback.id = lastFeedbackItemId ? lastFeedbackItemId : null;


### PR DESCRIPTION
The Examples landing page was hard to scan: a three-column masonry of 195
bare links, each prefixed with an icon, with no way to tell what a guide
covers without clicking into it. This rebuilds the page around described
cards: every item is a boxed card with its title, a one-sentence
description, and a type icon in the corner. Descriptions are sourced at
build time from the example scripts' doc comments and the tutorial/video
pages' frontmatter (23 video/tutorial/script pages that had no description
anywhere got one written, which also fixes their missing meta descriptions).

The page also gains a curated Featured row, per-type counts and a total in
the now full-width filter bar, and a "Request a new guide" box that files a
GitHub issue through the existing feedback endpoint — replacing the
"We welcome contributions" footer section.