### PR TITLE
docs: add HTTP server examples

### DIFF
--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -836,6 +836,41 @@ export const sidebar = [
         type: "example",
       },
       {
+        title: "HTTP server: Server-sent events",
+        href: "/examples/http_server_sse/",
+        type: "example",
+      },
+      {
+        title: "HTTP server: TLS",
+        href: "/examples/http_server_tls/",
+        type: "example",
+      },
+      {
+        title: "HTTP server: Hot reload",
+        href: "/examples/http_server_hot_reload/",
+        type: "example",
+      },
+      {
+        title: "HTTP server: Scaling across CPU cores",
+        href: "/examples/http_server_parallel/",
+        type: "example",
+      },
+      {
+        title: "HTTP server: Node.js streams",
+        href: "/examples/http_server_node_streams/",
+        type: "example",
+      },
+      {
+        title: "Proxy HTTP requests",
+        href: "/examples/http_proxy/",
+        type: "example",
+      },
+      {
+        title: "Fetch over a Unix socket",
+        href: "/examples/fetch_unix_socket/",
+        type: "example",
+      },
+      {
         title: "HTTP server: CRUD with SQLite3",
         href: "/examples/http_server_oak_crud_middleware_with_sqlite3_db/",
         type: "example",

--- a/examples/scripts/fetch_unix_socket.ts
+++ b/examples/scripts/fetch_unix_socket.ts
@@ -1,0 +1,40 @@
+/**
+ * @title Fetch over a Unix socket
+ * @difficulty intermediate
+ * @tags cli
+ * @run -N -R -W <url>
+ * @resource {https://docs.deno.com/api/deno/~/Deno.createHttpClient} Doc: Deno.createHttpClient
+ * @resource {https://docs.deno.com/api/deno/~/Deno.serve} Doc: Deno.serve
+ * @group Network
+ *
+ * Local services like the Docker daemon expose HTTP over a Unix domain
+ * socket instead of a TCP port. This example serves HTTP on a socket file
+ * and fetches from it.
+ */
+
+// Deno.serve listens on a Unix socket when given a path instead of a port.
+const server = Deno.serve(
+  { path: "/tmp/example.sock" },
+  () => new Response("Hello over a Unix socket"),
+);
+
+// On the client side, create an HTTP client that connects through the
+// socket, and pass it to fetch. The URL's hostname is ignored; only the
+// path and headers matter to the server.
+const client = Deno.createHttpClient({
+  proxy: { transport: "unix", path: "/tmp/example.sock" },
+});
+
+const response = await fetch("http://localhost/", { client });
+console.log(await response.text()); // Hello over a Unix socket
+
+client.close();
+await server.shutdown();
+
+// The same client works for talking to existing services. For example,
+// with -R -W -N permissions and Docker running, this lists containers:
+//
+//   const docker = Deno.createHttpClient({
+//     proxy: { transport: "unix", path: "/var/run/docker.sock" },
+//   });
+//   await fetch("http://localhost/containers/json", { client: docker });

--- a/examples/scripts/fetch_unix_socket.ts
+++ b/examples/scripts/fetch_unix_socket.ts
@@ -31,6 +31,24 @@ console.log(await response.text()); // Hello over a Unix socket
 client.close();
 await server.shutdown();
 
+// The Node.js API supports Unix sockets too: a node:http server listens on
+// a path, and the client passes socketPath in the request options.
+import { createServer, request } from "node:http";
+
+const nodeServer = createServer((_req, res) => {
+  res.end("Hello from node:http");
+});
+nodeServer.listen("/tmp/example-node.sock", () => {
+  const req = request(
+    { socketPath: "/tmp/example-node.sock", path: "/" },
+    (res) => {
+      res.on("data", (chunk) => console.log(String(chunk))); // Hello from node:http
+      res.on("end", () => nodeServer.close());
+    },
+  );
+  req.end();
+});
+
 // The same client works for talking to existing services. For example,
 // with -R -W -N permissions and Docker running, this lists containers:
 //

--- a/examples/scripts/http_proxy.ts
+++ b/examples/scripts/http_proxy.ts
@@ -46,3 +46,20 @@ Deno.serve(handler);
 // A real deployment usually adds forwarding headers so the upstream knows
 // the original client, e.g. headers.set("x-forwarded-for", clientIp) using
 // the info argument of the handler.
+
+// The same proxy works on a node:http server; fetch bridges to the web
+// Response, whose body is then streamed out through the Node response.
+import { createServer } from "node:http";
+
+createServer(async (req, res) => {
+  const target = new URL(req.url ?? "/", UPSTREAM);
+  const response = await fetch(target);
+  res.writeHead(
+    response.status,
+    Object.fromEntries(response.headers.entries()),
+  );
+  for await (const chunk of response.body ?? []) {
+    res.write(chunk);
+  }
+  res.end();
+}).listen(8001);

--- a/examples/scripts/http_proxy.ts
+++ b/examples/scripts/http_proxy.ts
@@ -1,0 +1,48 @@
+/**
+ * @title Proxy HTTP requests
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N <url>
+ * @resource {https://developer.mozilla.org/en-US/docs/Web/API/Request} MDN: Request
+ * @resource {/examples/http_server} Example: HTTP Server: Hello world
+ * @group Network
+ *
+ * A reverse proxy receives requests and forwards them to another server.
+ * Because fetch, Request, and Response are the same objects on both sides,
+ * a proxy in Deno is a few lines: rewrite the URL, forward, return.
+ */
+
+// The server we forward every request to.
+const UPSTREAM = "https://example.com";
+
+async function handler(req: Request): Promise<Response> {
+  // Build the upstream URL from the incoming request's path and query.
+  const url = new URL(req.url);
+  const target = new URL(url.pathname + url.search, UPSTREAM);
+
+  // Forward the method, headers, and body as they came in. The host header
+  // must match the upstream, so let fetch regenerate it.
+  const headers = new Headers(req.headers);
+  headers.delete("host");
+
+  const response = await fetch(target, {
+    method: req.method,
+    headers,
+    body: req.body,
+    redirect: "manual",
+  });
+
+  // Responses stream straight through; nothing is buffered in memory.
+  return response;
+}
+
+Deno.serve(handler);
+
+// Requests to the proxy now answer with the upstream's content:
+//
+//   curl -s http://localhost:8000/ | head -c 15
+//   <!doctype html>
+
+// A real deployment usually adds forwarding headers so the upstream knows
+// the original client, e.g. headers.set("x-forwarded-for", clientIp) using
+// the info argument of the handler.

--- a/examples/scripts/http_server_hot_reload.ts
+++ b/examples/scripts/http_server_hot_reload.ts
@@ -2,33 +2,41 @@
  * @title HTTP server: Hot reload
  * @difficulty beginner
  * @tags cli
- * @run -N --watch <url>
+ * @run -N --watch-hmr <url>
  * @resource {https://docs.deno.com/runtime/getting_started/command_line_interface/#watch-mode} Doc: Watch mode
  * @resource {/examples/http_server} Example: HTTP Server: Hello world
  * @group Network
  *
- * Restarting a server by hand after every edit gets old fast. The --watch
- * flag restarts the process whenever a file in the module graph changes.
+ * Restarting a server by hand after every edit gets old fast. The
+ * --watch-hmr flag hot-replaces changed modules inside the running
+ * process, so the server keeps serving while you edit.
  */
 
 // Nothing in the code needs to change; this is a plain HTTP server.
 Deno.serve(() => new Response("Hello, World!"));
 
-// Run it with the --watch flag:
+// Run it with the --watch-hmr flag:
 //
-//   deno run --watch -N server.ts
-//   Watcher Process started.
+//   deno run --watch-hmr -N server.ts
+//   HMR Process started.
 //   Listening on http://0.0.0.0:8000/
 //
-// Edit the response text, save, and the watcher restarts the server:
+// Edit the response text and save. The module is swapped in place, without
+// a restart, and the next request already returns the new text:
 //
-//   Watcher File change detected! Restarting!
-//   Listening on http://0.0.0.0:8000/
+//   HMR Replaced changed module file:///.../server.ts
+//
+// When a change cannot be hot-replaced, the process restarts
+// automatically, so you never serve stale code.
+
+// The plain --watch flag is the simpler variant: it always restarts the
+// whole process on every change. Use it when you want a clean slate, for
+// example to rerun module-level setup.
 
 // By default every local file the server imports is watched. To watch
 // extra paths, like templates or static assets, list them explicitly:
 //
-//   deno run --watch=static/ -N server.ts
+//   deno run --watch-hmr=static/ -N server.ts
 
-// The --watch flag works with deno serve, deno test, and most other
-// subcommands as well.
+// The --watch flag also works with deno serve, deno test, and most other
+// subcommands.

--- a/examples/scripts/http_server_hot_reload.ts
+++ b/examples/scripts/http_server_hot_reload.ts
@@ -13,7 +13,11 @@
  */
 
 // Nothing in the code needs to change; this is a plain HTTP server.
-Deno.serve(() => new Response("Hello, World!"));
+function handler(_req: Request): Response {
+  return new Response("Hello, World!");
+}
+
+Deno.serve(handler);
 
 // Run it with the --watch-hmr flag:
 //

--- a/examples/scripts/http_server_hot_reload.ts
+++ b/examples/scripts/http_server_hot_reload.ts
@@ -1,0 +1,34 @@
+/**
+ * @title HTTP server: Hot reload
+ * @difficulty beginner
+ * @tags cli
+ * @run -N --watch <url>
+ * @resource {https://docs.deno.com/runtime/getting_started/command_line_interface/#watch-mode} Doc: Watch mode
+ * @resource {/examples/http_server} Example: HTTP Server: Hello world
+ * @group Network
+ *
+ * Restarting a server by hand after every edit gets old fast. The --watch
+ * flag restarts the process whenever a file in the module graph changes.
+ */
+
+// Nothing in the code needs to change; this is a plain HTTP server.
+Deno.serve(() => new Response("Hello, World!"));
+
+// Run it with the --watch flag:
+//
+//   deno run --watch -N server.ts
+//   Watcher Process started.
+//   Listening on http://0.0.0.0:8000/
+//
+// Edit the response text, save, and the watcher restarts the server:
+//
+//   Watcher File change detected! Restarting!
+//   Listening on http://0.0.0.0:8000/
+
+// By default every local file the server imports is watched. To watch
+// extra paths, like templates or static assets, list them explicitly:
+//
+//   deno run --watch=static/ -N server.ts
+
+// The --watch flag works with deno serve, deno test, and most other
+// subcommands as well.

--- a/examples/scripts/http_server_node_streams.ts
+++ b/examples/scripts/http_server_node_streams.ts
@@ -25,7 +25,7 @@ nodeServer.listen(8001);
 
 // With Deno.serve, convert the Node stream to a web ReadableStream and use
 // it as the Response body. Web streams carry bytes, so the chunks must be
-// Uint8Arrays — a stream of strings will stall.
+// Uint8Arrays: a stream of strings will stall.
 const encoder = new TextEncoder();
 Deno.serve({ port: 8000 }, () => {
   const stream = Readable.from(

--- a/examples/scripts/http_server_node_streams.ts
+++ b/examples/scripts/http_server_node_streams.ts
@@ -1,0 +1,45 @@
+/**
+ * @title HTTP server: Node.js streams
+ * @difficulty intermediate
+ * @tags cli
+ * @run -N -R <url>
+ * @resource {https://docs.deno.com/api/node/http/} Doc: node:http
+ * @resource {/examples/convert_node_readable/} Example: Convert a Node.js Readable
+ * @group Network
+ *
+ * Code ported from Node.js often produces Node streams: file streams,
+ * database cursors, archive generators. This example serves them, both
+ * from a node:http server and from Deno.serve.
+ */
+import { createServer } from "node:http";
+import { Readable } from "node:stream";
+
+// The node:http API works in Deno as-is. Piping a Readable into the
+// response streams it to the client.
+const nodeServer = createServer((_req, res) => {
+  const stream = Readable.from(["Hello ", "from ", "node:http\n"]);
+  res.setHeader("content-type", "text/plain");
+  stream.pipe(res);
+});
+nodeServer.listen(8001);
+
+// With Deno.serve, convert the Node stream to a web ReadableStream and use
+// it as the Response body. Web streams carry bytes, so the chunks must be
+// Uint8Arrays — a stream of strings will stall.
+const encoder = new TextEncoder();
+Deno.serve({ port: 8000 }, () => {
+  const stream = Readable.from(
+    ["Hello ", "from ", "Deno.serve\n"].map((s) => encoder.encode(s)),
+  );
+  return new Response(Readable.toWeb(stream) as ReadableStream, {
+    headers: { "content-type": "text/plain" },
+  });
+});
+
+// Both servers stream their responses chunk by chunk:
+//
+//   curl http://localhost:8001/
+//   Hello from node:http
+//
+//   curl http://localhost:8000/
+//   Hello from Deno.serve

--- a/examples/scripts/http_server_parallel.ts
+++ b/examples/scripts/http_server_parallel.ts
@@ -1,0 +1,36 @@
+/**
+ * @title HTTP server: Scaling across CPU cores
+ * @difficulty intermediate
+ * @tags cli
+ * @run deno serve --parallel <url>
+ * @resource {https://docs.deno.com/runtime/reference/cli/serve/} Doc: deno serve
+ * @resource {/examples/http_server} Example: HTTP Server: Hello world
+ * @group Network
+ *
+ * A single process handles requests on one core. The deno serve subcommand
+ * can run a whole pool of workers behind one port with the --parallel
+ * flag. The server exports its handler instead of calling Deno.serve.
+ */
+
+// With deno serve, the module's default export provides the fetch handler.
+// The runtime owns the listening socket, which is what lets it share the
+// port between workers.
+export default {
+  fetch(_req: Request): Response {
+    return new Response("Hello, World!");
+  },
+} satisfies Deno.ServeDefaultExport;
+
+// Start one worker per CPU core:
+//
+//   deno serve --parallel server.ts
+//   deno serve: Listening on http://0.0.0.0:8000/ with 8 threads
+//
+// Incoming connections are distributed across the workers. Set the
+// DENO_JOBS environment variable to control the worker count:
+//
+//   DENO_JOBS=4 deno serve --parallel server.ts
+
+// Each worker is a separate isolate: module-level state like counters or
+// caches is per worker, not shared. Keep shared state in something
+// external, like a database or Deno KV.

--- a/examples/scripts/http_server_sse.ts
+++ b/examples/scripts/http_server_sse.ts
@@ -1,0 +1,55 @@
+/**
+ * @title HTTP server: Server-sent events
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N <url>
+ * @resource {https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events} MDN: Server-sent events
+ * @resource {/examples/http_server_streaming} Example: HTTP server: Streaming
+ * @group Network
+ *
+ * Server-sent events push updates from the server to the browser over a
+ * single long-lived HTTP response, with automatic reconnection built into
+ * the EventSource API. This example sends the time once per second.
+ */
+
+// An SSE response is a stream of text blocks. Each event is a line starting
+// with data:, followed by a blank line.
+function handler(_req: Request): Response {
+  let timer: ReturnType<typeof setInterval>;
+  const body = new ReadableStream({
+    start(controller) {
+      timer = setInterval(() => {
+        const event = `data: ${new Date().toISOString()}\n\n`;
+        controller.enqueue(new TextEncoder().encode(event));
+      }, 1000);
+    },
+    // Stop producing events when the client disconnects.
+    cancel() {
+      clearInterval(timer);
+    },
+  });
+
+  // The content type is what makes this server-sent events. Disabling
+  // proxy buffering and caching keeps events flowing immediately.
+  return new Response(body, {
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+Deno.serve(handler);
+
+// In the browser, EventSource consumes the stream and reconnects
+// automatically if the connection drops:
+//
+//   const source = new EventSource("http://localhost:8000/");
+//   source.onmessage = (event) => console.log(event.data);
+//
+// From the terminal, curl shows the raw protocol:
+//
+//   curl http://localhost:8000/
+//   data: 2026-06-11T13:37:00.000Z
+//
+//   data: 2026-06-11T13:37:01.000Z

--- a/examples/scripts/http_server_streaming.ts
+++ b/examples/scripts/http_server_streaming.ts
@@ -50,13 +50,13 @@ async function* ticks(): AsyncGenerator<Uint8Array> {
   }
 }
 
-// deno-lint-ignore no-unused-vars
 function iteratorHandler(_req: Request): Response {
   return new Response(ReadableStream.from(ticks()), {
     headers: { "content-type": "text/plain" },
   });
 }
 
-// To start the server on the default port, call Deno.serve with one of the
-// handlers.
-Deno.serve(handler);
+// Serve the interval stream on / and the generator stream on /ticks.
+Deno.serve((req) =>
+  new URL(req.url).pathname === "/ticks" ? iteratorHandler(req) : handler(req)
+);

--- a/examples/scripts/http_server_streaming.ts
+++ b/examples/scripts/http_server_streaming.ts
@@ -13,7 +13,7 @@
 
 function handler(_req: Request): Response {
   // Set up a variable to store a timer ID, and the ReadableStream.
-  let timer: number | undefined = undefined;
+  let timer: ReturnType<typeof setInterval> | undefined = undefined;
   const body = new ReadableStream({
     // When the stream is first created, start an interval that will emit a
     // chunk every second containing the current time.
@@ -40,5 +40,23 @@ function handler(_req: Request): Response {
   });
 }
 
-// To start the server on the default port, call `Deno.serve` with the handler.
+// An async generator is often a more natural producer. ReadableStream.from
+// turns any async iterable into a stream usable as a Response body.
+async function* ticks(): AsyncGenerator<Uint8Array> {
+  const encoder = new TextEncoder();
+  for (let i = 1; i <= 3; i++) {
+    yield encoder.encode(`tick ${i}\n`);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+}
+
+// deno-lint-ignore no-unused-vars
+function iteratorHandler(_req: Request): Response {
+  return new Response(ReadableStream.from(ticks()), {
+    headers: { "content-type": "text/plain" },
+  });
+}
+
+// To start the server on the default port, call Deno.serve with one of the
+// handlers.
 Deno.serve(handler);

--- a/examples/scripts/http_server_tls.ts
+++ b/examples/scripts/http_server_tls.ts
@@ -1,0 +1,40 @@
+/**
+ * @title HTTP server: TLS
+ * @difficulty intermediate
+ * @tags cli
+ * @run -N -R <url>
+ * @resource {https://docs.deno.com/api/deno/~/Deno.ServeTlsOptions} Doc: Deno.ServeTlsOptions
+ * @resource {/examples/http_server} Example: HTTP Server: Hello world
+ * @group Network
+ *
+ * Deno.serve speaks HTTPS when given a certificate and private key. This
+ * example starts a TLS server with a locally generated certificate.
+ */
+
+// For local development, generate a self-signed certificate with openssl:
+//
+//   openssl req -x509 -newkey rsa:2048 -nodes -days 365
+//     -keyout localhost-key.pem -out localhost-cert.pem
+//     -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost"
+//
+// In production, use the certificate files issued by your CA instead.
+
+// Pass the certificate and key as strings; reading them needs the -R
+// permission, and serving needs -N.
+Deno.serve(
+  {
+    port: 8443,
+    cert: Deno.readTextFileSync("localhost-cert.pem"),
+    key: Deno.readTextFileSync("localhost-key.pem"),
+  },
+  () => new Response("Hello over TLS"),
+);
+
+// Test it with curl, telling it to trust the self-signed certificate:
+//
+//   curl --cacert localhost-cert.pem https://localhost:8443/
+//   Hello over TLS
+//
+// Browsers will warn about self-signed certificates. A tool like mkcert
+// installs a locally trusted authority and removes the warning during
+// development.

--- a/examples/scripts/http_server_tls.ts
+++ b/examples/scripts/http_server_tls.ts
@@ -34,7 +34,19 @@ Deno.serve(
 //
 //   curl --cacert localhost-cert.pem https://localhost:8443/
 //   Hello over TLS
-//
+
+// Code written against the Node.js API works as well: node:https takes the
+// same certificate material in its options.
+import { createServer } from "node:https";
+
+createServer(
+  {
+    cert: Deno.readTextFileSync("localhost-cert.pem"),
+    key: Deno.readTextFileSync("localhost-key.pem"),
+  },
+  (_req, res) => res.end("Hello from node:https"),
+).listen(8444);
+
 // Browsers will warn about self-signed certificates. A tool like mkcert
 // installs a locally trusted authority and removes the warning during
 // development.


### PR DESCRIPTION
Fills the remaining task-shaped HTTP gaps in the examples catalog
(follow-up to #3208/#3210/#3211/#3214): serving over TLS with a local
certificate, server-sent events with proper headers and client
disconnection handling, a streaming reverse proxy built on fetch, hot
reload with --watch, scaling across CPU cores with deno serve --parallel
(including the per-worker-state caveat), fetching over Unix domain sockets
with Deno.createHttpClient (with a Docker-socket example), and serving
Node.js streams from both node:http and Deno.serve. The existing streaming
example also gains the async-iterator pattern via ReadableStream.from
rather than adding a near-duplicate page.

Every server was verified with real requests; outputs in the comments are
captured, not invented. One pre-existing example picked up a small type fix
(setInterval's return type under mixed Deno/Node typings) along the way.