### PR TITLE
docs: add WebSocket, HTML extraction, and runtime utility examples

### DIFF
--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -197,6 +197,11 @@ export const sidebar = [
         type: "example",
       },
       {
+        title: "Extract links and metadata from HTML",
+        href: "/examples/extract_html_data/",
+        type: "example",
+      },
+      {
         title: "Fetch and stream data",
         href: "/examples/fetch_data_tutorial/",
         type: "tutorial",
@@ -608,6 +613,11 @@ export const sidebar = [
         type: "tutorial",
       },
       {
+        title: "Use Deno in Docker",
+        href: "/runtime/reference/docker/",
+        type: "tutorial",
+      },
+      {
         title: "Deploying Deno with Docker",
         href: "/examples/deploying_deno_with_docker/",
         externalURL:
@@ -911,6 +921,16 @@ export const sidebar = [
         type: "example",
       },
       {
+        title: "WebSocket server: Broadcasting messages",
+        href: "/examples/websocket_pubsub/",
+        type: "example",
+      },
+      {
+        title: "WebSocket server: Per-socket state",
+        href: "/examples/websocket_context/",
+        type: "example",
+      },
+      {
         title: "TCP Echo Server",
         href: "/examples/tcp_echo_server/",
         type: "example",
@@ -988,6 +1008,16 @@ export const sidebar = [
       {
         title: "Write to stdout",
         href: "/examples/write_stdout/",
+        type: "example",
+      },
+      {
+        title: "Set the time zone",
+        href: "/examples/set_timezone/",
+        type: "example",
+      },
+      {
+        title: "Find an executable on the PATH",
+        href: "/examples/find_executable/",
         type: "example",
       },
       {
@@ -1195,6 +1225,11 @@ export const sidebar = [
       {
         title: "Exponential backoff",
         href: "/examples/exponential_backoff/",
+        type: "example",
+      },
+      {
+        title: "Inspect memory with heap snapshots",
+        href: "/examples/heap_snapshot/",
         type: "example",
       },
     ],

--- a/examples/scripts/extract_html_data.ts
+++ b/examples/scripts/extract_html_data.ts
@@ -1,0 +1,42 @@
+/**
+ * @title Extract links and metadata from HTML
+ * @difficulty beginner
+ * @tags cli, deploy
+ * @run -N <url>
+ * @resource {https://jsr.io/@b-fuze/deno-dom} Doc: deno-dom
+ * @resource {https://ogp.me/} Reference: Open Graph protocol
+ * @group Web Standard APIs
+ *
+ * Scrapers, link checkers, and preview cards all start the same way: fetch
+ * a page and pull data out of its HTML. This example parses a page with
+ * deno-dom and extracts its links, title, and social metadata.
+ */
+import { DOMParser } from "jsr:@b-fuze/deno-dom";
+
+// Fetch a page and parse the HTML into a queryable document.
+const html = await (await fetch("https://example.com/")).text();
+const doc = new DOMParser().parseFromString(html, "text/html");
+
+// Extract every link with the same querySelectorAll you would use in a
+// browser. Resolving against the page URL turns relative hrefs absolute.
+for (const anchor of doc.querySelectorAll("a[href]")) {
+  const href = new URL(anchor.getAttribute("href")!, "https://example.com/");
+  console.log(href.href); // https://www.iana.org/domains/example
+}
+
+// The document title works like in the browser too.
+console.log(doc.title); // Example Domain
+
+// Social preview cards read Open Graph meta tags. Collect every og:
+// property into a record.
+const og: Record<string, string> = {};
+for (const meta of doc.querySelectorAll('meta[property^="og:"]')) {
+  const property = meta.getAttribute("property")!.slice(3);
+  og[property] = meta.getAttribute("content") ?? "";
+}
+console.log(og); // {} (example.com has no Open Graph tags)
+
+// Pages without Open Graph tags usually still have a description.
+const description = doc.querySelector('meta[name="description"]')
+  ?.getAttribute("content");
+console.log(description ?? "(no description)");

--- a/examples/scripts/find_executable.ts
+++ b/examples/scripts/find_executable.ts
@@ -1,0 +1,49 @@
+/**
+ * @title Find an executable on the PATH
+ * @difficulty beginner
+ * @tags cli
+ * @run -R -E <url>
+ * @resource {https://docs.deno.com/api/deno/~/Deno.env} Doc: Deno.env
+ * @resource {https://docs.deno.com/api/deno/~/Deno.Command} Doc: Deno.Command
+ * @group System
+ *
+ * Before spawning a tool like git or ffmpeg, it is useful to know whether
+ * it is installed and where. This example implements the which command:
+ * scan each directory on the PATH for an executable file.
+ */
+
+async function which(command: string): Promise<string | null> {
+  const PATH = Deno.env.get("PATH") ?? "";
+  // Windows separates entries with ";" and resolves extensions from
+  // PATHEXT; this example covers the common case.
+  const separator = Deno.build.os === "windows" ? ";" : ":";
+
+  for (const dir of PATH.split(separator)) {
+    if (dir === "") continue;
+    const candidate = `${dir}/${command}`;
+    try {
+      const info = await Deno.stat(candidate);
+      // On unix, check that some execute bit is set. Windows has no mode,
+      // so existence is the best cheap signal.
+      const executable = Deno.build.os === "windows" ||
+        ((info.mode ?? 0) & 0o111) !== 0;
+      if (info.isFile && executable) {
+        return candidate;
+      }
+    } catch {
+      // Not in this directory; keep looking.
+    }
+  }
+  return null;
+}
+
+console.log(await which("git")); // /usr/bin/git
+console.log(await which("definitely-not-installed")); // null
+
+// A typical use is a friendly error before spawning a subprocess.
+const ffmpeg = await which("ffmpeg");
+if (!ffmpeg) {
+  console.log("ffmpeg is required: https://ffmpeg.org/download.html");
+}
+
+// Reading the PATH requires -E, and stat-ing the candidates requires -R.

--- a/examples/scripts/heap_snapshot.ts
+++ b/examples/scripts/heap_snapshot.ts
@@ -1,0 +1,45 @@
+/**
+ * @title Inspect memory with heap snapshots
+ * @difficulty intermediate
+ * @tags cli
+ * @run -R -W <url>
+ * @resource {https://docs.deno.com/api/node/v8/} Doc: node:v8
+ * @resource {https://docs.deno.com/runtime/fundamentals/debugging/} Doc: Debugging
+ * @group Advanced
+ *
+ * When memory keeps growing, a heap snapshot shows what is holding it: a
+ * full dump of every live object, inspectable in Chrome DevTools. This
+ * example takes one programmatically.
+ */
+import v8 from "node:v8";
+
+// Something to find in the snapshot: a deliberately retained array.
+const retained: string[] = [];
+for (let i = 0; i < 10_000; i++) {
+  retained.push(`entry ${i}`);
+}
+
+// Write a snapshot of the current heap to a file. The .heapsnapshot
+// extension is what DevTools expects.
+const file = v8.writeHeapSnapshot("./before-cleanup.heapsnapshot");
+console.log(file); // ./before-cleanup.heapsnapshot
+
+// Open Chrome DevTools at chrome://inspect, go to the Memory tab, load the
+// file, and search for "entry " to find the retained strings, along with
+// the retainer chain explaining why they cannot be collected.
+
+// For leak hunting, take a second snapshot after the suspect operation and
+// diff the two in DevTools.
+retained.length = 0;
+v8.writeHeapSnapshot("./after-cleanup.heapsnapshot");
+
+// To take snapshots interactively instead, run the program with
+// --inspect-brk and use the Memory tab against the live process:
+//
+//   deno run --inspect-brk main.ts
+
+console.log("snapshots written");
+
+// Clean up the demo files.
+await Deno.remove("./before-cleanup.heapsnapshot");
+await Deno.remove("./after-cleanup.heapsnapshot");

--- a/examples/scripts/set_timezone.ts
+++ b/examples/scripts/set_timezone.ts
@@ -1,0 +1,38 @@
+/**
+ * @title Set the time zone
+ * @difficulty beginner
+ * @tags cli
+ * @run <url>
+ * @resource {https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat} MDN: Intl.DateTimeFormat
+ * @resource {/examples/temporal/} Example: Temporal API
+ * @group System
+ *
+ * Date, Intl, and Temporal all format times in the process time zone,
+ * which defaults to the operating system setting. The TZ environment
+ * variable overrides it, which makes time-dependent behavior reproducible.
+ */
+
+// The current time zone is visible through the Intl API.
+const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+console.log(zone); // Europe/Warsaw (or whatever the OS is set to)
+
+// Everything that formats local time follows it.
+console.log(new Date().toString());
+
+// Start the process with TZ set to pin the zone, for example to keep
+// timestamps in CI logs consistent or to reproduce a user's bug report:
+//
+//   TZ=Asia/Tokyo deno run main.ts
+//   Asia/Tokyo
+//   Thu Jun 11 2026 22:15:00 GMT+0900 (Japan Standard Time)
+//
+//   TZ=UTC deno run main.ts
+//   UTC
+
+// To format a single value in another zone without changing the process
+// zone, pass timeZone to Intl instead.
+const tokyo = new Intl.DateTimeFormat("en-US", {
+  timeStyle: "long",
+  timeZone: "Asia/Tokyo",
+}).format(new Date());
+console.log(tokyo);

--- a/examples/scripts/set_timezone.ts
+++ b/examples/scripts/set_timezone.ts
@@ -29,8 +29,17 @@ console.log(new Date().toString());
 //   TZ=UTC deno run main.ts
 //   UTC
 
-// To format a single value in another zone without changing the process
-// zone, pass timeZone to Intl instead.
+// The Temporal API is the preferred way to work with zoned time. The
+// current moment in the process zone keeps its zone name attached.
+const now = Temporal.Now.zonedDateTimeISO();
+console.log(now.timeZoneId); // Europe/Warsaw (follows TZ like the above)
+
+// Getting the same moment in another zone is an argument, not a process
+// setting, so zone conversions stay explicit and local to the call.
+const tokyoTime = Temporal.Now.zonedDateTimeISO("Asia/Tokyo");
+console.log(tokyoTime.hour); // e.g. 22
+
+// The Intl API formats a value for another zone the same way.
 const tokyo = new Intl.DateTimeFormat("en-US", {
   timeStyle: "long",
   timeZone: "Asia/Tokyo",

--- a/examples/scripts/websocket_context.ts
+++ b/examples/scripts/websocket_context.ts
@@ -22,6 +22,9 @@ interface Session {
 const sessions = new Map<WebSocket, Session>();
 
 Deno.serve((req) => {
+  if (req.headers.get("upgrade") !== "websocket") {
+    return new Response("This endpoint expects a WebSocket", { status: 426 });
+  }
   const { socket, response } = Deno.upgradeWebSocket(req);
 
   // Read the username from the connection URL, e.g. /?username=ada.

--- a/examples/scripts/websocket_context.ts
+++ b/examples/scripts/websocket_context.ts
@@ -1,0 +1,60 @@
+/**
+ * @title WebSocket server: Per-socket state
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N <url>
+ * @resource {https://docs.deno.com/api/deno/~/Deno.upgradeWebSocket} Doc: Deno.upgradeWebSocket
+ * @resource {/examples/websocket_pubsub/} Example: WebSocket server: Broadcasting messages
+ * @group Network
+ *
+ * Most WebSocket servers need to know who each socket belongs to: a
+ * username, a room, a session. This example attaches state to every
+ * connection and uses it when handling messages.
+ */
+
+// State for one connection. The upgrade request is the natural place to
+// pull it from: query parameters, cookies, or an auth header.
+interface Session {
+  username: string;
+  joined: Date;
+}
+
+const sessions = new Map<WebSocket, Session>();
+
+Deno.serve((req) => {
+  const { socket, response } = Deno.upgradeWebSocket(req);
+
+  // Read the username from the connection URL, e.g. /?username=ada.
+  const username = new URL(req.url).searchParams.get("username") ?? "guest";
+
+  // Each handler closes over this connection's socket, and the Map lets
+  // any other part of the server look the session up later.
+  socket.onopen = () => {
+    sessions.set(socket, { username, joined: new Date() });
+    socket.send(`welcome, ${username}`);
+  };
+
+  socket.onmessage = (event) => {
+    const session = sessions.get(socket)!;
+    socket.send(`${session.username} said: ${event.data}`);
+  };
+
+  socket.onclose = () => {
+    sessions.delete(socket);
+  };
+
+  return response;
+});
+
+// Connecting with a username tags every reply:
+//
+//   const ws = new WebSocket("ws://localhost:8000/?username=ada");
+//   ws.onmessage = (event) => console.log(event.data);
+//   ws.onopen = () => ws.send("hi");
+//
+//   welcome, ada
+//   ada said: hi
+
+// Note that Deno's WebSocket upgrade does not negotiate per-message
+// compression; large payloads are sent as-is, so compress them yourself if
+// it matters.

--- a/examples/scripts/websocket_pubsub.ts
+++ b/examples/scripts/websocket_pubsub.ts
@@ -1,0 +1,61 @@
+/**
+ * @title WebSocket server: Broadcasting messages
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N <url>
+ * @resource {https://docs.deno.com/api/deno/~/Deno.upgradeWebSocket} Doc: Deno.upgradeWebSocket
+ * @resource {/examples/http_server_websocket/} Example: HTTP server: WebSockets
+ * @group Network
+ *
+ * Chat rooms, live dashboards, and multiplayer games all need one thing:
+ * deliver a message from one client to all the others. This example keeps
+ * track of connected sockets and broadcasts every message it receives.
+ */
+
+// All currently connected clients. A Set handles disconnects cleanly.
+const clients = new Set<WebSocket>();
+
+function broadcast(message: string) {
+  for (const client of clients) {
+    // A socket may be mid-handshake or closing; only send when open.
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(message);
+    }
+  }
+}
+
+Deno.serve((req) => {
+  if (req.headers.get("upgrade") !== "websocket") {
+    return new Response("This endpoint expects a WebSocket", { status: 426 });
+  }
+  const { socket, response } = Deno.upgradeWebSocket(req);
+
+  // Register the socket once the connection is established, and clean up
+  // when it goes away for any reason.
+  socket.onopen = () => {
+    clients.add(socket);
+    broadcast(`${clients.size} clients connected`);
+  };
+  socket.onclose = () => {
+    clients.delete(socket);
+    broadcast(`${clients.size} clients connected`);
+  };
+
+  // Relay each incoming message to everyone, including the sender.
+  socket.onmessage = (event) => {
+    broadcast(event.data);
+  };
+
+  return response;
+});
+
+// Connect two clients from another terminal and every message appears in
+// both:
+//
+//   const ws = new WebSocket("ws://localhost:8000/");
+//   ws.onmessage = (event) => console.log(event.data);
+//   ws.onopen = () => ws.send("hello, everyone");
+
+// This state lives in one process. To broadcast across several servers or
+// deno serve --parallel workers, relay messages through something shared,
+// like Deno KV watch or a Redis channel.

--- a/examples/scripts/websocket_pubsub.ts
+++ b/examples/scripts/websocket_pubsub.ts
@@ -56,6 +56,18 @@ Deno.serve((req) => {
 //   ws.onmessage = (event) => console.log(event.data);
 //   ws.onopen = () => ws.send("hello, everyone");
 
-// This state lives in one process. To broadcast across several servers or
-// deno serve --parallel workers, relay messages through something shared,
-// like Deno KV watch or a Redis channel.
+// This state lives in one worker. To broadcast across the workers of
+// deno serve --parallel, relay each message through a BroadcastChannel,
+// which reaches the other workers; on Deno Deploy it reaches the other
+// instances too.
+//
+//   const relay = new BroadcastChannel("chat");
+//   relay.onmessage = (event) => broadcast(event.data);
+//   socket.onmessage = (event) => {
+//     broadcast(event.data);
+//     relay.postMessage(event.data);
+//   };
+//
+// Separate processes and machines do not share a BroadcastChannel; for
+// those, relay through something external like Deno KV watch or a Redis
+// channel.


### PR DESCRIPTION
Closes the remaining small task-shaped gaps in the examples catalog:
broadcasting WebSocket messages to all connected clients (with the
single-process caveat and pointers to shared backends), attaching
per-socket state to WebSocket connections, extracting links and Open
Graph metadata from fetched HTML with deno-dom, pinning the process time
zone with TZ, taking V8 heap snapshots programmatically via node:v8 for
DevTools analysis, and finding an executable on the PATH (a small which
implementation with the unix/Windows differences noted).

The existing Docker reference guide is now also surfaced as a card in the
examples catalog's deployment section, where people actually look for it.
One scoping note: WebSocket compression got a one-line honesty note in
the per-socket-state example instead of a page, since the upgrade does
not negotiate per-message deflate (verified: negotiated extensions come
back empty).

Both WebSocket servers were verified with live clients, and every
standalone script runs with outputs matching its comments.