### PR TITLE
docs: version-callout policy, drifted descriptions, anchor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ summary table when it links to the full reference. When the same material exists
 in both kinds of page, move the depth to the reference and keep the narrative in
 the guide.
 
+### Mark version-specific behavior
+
+When documenting behavior that was added or changed in a specific Deno version,
+say so where it's documented: use an info admonition titled with the version
+(`:::info Deno 2.8`) for a behavior change worth a callout, or an inline "(Deno
+2.8+)" for a brief mention. This keeps pages visibly current, matches how people
+search ("what's new in Deno 2.8"), and tells readers on older versions why
+something doesn't work for them. Don't version-mark behavior older than the
+previous major release.
+
 ## Reference docs
 
 The reference docs served at `/api` are generated via the `deno doc` subcommand.

--- a/runtime/fundamentals/debugging.md
+++ b/runtime/fundamentals/debugging.md
@@ -1,7 +1,7 @@
 ---
 last_modified: 2026-05-20
 title: "Debugging"
-description: "Complete guide to debugging Deno applications. Learn to use Chrome DevTools, VS Code debugger, and other debugging techniques for TypeScript/JavaScript code in Deno."
+description: "Debug Deno programs with the V8 inspector: Chrome DevTools, VS Code and JetBrains setup, network inspection, worker debugging, and the --inspect flag family."
 oldUrl:
   - /runtime/manual/getting_started/debugging_your_code/
   - /runtime/manual/basics/debugging_your_code/

--- a/runtime/packages/supply_chain.md
+++ b/runtime/packages/supply_chain.md
@@ -78,7 +78,7 @@ absolute cutoff date (`2025-09-16`) or RFC3339 timestamp, or `0` to disable. The
 field also supports an object form that exempts specific packages; see the
 [`minimumDependencyAge` reference](/runtime/reference/deno_json/#minimum-dependency-age)
 for the full shape, and
-[`.npmrc` configuration](/runtime/fundamentals/node/#npmrc-configuration) for
+[`.npmrc` configuration](/runtime/fundamentals/node/#.npmrc-configuration) for
 the other npm-registry options Deno reads.
 
 ## Typical CI pattern

--- a/runtime/reference/deno_json.md
+++ b/runtime/reference/deno_json.md
@@ -345,7 +345,7 @@ To exempt specific packages, use the object form with an `exclude` list:
 
 The same control is available as the `--minimum-dependency-age` CLI flag and as
 `min-release-age` in
-[`.npmrc`](/runtime/fundamentals/node/#npmrc-configuration).
+[`.npmrc`](/runtime/fundamentals/node/#.npmrc-configuration).
 
 ## Node modules directory
 

--- a/runtime/test/index.md
+++ b/runtime/test/index.md
@@ -1,7 +1,7 @@
 ---
 last_modified: 2026-05-20
 title: "Testing"
-description: "A guide to Deno's testing capabilities. Learn about the built-in test runner, assertions, mocking, coverage reporting, snapshot testing, and how to write effective tests for your Deno applications."
+description: "Write and run tests with Deno's built-in test runner: assertions, test steps, hooks, filtering, and reporters, with dedicated guides for mocking, snapshots, and coverage."
 oldUrl:
   - /runtime/fundamentals/testing/
   - /runtime/manual/basics/testing/


### PR DESCRIPTION
Three small consistency items. The README gains a "Mark version-specific
behavior" convention next to the ownership rule: an info admonition titled
with the version for notable changes, inline "(Deno 2.8+)" for brief
mentions, and no version-marking for behavior older than the previous major
release. Two meta descriptions that drifted from their restructured pages
are updated: the testing hub no longer promises in-page mocking/snapshot/
coverage depth (those are spokes now) and the debugging page stops calling
itself a complete guide post-CPU-profiling split. And two links to the
.npmrc configuration section on the Node page pointed at #npmrc-configuration
while the generated id is #.npmrc-configuration (the slugifier keeps the
leading dot, confirmed in the built output), so they never scrolled; fixed.