### PR TITLE
docs: opt-in sidebar disclosure for groups with landing pages

### DIFF
--- a/_components/SidebarNav/comp.tsx
+++ b/_components/SidebarNav/comp.tsx
@@ -26,7 +26,9 @@ export default function (data: Lume.Data) {
             <SidebarList>
               {nav.items?.map((item: any) => (
                 <li key={item.href}>
-                  {item.items && item.items.length > 0
+                  {item.items && item.items.length > 0 && item.disclosure
+                    ? <SidebarDisclosure item={item} currentUrl={currentUrl} />
+                    : item.items && item.items.length > 0
                     ? (
                       <>
                         <button
@@ -65,6 +67,94 @@ export default function (data: Lume.Data) {
         </nav>
       ))}
     </>
+  );
+}
+
+// Opt-in (item.disclosure = true in a section's _data.ts) group pattern for
+// sections whose group item has its own landing page: the label is a normal
+// link and a separate chevron button toggles the children. Groups that do
+// not opt in keep the existing accordion above, untouched. The active
+// trail's open state is rendered on the server, so there is no expand flash.
+function SidebarDisclosure(
+  props: { item: any; currentUrl: string },
+) {
+  const { item, currentUrl } = props;
+  const groupId = `sidebar-group-${
+    String(item.href || item.title).replace(/[^a-zA-Z0-9]+/g, "-").replace(
+      /^-|-$/g,
+      "",
+    ).toLowerCase()
+  }`;
+  const selfActive = Boolean(
+    item.href && item.href.replace(/\/$/, "") === currentUrl,
+  );
+  const childActive = item.items.some(
+    (sub: any) => sub.href && sub.href.replace(/\/$/, "") === currentUrl,
+  );
+  const open = selfActive || childActive;
+
+  const chevron = (
+    <svg
+      class="sidebar-disclosure-chevron"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      fill="none"
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+    >
+      <path
+        d="M6 4l4 4-4 4"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+
+  return (
+    <div class="sidebar-disclosure" data-disclosure data-open={String(open)}>
+      <div class="sidebar-disclosure-row flex items-stretch">
+        <a
+          href={item.href}
+          className={`grow block m-0 py-2 px-3 border-l hover:bg-header-highlight hover:border-foreground-secondary hover:text-gray-800 transition-colors duration-150 ${
+            selfActive
+              ? "bg-header-highlight text-gray-800 border-foreground-secondary"
+              : "border-foreground-tertiary"
+          }`}
+          data-active={selfActive}
+        >
+          {item.title}
+        </a>
+        <button
+          type="button"
+          class="sidebar-disclosure-btn"
+          data-disclosure-toggle
+          aria-expanded={String(open)}
+          aria-controls={groupId}
+          aria-label={`Toggle ${item.title} pages`}
+        >
+          {chevron}
+        </button>
+      </div>
+      <ul
+        id={groupId}
+        class="sidebar-disclosure-list p-0 list-none"
+        hidden={!open}
+      >
+        {item.items.map((subItem: any) => (
+          <li key={subItem.href}>
+            <SidebarItem
+              title={subItem.title}
+              href={subItem.href}
+              isActive={subItem.href.replace(/\/$/, "") === currentUrl}
+              nested
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }
 

--- a/_components/SidebarNav/script.js
+++ b/_components/SidebarNav/script.js
@@ -60,6 +60,40 @@ if (sidebar) {
   });
 }
 
+if (sidebar) {
+  // Opt-in disclosure groups (item.disclosure in a section's _data.ts).
+  // Each group is independent: opening one never closes another. The server
+  // renders the active trail open; other groups restore the user's last
+  // choice from localStorage, defaulting to collapsed. The legacy accordion
+  // above is untouched and handles all non-opted-in groups.
+  sidebar.querySelectorAll("[data-disclosure]").forEach((group) => {
+    const list = group.querySelector(":scope > ul");
+    const buttons = group.querySelectorAll("[data-disclosure-toggle]");
+    if (!list) return;
+    const storageKey = `sidebar-open:${list.id}`;
+
+    const setOpen = (open, persist) => {
+      group.setAttribute("data-open", String(open));
+      list.hidden = !open;
+      buttons.forEach((b) => b.setAttribute("aria-expanded", String(open)));
+      if (persist) localStorage.setItem(storageKey, String(open));
+    };
+
+    if (
+      group.getAttribute("data-open") !== "true" &&
+      localStorage.getItem(storageKey) === "true"
+    ) {
+      setOpen(true, false);
+    }
+
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        setOpen(group.getAttribute("data-open") !== "true", true);
+      });
+    });
+  });
+}
+
 // Wire up the hamburger toggle button
 if (sidebar && button) {
   button.addEventListener("click", () => {

--- a/style.css
+++ b/style.css
@@ -1549,6 +1549,48 @@
     padding-bottom: 1rem;
   }
 
+  /* Opt-in sidebar disclosure groups (item.disclosure in _data.ts): label is
+     a link, the chevron button is the only toggle. Visual treatment kept
+     minimal pending the styling overhaul. Legacy .sub-nav-toggle accordions
+     above are unaffected. */
+  .sidebar-disclosure {
+    .sidebar-disclosure-btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      width: 2rem;
+      flex-shrink: 0;
+      cursor: pointer;
+      color: var(--color-foreground-secondary);
+
+      &:hover {
+        background-color: var(--color-header-highlight);
+        color: var(--color-gray-800);
+      }
+    }
+
+    .sidebar-disclosure-chevron {
+      transition: transform 0.1s ease-in;
+    }
+
+    &[data-open="true"] .sidebar-disclosure-chevron {
+      transform: rotate(90deg);
+    }
+
+    .sidebar-disclosure-list {
+      margin-left: 1rem !important;
+      border-left: 1px solid var(--color-foreground-tertiary);
+    }
+
+    &[data-open="true"] {
+      padding-bottom: 0.5rem;
+    }
+
+    &[data-open="true"] > .sidebar-disclosure-row > a {
+      font-weight: 600;
+    }
+  }
+
   #hamburger-button[aria-pressed="true"] {
     .hamburger-bar--top {
       transform: translate(0, 0.4375rem) rotate(45deg);

--- a/types.ts
+++ b/types.ts
@@ -60,6 +60,10 @@ export interface SidebarItem {
   label?: string;
   href?: string;
   items?: SidebarItem[];
+  // Opt in to the link-plus-chevron disclosure rendering for a group whose
+  // item has its own landing page. Groups without this keep the legacy
+  // accordion (CLI reference, Standard library).
+  disclosure?: boolean;
   externalUrl?: string;
   type?: "video" | "example" | "tutorial";
 }


### PR DESCRIPTION
On #3220's preview, the "Testing" sidebar item has a landing page but is not
clickable: items with children render as an accordion button that swallows
the href. This adds a new, opt-in pattern instead of changing the existing
accordions: a group item with disclosure: true in its section's _data.ts
renders its label as a normal link (hover, active state, navigates to the
hub) with a separate chevron button that toggles the children. Opted-in
groups are independent of one another, the active trail is rendered open by
the server (no expand flash), everything else defaults to collapsed, and
manual toggles are remembered per group.

Nothing in this PR opts in, so the CLI reference and Standard library render
byte-for-byte as before (verified in the built output: legacy accordion
markup present, zero traces of the new pattern). #3220 adds disclosure: true
to its Testing item in a follow-up commit, which is where the new behavior
becomes visible. Visual polish is deliberately minimal, pending the styling
overhaul.