### PR TITLE
docs: fix deno clean --except and flesh out thin CLI pages

### DIFF
--- a/runtime/reference/cli/bundle.md
+++ b/runtime/reference/cli/bundle.md
@@ -9,7 +9,7 @@ info: "`deno bundle` is currently an experimental subcommand and is subject to c
 ---
 
 `deno bundle` combines your module and all of its dependencies into a single
-JavaScript file.
+JavaScript file, using [esbuild](https://esbuild.github.io/) under the hood.
 
 ## Basic usage
 
@@ -17,10 +17,33 @@ JavaScript file.
 deno bundle -o output.js main.ts
 ```
 
-The output file can then be run with Deno or in other JavaScript runtimes:
+Without `-o`/`--output`, the bundle is written to standard output. The output
+file can then be run with Deno or in other JavaScript runtimes:
 
 ```sh
 deno run output.js
+```
+
+## Common options
+
+Target a platform with `--platform` (`deno` by default, or `browser`), shrink
+the output with `--minify`, and emit source maps with `--sourcemap`:
+
+```sh
+deno bundle --platform=browser --minify --sourcemap -o dist/app.js main.ts
+```
+
+Split shared code into separate chunks with `--code-splitting` and an output
+directory:
+
+```sh
+deno bundle --code-splitting --outdir dist/ main.ts worker.ts
+```
+
+Keep a dependency out of the bundle with `--external`:
+
+```sh
+deno bundle --external npm:sharp -o output.js main.ts
 ```
 
 For more on bundling strategies with Deno, see the

--- a/runtime/reference/cli/clean.md
+++ b/runtime/reference/cli/clean.md
@@ -25,12 +25,13 @@ Preview what would be deleted without actually removing anything:
 deno clean --dry-run
 ```
 
-## Keeping specific caches
+## Keeping what a project still needs
 
-Use `--except` to preserve certain cache types while cleaning the rest:
+Use `--except` with one or more entry points to remove everything from the cache
+except the data those files need:
 
 ```sh
-deno clean --except=npm,jsr
+deno clean --except main.ts
 ```
 
 ## When to use this

--- a/runtime/reference/cli/lsp.md
+++ b/runtime/reference/cli/lsp.md
@@ -2,6 +2,10 @@
 last_modified: 2024-10-07
 title: "deno lsp"
 oldUrl: /runtime/manual/tools/lsp/
+command: lsp
+openGraphLayout: "/open_graph/cli-commands.jsx"
+openGraphTitle: "deno lsp"
+description: "Start the Deno language server, used by editors for IntelliSense, formatting, and diagnostics"
 ---
 
 :::info

--- a/runtime/reference/cli/remove.md
+++ b/runtime/reference/cli/remove.md
@@ -29,3 +29,6 @@ deno remove @std/path @std/assert npm:express
 `deno remove` will look at both
 [`deno.json`](/runtime/fundamentals/configuration/) and `package.json` (if
 present) and remove the matching dependency from whichever file it is found in.
+
+Removing a dependency does not delete it from the global cache. To reclaim disk
+space, see [`deno clean`](/runtime/reference/cli/clean/).


### PR DESCRIPTION
The deno clean page documented --except=npm,jsr as keeping cache types,
which is not what the flag does: --except takes entry-point files and
retains the cache those files need (verified by running it; the documented
form errors out). Fixed with the real semantics.

While in the thin CLI pages: deno bundle now covers what the command can
actually do beyond one example (stdout default, --platform/--minify/
--sourcemap, code splitting with --outdir, --external; all taken from the
current --help), deno lsp gains the command frontmatter so the generated
flag reference renders like every other command page, and deno remove notes
that removal does not reclaim cache space, linking deno clean.