### PR TITLE
docs: lint guide intro with real output; fix workspaces heading nesting

### DIFF
--- a/runtime/fundamentals/workspaces.md
+++ b/runtime/fundamentals/workspaces.md
@@ -251,7 +251,7 @@ COPY project-b/ /app/project-b/
 This preserves the workspace resolution mechanism that Deno uses to find and
 import workspace dependencies.
 
-### Multiple package entries
+## Multiple package entries
 
 The `exports` property details the entry points and exposes which modules should
 be importable by users of your package.
@@ -281,7 +281,7 @@ following entries:
 - `@scope/my-package/foo`
 - `@scope/my-package/other`
 
-### Publishing workspace packages to registries
+## Publishing workspace packages to registries
 
 Workspaces make it easy to publish packages to registries like JSR or NPM. You
 can publish individual workspace members while keeping their development
@@ -357,7 +357,7 @@ When publishing packages that depend on other workspace members, Deno will
 automatically replace workspace references with proper registry references in
 the published code.
 
-### Migrating from `npm` workspaces
+## Migrating from `npm` workspaces
 
 Deno workspaces support using a Deno-first package from an existing npm package.
 In this example, we mix and match a Deno library called `@deno/hi`, with a

--- a/runtime/lint_and_format/index.md
+++ b/runtime/lint_and_format/index.md
@@ -6,17 +6,17 @@ oldUrl:
   - /runtime/fundamentals/linting_and_formatting/
 ---
 
-In an ideal world, your code is always clean, consistent, and free of pesky
-errors. That's the promise of Deno's built-in linting and formatting tools. By
-integrating these features directly into the runtime, Deno eliminates the need
-for external dependencies and complex configurations in your projects. These
-inbuilt tools are fast and performant, not only saving time but also ensuring
-that every line of code adheres to best practices.
+Deno ships a linter and a formatter in the `deno` binary. No packages to
+install, no config files required:
 
-With `deno fmt` and `deno lint`, you can focus on writing great code, knowing
-that Deno has your back. It's like having a vigilant assistant who keeps your
-codebase in top shape, allowing you to concentrate on what truly matters:
-building amazing applications.
+```sh
+deno lint    # catch bugs and anti-patterns
+deno fmt     # format code, markdown, and JSON
+```
+
+Both are fast, run the same way locally and in CI, and are configured (when you
+need to configure anything at all) in the same `deno.json` as the rest of your
+project.
 
 ## Linting
 
@@ -44,6 +44,37 @@ deno lint src/
 ```
 
 This command will lint all files in the `src/` directory.
+
+A finding shows the rule name, the offending code, and a hint:
+
+```console
+$ deno lint main.ts
+error[require-await]: Async function 'fetchData' has no 'await' expression
+ --> /project/main.ts:1:1
+  |
+1 | async function fetchData() {
+  | ^^^^^
+  = hint: Remove 'async' keyword from the function or use 'await' expression inside.
+
+  docs: https://docs.deno.com/lint/rules/require-await
+
+Found 1 problem
+Checked 1 file
+```
+
+Some rules can fix the problem for you: run `deno lint --fix` to apply those
+fixes automatically. To silence a rule for one line, add an ignore directive
+naming the rule above it:
+
+```ts
+// deno-lint-ignore require-await
+async function fetchData() {
+  return "data";
+}
+```
+
+See the [`deno lint` reference](/runtime/reference/cli/lint/) for all flags and
+directive forms.
 
 The linter can be configured in a
 [`deno.json`](/runtime/reference/deno_json/#linting) file. You can specify


### PR DESCRIPTION
Two structural polish items from the content review. The lint and format
guide opened with two paragraphs of filler ("it's like having a vigilant
assistant") before the reader learned anything actionable; it now opens with
the two commands, shows what a real lint finding looks like (output captured
from an actual deno lint run), and covers deno lint --fix and per-line
ignore directives, linking the reference for the rest.

In the workspaces guide, "Multiple package entries", "Publishing workspace
packages to registries", and "Migrating from npm workspaces" were nested
under "How Deno resolves workspace dependencies", where they don't belong
and were invisible in the table of contents. They are top-level sections
now. No anchor was referenced externally, so no links break.