### PR TITLE
docs: add import maps tutorial and surface debugging guide

### DIFF
--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -163,6 +163,11 @@ export const sidebar = [
           "https://www.youtube.com/watch?v=7uiL4WYvZVs&list=PLvvLnBDNuTEov9EBIp3MMfHlBxaKGRWTe&index=8",
         type: "video",
       },
+      {
+        title: "Re-map import paths",
+        href: "/examples/import_maps_tutorial/",
+        type: "tutorial",
+      },
     ],
   },
 
@@ -1196,6 +1201,11 @@ export const sidebar = [
         title: "Exponential backoff",
         href: "/examples/exponential_backoff/",
         type: "example",
+      },
+      {
+        title: "Debugging with Chrome DevTools",
+        href: "/runtime/fundamentals/debugging/",
+        type: "tutorial",
       },
     ],
   },

--- a/examples/tutorials/add_remove_dependencies.md
+++ b/examples/tutorials/add_remove_dependencies.md
@@ -111,7 +111,10 @@ of a package somewhere deeper in the tree, use the `overrides` field in
 ```
 
 `deno install` resolves `ms` to 2.1.2 everywhere it appears, and records that in
-the lockfile.
+the lockfile. For overriding with a local copy of a package, or remapping your
+own imports rather than the dependency tree, see
+[Overriding dependencies](/runtime/packages/#overriding-dependencies) and
+[Re-map import paths](/examples/import_maps_tutorial/).
 
 ## Removing packages
 

--- a/examples/tutorials/import_maps.md
+++ b/examples/tutorials/import_maps.md
@@ -81,26 +81,14 @@ for imports that originate under a given path prefix:
 
 Modules under `vendor/` get the legacy logger; everything else gets the default.
 
-## Overriding versions in package.json projects
+:::note
 
-The import map redirects specifiers in your own code. To force a version of a
-package deeper in the dependency tree, projects with a `package.json` use its
-`overrides` field, which Deno honors the same way npm does:
+The import map redirects specifiers in your own code. To force the version of a
+package deeper in the dependency tree, use the `overrides` field of
+`package.json` instead; see
+[Overriding transitive dependencies](/examples/add_remove_dependencies_tutorial/#overriding-transitive-dependencies).
 
-```json title="package.json"
-{
-  "dependencies": {
-    "debug": "4.4.3"
-  },
-  "overrides": {
-    "ms": "2.1.2"
-  }
-}
-```
-
-`deno install` resolves `ms` to 2.1.2 everywhere it appears in the tree. See
-[Overriding transitive dependencies](/examples/add_remove_dependencies_tutorial/#overriding-transitive-dependencies)
-for the longer treatment.
+:::
 
 For how packages themselves are named and versioned in the import map, see
 [Add and remove dependencies](/examples/add_remove_dependencies_tutorial/) and

--- a/examples/tutorials/import_maps.md
+++ b/examples/tutorials/import_maps.md
@@ -1,0 +1,85 @@
+---
+title: "Re-map import paths"
+description: "Use the imports field in deno.json as an import map: path aliases like @/ for src/, bare names for local modules, and scoped overrides for transitive imports."
+url: /examples/import_maps_tutorial/
+---
+
+The `imports` field in `deno.json` is an import map: any specifier prefix can be
+re-mapped to any location. Besides naming packages, it replaces the `paths`
+section of `tsconfig.json` for path aliases like `@/`.
+
+## Alias a directory
+
+A key ending in `/` maps a whole prefix. The common convention aliases the
+source root:
+
+```json title="deno.json"
+{
+  "imports": {
+    "@/": "./src/"
+  }
+}
+```
+
+Imports anywhere in the project can now address files from the root instead of
+counting `../` segments:
+
+```ts title="src/pages/about.ts"
+import { greet } from "@/greet.ts";
+```
+
+## Alias a single module
+
+A key without a trailing slash maps one bare name to one file, which reads
+nicely for modules used everywhere:
+
+```json title="deno.json"
+{
+  "imports": {
+    "@/": "./src/",
+    "logger": "./src/utils/logger.ts"
+  }
+}
+```
+
+```ts title="main.ts"
+import { greet } from "@/greet.ts";
+import { log } from "logger";
+
+log(greet("import maps"));
+```
+
+```sh
+$ deno run main.ts
+[log] Hello, import maps!
+```
+
+## Editor support
+
+The Deno language server reads the same file, so completions and
+go-to-definition follow the aliases with no extra `tsconfig.json` configuration.
+If you migrate a project that has `compilerOptions.paths`, move those entries
+into `imports`.
+
+## Scoped overrides
+
+The standard import map `scopes` field also works, remapping a specifier only
+for imports that originate under a given path prefix:
+
+```json title="deno.json"
+{
+  "imports": {
+    "logger": "./src/utils/logger.ts"
+  },
+  "scopes": {
+    "./vendor/": {
+      "logger": "./vendor/legacy_logger.ts"
+    }
+  }
+}
+```
+
+Modules under `vendor/` get the legacy logger; everything else gets the default.
+For how packages themselves are named and versioned in the import map, see
+[Add and remove dependencies](/examples/add_remove_dependencies_tutorial/) and
+the [modules documentation](/runtime/fundamentals/modules/).

--- a/examples/tutorials/import_maps.md
+++ b/examples/tutorials/import_maps.md
@@ -80,6 +80,28 @@ for imports that originate under a given path prefix:
 ```
 
 Modules under `vendor/` get the legacy logger; everything else gets the default.
+
+## Overriding versions in package.json projects
+
+The import map redirects specifiers in your own code. To force a version of a
+package deeper in the dependency tree, projects with a `package.json` use its
+`overrides` field, which Deno honors the same way npm does:
+
+```json title="package.json"
+{
+  "dependencies": {
+    "debug": "4.4.3"
+  },
+  "overrides": {
+    "ms": "2.1.2"
+  }
+}
+```
+
+`deno install` resolves `ms` to 2.1.2 everywhere it appears in the tree. See
+[Overriding transitive dependencies](/examples/add_remove_dependencies_tutorial/#overriding-transitive-dependencies)
+for the longer treatment.
+
 For how packages themselves are named and versioned in the import map, see
 [Add and remove dependencies](/examples/add_remove_dependencies_tutorial/) and
 the [modules documentation](/runtime/fundamentals/modules/).


### PR DESCRIPTION
Two small catalog gaps: re-mapping import paths had no task page despite
being the tsconfig-paths question every migrating project asks (the new
tutorial covers directory aliases like @/, single-module bare names, editor
support, and scoped overrides, all verified in a sample project), and the
existing debugging guide was invisible from the examples catalog, so it now
has a pointer card in the Advanced section like the Docker guide.

Note: the import maps tutorial links to the add/remove dependencies
tutorial from the open package management PR; that link goes live when
both are merged.