### PR TITLE
docs: use deno install with unprefixed npm package on the landing

### DIFF
--- a/runtime/index.md
+++ b/runtime/index.md
@@ -122,12 +122,12 @@ ok | 2 passed | 0 failed (15ms)
 
 ## Add a dependency
 
-Pull in packages from [JSR](https://jsr.io) or npm with
-[`deno add`](/runtime/reference/cli/add/), which records them in `deno.json`:
+Pull in packages from npm or [JSR](https://jsr.io) with
+[`deno install`](/runtime/reference/cli/install/):
 
 ```sh
-deno add jsr:@std/assert    # the Deno standard library, on JSR
-deno add npm:express        # any npm package
+deno install express            # any npm package, like npm install
+deno install jsr:@std/assert    # the Deno standard library, on JSR
 ```
 
 Then import and use them:


### PR DESCRIPTION
The get-started landing taught dependencies via deno add with prefixed
specifiers. Since Deno 2.8 unprefixed names default to npm, so the most
familiar form for newcomers is deno install express, mirroring npm install.
The landing now leads with that, keeps the jsr: form for the standard
library, and links the deno install reference. It deliberately does not say
where the dependency is recorded, since that depends on whether the project
uses deno.json or package.json; the install reference covers it.