### PR TITLE
docs: fill the top search gaps (minimumDependencyAge, denort, assets)

### DIFF
--- a/runtime/getting_started/installation.md
+++ b/runtime/getting_started/installation.md
@@ -159,8 +159,20 @@ cargo install deno --locked
 
 Deno binaries can also be installed manually, by downloading a zip file at
 [github.com/denoland/deno/releases](https://github.com/denoland/deno/releases).
-These packages contain just a single executable file. You will have to set the
-executable bit on macOS and Linux.
+Each release ships one archive per platform, containing a single executable:
+
+| Platform                    | Asset                                |
+| --------------------------- | ------------------------------------ |
+| Windows x86_64              | `deno-x86_64-pc-windows-msvc.zip`    |
+| Windows ARM64               | `deno-aarch64-pc-windows-msvc.zip`   |
+| macOS ARM64 (Apple Silicon) | `deno-aarch64-apple-darwin.zip`      |
+| macOS x86_64 (Intel)        | `deno-x86_64-apple-darwin.zip`       |
+| Linux x86_64                | `deno-x86_64-unknown-linux-gnu.zip`  |
+| Linux ARM64                 | `deno-aarch64-unknown-linux-gnu.zip` |
+
+Unzip the archive and place the `deno` executable somewhere on your `PATH`. You
+will have to set the executable bit on macOS and Linux. Each asset has a
+matching `.sha256sum` file for verifying the download.
 
 ## Docker
 

--- a/runtime/packages/index.md
+++ b/runtime/packages/index.md
@@ -578,7 +578,10 @@ project:
 `deno.json` and `--minimum-dependency-age` accept an
 [ISO-8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) such as
 `P3D` (3 days) or `PT72H` (72 hours), an integer (interpreted as minutes), an
-absolute cutoff date (`2025-09-16`) or RFC3339 timestamp, or `0` to disable. See
+absolute cutoff date (`2025-09-16`) or RFC3339 timestamp, or `0` to disable. The
+field also supports an object form that exempts specific packages; see the
+[`minimumDependencyAge` reference](/runtime/reference/deno_json/#minimum-dependency-age)
+for the full shape, and
 [`.npmrc` configuration](/runtime/fundamentals/node/#npmrc-configuration) for
 the other npm-registry options Deno reads.
 

--- a/runtime/reference/cli/compile.md
+++ b/runtime/reference/cli/compile.md
@@ -88,6 +88,23 @@ Deno supports cross compiling to all targets regardless of the host platform.
 | Linux   | x86_64       | `x86_64-unknown-linux-gnu`  |
 | Linux   | ARM64        | `aarch64-unknown-linux-gnu` |
 
+## The denort binary
+
+`deno compile` embeds your program into `denort` ("Deno runtime"): a stripped
+build of Deno that contains only what's needed to run a compiled program, with
+none of the tooling subcommands. Using `denort` as the base instead of the full
+`deno` binary is what keeps compiled executables smaller.
+
+The first time you compile for a given Deno version and target, Deno downloads
+the matching `denort-<target>.zip` from `dl.deno.land` and caches it in
+`DENO_DIR`. This is also how cross-compilation works: compiling with `--target`
+fetches that platform's `denort`. Subsequent compiles reuse the cached binary
+and work offline.
+
+To use a custom or locally built runtime as the base, set the `DENORT_BIN`
+environment variable to its path. Deno also picks up a `denort` binary placed
+next to the `deno` executable.
+
 ## Icons
 
 It is possible to add an icon to the executable by using the `--icon` flag when

--- a/runtime/reference/deno_json.md
+++ b/runtime/reference/deno_json.md
@@ -311,6 +311,42 @@ Deno uses lockfile by default, you can disable it with following configuration:
 }
 ```
 
+## Minimum dependency age
+
+The `minimumDependencyAge` field stops Deno from installing npm or JSR package
+versions that were published more recently than the configured age. Freshly
+published malicious versions are usually detected and yanked within days, so a
+small delay window catches the bulk of supply-chain attacks. See
+[supply chain management](/runtime/packages/#supply-chain-management) for
+guidance on choosing a window.
+
+```jsonc title="deno.json"
+{
+  // Don't install versions published less than 3 days ago
+  "minimumDependencyAge": "P3D"
+}
+```
+
+The value accepts an
+[ISO-8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations) such as
+`P3D` or `PT72H`, a number of minutes (`120`), an absolute cutoff date
+(`2025-09-16`) or RFC3339 timestamp, or `0` to disable.
+
+To exempt specific packages, use the object form with an `exclude` list:
+
+```jsonc title="deno.json"
+{
+  "minimumDependencyAge": {
+    "age": "P3D",
+    "exclude": ["npm:@mycompany/cli", "jsr:@mycompany/lib"]
+  }
+}
+```
+
+The same control is available as the `--minimum-dependency-age` CLI flag and as
+`min-release-age` in
+[`.npmrc`](/runtime/fundamentals/node/#npmrc-configuration).
+
 ## Node modules directory
 
 By default Deno uses a local `node_modules` directory if you have a


### PR DESCRIPTION
Site-search analytics surfaced queries that consistently return nothing:
minimumDependencyAge (40 no-result searches, our top gap), denort (19), and
the Windows install command and release zip names (~13). All three are real
things Deno ships that the docs never named.

minimumDependencyAge gets a section in the deno.json reference, including
the object form with per-package exclude (verified against the config
schema and exercised on Deno 2.8); the packages guide links to it. The
compile reference gains a section on the denort base binary: what it is,
the per-version/per-target download and caching, how it enables
cross-compilation, and the DENORT_BIN override (checked against
cli/standalone/binary.rs). The installation page's manual-download section
now lists the actual per-platform release assets, so searches for names
like deno-x86_64-pc-windows-msvc.zip land somewhere (names verified against
the v2.8.2 release).