### PR TITLE
docs: Node compatibility rewrite, version C (task recipes)

### DIFF
--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-20
+last_modified: 2026-06-12
 title: "Node and npm Compatibility"
 description: "Guide to using Node.js modules and npm packages in Deno. Learn about compatibility features, importing npm packages, and differences between Node.js and Deno environments."
 oldUrl:
@@ -15,54 +15,82 @@ oldUrl:
   - /runtime/manual/node/private_registries
 ---
 
-Deno is Node-compatible: most Node.js projects will run in Deno with little or
-no change. You can import npm packages with the `npm:` specifier, use Node's
-built-in modules through `node:` specifiers, and keep your existing
-`package.json`. No `npm install` step is required before running your code.
+You have Node.js code or npm dependencies and you want them running under Deno.
+This page is a set of recipes, one per task: each starts with a working example,
+then covers the rules behind it and what to do when it doesn't work. Start with
+the task in front of you.
 
-```ts title="main.ts"
-import chalk from "npm:chalk@5";
-console.log(chalk.green("Hello from npm in Deno"));
+## Using npm packages
+
+To use a package from npm, import it with an `npm:` prefix and run the file:
+
+```ts title="main.js"
+import * as emoji from "npm:node-emoji";
+
+console.log(emoji.emojify(`:sauropod: :heart:  npm`));
 ```
 
 ```sh
-deno run main.ts
+$ deno run main.js
+🦕 ❤️ npm
 ```
 
+Deno downloads the package on first run and stores it in a global cache, so your
+project directory stays clean. The full specifier format is:
+
+```console
+npm:<package-name>[@<version-requirement>][/<sub-path>]
+```
+
+A few rules to know:
+
+- npm packages run under the same
+  [permission system](/runtime/fundamentals/security/) as the rest of your code.
+  If a package reads files or environment variables, grant `-R` or `-E` (or
+  answer the permission prompts).
+- You can declare dependencies in `package.json` or in the `imports` map of
+  `deno.json` instead of writing `npm:` specifiers inline. See
+  [Run an existing Node project](#run-an-existing-node-project).
+- If a package fails with errors about missing files inside `node_modules`, it
+  expects a local `node_modules` directory. See
+  [Control node_modules](#control-node_modules).
+
+For examples with popular libraries, refer to the
+[tutorial section](/runtime/tutorials).
+
+## How compatible is it?
+
 As of Deno 2.8, **over 75% of Node's own test suite passes** in Deno, covering
-nearly every `node:` module. You can track the current state at
+nearly every `node:` module. Most pure-JavaScript npm packages work without
+changes. The honest caveats: some APIs are partial, packages with native addons
+need a local `node_modules` directory, and a few tools assume npm's exact
+on-disk layout. The recipes below cover each of those cases.
+
+You can track the current state at
 [node-test-viewer.deno.dev](https://node-test-viewer.deno.dev/) and browse the
 [list of supported Node.js APIs](/runtime/reference/node_apis/).
 
-That's all you really need to know to get started. The rest of this page covers
-the details, along with some key differences between the two runtimes that you
-can take advantage of to make your code simpler and smaller when migrating your
-Node.js projects to Deno.
+## Use a Node built-in module
 
-## Using Node's built-in modules
+Deno provides Node's built-in APIs through a compatibility layer. Import them
+with the `node:` prefix:
 
-Deno provides a compatibility layer that allows the use of Node.js built-in APIs
-within Deno programs. However, in order to use them, you will need to add the
-`node:` specifier to any import statements that use them:
-
-```js title=main.mjs
+```js title="main.mjs"
 import * as os from "node:os";
 console.log(os.cpus());
 ```
 
 Run it with `deno run main.mjs` and you will get the same output as running the
-program in Node.js.
+program in Node.js. Updating any imports in your application to use `node:`
+specifiers should enable any code using Node built-ins to function as it did in
+Node.js.
 
-Updating any imports in your application to use `node:` specifiers should enable
-any code using Node built-ins to function as it did in Node.js.
+The `node:module` built-in includes the
+[`registerHooks()`](/runtime/reference/loader_hooks/) API, which you can use to
+customize module resolution and loading from inside your program.
 
-To make updating existing code easier, Deno will provide helpful hints for
-imports that don't use the `node:` prefix:
-
-```js title="main.mjs"
-import * as os from "os";
-console.log(os.cpus());
-```
+**If it doesn't work:** a bare import like `import * as os from "os"` fails,
+because the `node:` prefix is required. Deno tells you how to fix it:
 
 ```sh
 $ deno run main.mjs
@@ -74,147 +102,74 @@ error: Import "os" not a dependency
 The same hints and additional quick-fixes are provided by the Deno LSP in your
 editor.
 
-The `node:module` built-in includes the
-[`registerHooks()`](/runtime/reference/loader_hooks/) API, which you can use to
-customize module resolution and loading from inside your program.
-
 <a href="/api/node/" class="docs-cta runtime-cta">Explore built-in Node APIs</a>
 
-## Using npm packages
+## Use Node globals like process and Buffer
 
-Deno has native support for importing npm packages by using `npm:` specifiers,
-which have the following format:
-
-```console
-npm:<package-name>[@<version-requirement>][/<sub-path>]
-```
-
-For example:
-
-```ts title="main.js"
-import * as emoji from "npm:node-emoji";
-
-console.log(emoji.emojify(`:sauropod: :heart:  npm`));
-```
-
-Can be run with:
-
-```sh
-$ deno run main.js
-🦕 ❤️ npm
-```
-
-No `npm install` is necessary before the `deno run` command and no
-`node_modules` folder is created: dependencies are stored in Deno's global
-cache. These packages are also subject to the same
-[permissions](/runtime/fundamentals/security/) as other code in Deno. If your
-tools expect a local `node_modules` directory, see
-[node_modules](#node_modules).
-
-npm specifiers also allow functionality that may be familiar from the `npx`
-command.
-
-```console
-# npx allows remote execution of a package from npm or a URL
-$ npx create-next-app@latest
-
-# deno run allows remote execution of a package from various locations,
-# and can scoped to npm via the `npm:` specifier.
-$ deno run -A npm:create-next-app@latest
-```
-
-For examples with popular libraries, please refer to the
-[tutorial section](/runtime/tutorials).
-
-### First-class package.json support
-
-Deno understands `package.json` in your project. You can:
-
-- Declare dependencies there (alongside or instead of inline `npm:` specifiers).
-- Use scripts from `package.json` via `deno task` (for example,
-  `deno task start`).
-- Rely on `package.json` fields like `type` when resolving modules (see
-  [CommonJS support](#commonjs-support)).
-
-## Node.js global objects
-
-In Node.js, there are a number of
-[global objects](https://nodejs.org/api/globals.html) available in the scope of
-all programs that are specific to Node.js, eg. `process` object.
-
-Here are a few globals that you might encounter in the wild and how to use them
+Node.js defines a number of
+[global objects](https://nodejs.org/api/globals.html) that are available in the
+scope of all programs. Here is how the ones you are most likely to meet behave
 in Deno:
 
-- `process` - Deno provides the `process` global, which is by far the most
-  popular global used in popular npm packages. It is available to all code. Deno
-  can also guide you towards importing it explicitly from `node:process`. Opt in
-  by enabling the [`no-process-global`](/lint/rules/no-process-global/) lint
-  rule (off by default since Deno 2.8); `deno lint` will then flag uses of the
-  global:
+- `process` is available as a global, no import needed. It is by far the most
+  used Node global in npm packages:
 
-```js title="process.js"
-console.log(process.versions.deno);
-```
+  ```js title="process.js"
+  console.log(process.versions.deno);
+  ```
 
-```shell
-$ deno run process.js
-2.8.3
-$ deno lint process.js
-error[no-process-global]: NodeJS process global is discouraged in Deno
- --> /process.js:1:13
-  |
-1 | console.log(process.versions.deno);
-  |             ^^^^^^^
-  = hint: Add `import process from "node:process";`
+  ```shell
+  $ deno run process.js
+  2.8.3
+  ```
 
-  docs: https://docs.deno.com/lint/rules/no-process-global
+  If you prefer explicit imports from `node:process`, enable the
+  [`no-process-global`](/lint/rules/no-process-global/) lint rule (off by
+  default since Deno 2.8) and `deno lint` will flag uses of the global:
+
+  ```shell
+  $ deno lint process.js
+  error[no-process-global]: NodeJS process global is discouraged in Deno
+   --> /process.js:1:13
+    |
+  1 | console.log(process.versions.deno);
+    |             ^^^^^^^
+    = hint: Add `import process from "node:process";`
+
+    docs: https://docs.deno.com/lint/rules/no-process-global
 
 
-Found 1 problem (1 fixable via --fix)
-Checked 1 file
-```
+  Found 1 problem (1 fixable via --fix)
+  Checked 1 file
+  ```
 
-- `require()` - see [CommonJS support](#commonjs-support)
+- `Buffer` is not a global by default. Import it from `node:buffer`:
 
-- `Buffer` - to use `Buffer` API it needs to be explicitly imported from the
-  `node:buffer` module:
+  ```js title="buffer.js"
+  import { Buffer } from "node:buffer";
 
-```js title="buffer.js"
-import { Buffer } from "node:buffer";
+  const buf = new Buffer(5, "0");
+  ```
 
-const buf = new Buffer(5, "0");
-```
+  Prefer using
+  [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)
+  or other
+  [`TypedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
+  subclasses instead.
 
-For TypeScript users needing Node.js-specific types like `BufferEncoding`, these
-are available through the `NodeJS` namespace when using `@types/node`:
+- `require()` is covered in [CommonJS support](#commonjs-support).
 
-```ts title="buffer-types.ts"
-/// <reference types="npm:@types/node" />
+- `__filename`: use `import.meta.filename` instead.
 
-// Now you can use NodeJS namespace types
-function writeToBuffer(data: string, encoding: NodeJS.BufferEncoding): Buffer {
-  return Buffer.from(data, encoding);
-}
-```
+- `__dirname`: use `import.meta.dirname` instead.
 
-Prefer using
-[`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array)
-or other
-[`TypedArray`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray)
-subclasses instead.
-
-- `__filename` - use `import.meta.filename` instead.
-
-- `__dirname` - use `import.meta.dirname` instead.
-
-- `setTimeout` / `setInterval` - starting in Deno 2.8, the global timer
-  functions return a Node.js
-  [`Timeout`](https://nodejs.org/api/timers.html#class-timeout) object instead
-  of a number, matching Node.js semantics. The returned object exposes methods
-  like `.ref()`, `.unref()`, `.refresh()`, and `.hasRef()`. It still coerces to
-  a number (via `Symbol.toPrimitive`), so existing code that stores the timer ID
-  as a number or passes it to `clearTimeout`/`clearInterval` continues to work
-  unchanged.
+- `setTimeout` / `setInterval`: starting in Deno 2.8, the global timer functions
+  return a Node.js [`Timeout`](https://nodejs.org/api/timers.html#class-timeout)
+  object instead of a number, matching Node.js semantics. The returned object
+  exposes methods like `.ref()`, `.unref()`, `.refresh()`, and `.hasRef()`. It
+  still coerces to a number (via `Symbol.toPrimitive`), so existing code that
+  stores the timer ID as a number or passes it to `clearTimeout`/`clearInterval`
+  continues to work unchanged.
 
   ```ts
   const t = setTimeout(() => {}, 1000);
@@ -222,26 +177,143 @@ subclasses instead.
   clearTimeout(t);
   ```
 
+## Run an existing Node project
+
+Deno understands `package.json`, so a typical Node project runs with two
+commands: one to install, one to run.
+
+```json title="package.json"
+{
+  "type": "module",
+  "scripts": {
+    "start": "node main.js"
+  },
+  "dependencies": {
+    "chalk": "^5"
+  }
+}
+```
+
+```js title="main.js"
+import chalk from "chalk";
+console.log(chalk.green("ready"));
+```
+
+```sh
+$ deno install
+$ deno run -R -E main.js
+ready
+```
+
+`deno install` reads `package.json` and creates a `node_modules` directory, so
+bare imports like `"chalk"` resolve just as they do in Node. The `-R` and `-E`
+flags grant the read and environment access that resolving `node_modules` (and
+chalk's color detection) need.
+
+What carries over from your `package.json`:
+
+- **Dependencies** declared there are installed by `deno install` and importable
+  by bare specifier.
+- **Scripts** run via `deno task`, like `npm run`: `deno task start` runs the
+  `start` script. Scripts execute in Deno's built-in cross-platform shell, and
+  CLI tools installed in `node_modules/.bin` (test runners, bundlers, linters)
+  resolve automatically. The commands themselves still run whatever executables
+  they name, so a script that invokes `node` runs Node.
+- **Fields** like `"type"` are respected when resolving modules (see
+  [CommonJS support](#commonjs-support)).
+
+Projects with a `package.json` default to the manual `node_modules` mode, which
+is why the explicit `deno install` step is needed. The
+[Control node_modules](#control-node_modules) recipe covers the alternatives.
+
+For a full checklist, optional toolchain improvements, and a Node-to-Deno
+command cheatsheet, see the
+[Migrating from Node.js to Deno guide](/runtime/migrate/).
+
+## Run an npm CLI tool
+
+You can run npm CLI tools (packages with `bin` entries) directly, the way you
+would with `npx`:
+
+```sh
+$ deno run -R -E npm:cowsay@1.5.0 "Hello there!"
+ ______________
+< Hello there! >
+ --------------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+```
+
+The specifier format accepts a subpath that selects a specific binary when a
+package ships several:
+
+```console
+npm:<package-name>[@<version-requirement>][/<binary-name>]
+```
+
+For example, `deno run -R -E npm:cowsay@1.5.0/cowthink` runs the `cowthink`
+binary from the same package. Scaffolding tools work the same way; this pair of
+commands is equivalent:
+
+```console
+# npx allows remote execution of a package from npm or a URL
+$ npx create-next-app@latest
+
+# deno run allows remote execution of a package from various locations,
+# and can be scoped to npm via the `npm:` specifier.
+$ deno run -A npm:create-next-app@latest
+```
+
+**If it doesn't work:** tools that read files or environment variables stop at a
+permission prompt (or fail in CI). Grant the specific permissions the tool
+needs, or `-A` for trusted scaffolding tools that need broad access.
+
 ## CommonJS support
 
-Deno supports CommonJS modules by default. When using CommonJS, Deno expects
-that dependencies will be installed manually and a `node_modules` directory will
-be present. It's best to set `"nodeModulesDir": "auto"` in your `deno.json` to
-ensure that (see [node_modules](#node_modules)).
+Deno supports CommonJS modules by default. Here is the smallest working setup
+for a `.cjs` file with an npm dependency:
 
-Deno's permission system also applies to CommonJS code. You typically need the
-`-R` (`--allow-read`) and `-E` (`--allow-env`) flags, because Deno probes
-`package.json` files and the `node_modules` directory to resolve CommonJS
-modules.
-
-### How Deno determines module type
-
-If the file extension is `.cjs`, Deno will treat the module as CommonJS, without
-consulting `package.json`:
+```json title="deno.json"
+{
+  "nodeModulesDir": "auto"
+}
+```
 
 ```js title="main.cjs"
 const express = require("express");
 ```
+
+```shell
+$ deno install npm:express
+Dependencies:
++ npm:express 5.2.1
+
+$ deno run -R -E main.cjs
+[Function: createApplication] {
+  application: {
+    init: [Function: init],
+    defaultConfiguration: [Function: defaultConfiguration],
+    ...
+  }
+}
+```
+
+Two requirements drive this recipe. CommonJS resolution expects dependencies to
+be installed in a local `node_modules` directory, which
+`"nodeModulesDir":
+"auto"` ensures (see
+[Control node_modules](#control-node_modules)). And Deno's permission system
+applies to CommonJS code too: you typically need `-R` (`--allow-read`) and `-E`
+(`--allow-env`), because Deno probes `package.json` files and the `node_modules`
+directory to resolve CommonJS modules.
+
+### How Deno decides a file is CommonJS
+
+If the file extension is `.cjs`, Deno treats the module as CommonJS without
+consulting `package.json`.
 
 Deno will also attempt to load `.js`, `.jsx`, `.ts`, and `.tsx` files as
 CommonJS if there's a `package.json` file with the `"type": "commonjs"` option
@@ -270,32 +342,9 @@ use of CommonJS. You can opt into this detection by running with the
 `--unstable-detect-cjs` flag in Deno >= 2.1.2. It takes effect except when
 there's a `package.json` file with `{ "type": "module" }`.
 
-### Using require()
+### Call require() from an ES module
 
-To run the `.cjs` example above, install the dependency and pass the read and
-env permission flags:
-
-```shell
-$ cat deno.json
-{
-  "nodeModulesDir": "auto"
-}
-
-$ deno install npm:express
-Dependencies:
-+ npm:express 5.2.1
-
-$ deno run -R -E main.cjs
-[Function: createApplication] {
-  application: {
-    init: [Function: init],
-    defaultConfiguration: [Function: defaultConfiguration],
-    ...
-  }
-}
-```
-
-In ES modules, you can create an instance of the `require()` function manually:
+You can create an instance of the `require()` function manually:
 
 ```js title="main.js"
 import { createRequire } from "node:module";
@@ -307,7 +356,7 @@ In this scenario the same requirements apply as when running `.cjs` files:
 dependencies need to be installed manually and appropriate permission flags
 given.
 
-### CommonJS and ESM interop
+### Mix CommonJS and ES modules
 
 Deno's `require()` implementation supports requiring ES modules. This works the
 same as in Node.js, where you can only `require()` ES modules that don't have
@@ -338,7 +387,7 @@ $ deno run -R main.cjs
 Hello Deno
 ```
 
-You can also import CommonJS files in ES modules:
+The other direction works too. You can import CommonJS files in ES modules:
 
 ```js title="greet.cjs"
 module.exports = {
@@ -356,188 +405,29 @@ $ deno run main.js
 { hello: "world" }
 ```
 
-### Troubleshooting
-
-Deno will guide you when a file looks like CommonJS but isn't loaded as such. If
-you see an error about `module` not being defined, fix it by one of the
-following:
+**If it doesn't work:** Deno will guide you when a file looks like CommonJS but
+isn't loaded as such. If you see an error about `module` not being defined, fix
+it by one of the following:
 
 - Rewrite the code to ESM
 - Change the file extension to `.cjs`
 - Add a nearby `package.json` with `{ "type": "commonjs" }`
 - Run with `--unstable-detect-cjs`
 
-## Conditional exports
-
-Package exports can be
-[conditioned](https://nodejs.org/api/packages.html#conditional-exports) on the
-resolution mode. The conditions satisfied by an import from a Deno ESM module
-are as follows:
-
-```json
-["deno", "node", "import", "module-sync", "default"]
-```
-
-This means that the first condition listed in a package export whose key equals
-any of these strings will be matched. For `require()` resolution, including
-`createRequire()`, the conditions are:
-
-```json
-["require", "node", "module-sync", "default"]
-```
-
-Deno also applies `module-sync` when analyzing CommonJS modules that re-export
-through `require()`.
-
-You can expand the import conditions list using the `--conditions` CLI flag:
-
-```shell
-deno run --conditions development,react-server main.ts
-```
-
-```json
-[
-  "development",
-  "react-server",
-  "deno",
-  "node",
-  "import",
-  "module-sync",
-  "default"
-]
-```
-
-## Importing types
-
-Many npm packages ship with types, you can import these and use them with types
-directly:
-
-```ts
-import chalk from "npm:chalk@5";
-```
-
-Some packages do not ship with types but you can specify their types with the
-[`@ts-types`](/runtime/fundamentals/typescript) directive. For example, using a
-[`@types`](https://www.typescriptlang.org/docs/handbook/2/type-declarations.html#definitelytyped--types)
-package:
-
-```ts
-// @ts-types="npm:@types/express@^4.17"
-import express from "npm:express@^4.17";
-```
-
-### Module resolution
-
-The official TypeScript compiler `tsc` supports different
-[moduleResolution](https://www.typescriptlang.org/tsconfig#moduleResolution)
-settings. Deno only supports the modern `node16` resolution. Unfortunately many
-npm packages fail to correctly provide types under node16 module resolution,
-which can result in `deno check` reporting type errors, that `tsc` does not
-report.
-
-If a default export from an `npm:` import appears to have a wrong type (with the
-right type seemingly being available under the `.default` property), it's most
-likely that the package provides wrong types under node16 module resolution for
-imports from ESM. You can verify this by checking if the error also occurs with
-`tsc --module node16` and `"type": "module"` in `package.json` or by consulting
-the [Are the types wrong?](https://arethetypeswrong.github.io/) website
-(particularly the "node16 from ESM" row).
-
-If you want to use a package that doesn't support TypeScript's node16 module
-resolution, you can:
-
-1. Open an issue at the issue tracker of the package about the problem. (And
-   perhaps contribute a fix :) (Although, unfortunately, there is a lack of
-   tooling for packages to support both ESM and CJS, since default exports
-   require different syntaxes. See also
-   [microsoft/TypeScript#54593](https://github.com/microsoft/TypeScript/issues/54593))
-2. Use a [CDN](/runtime/fundamentals/modules/#url_imports), that rebuilds the
-   packages for Deno support, instead of an `npm:` identifier.
-3. Ignore the type errors you get in your code base with `// @ts-expect-error`
-   or `// @ts-ignore`.
-
-## Including Node types
-
-Starting in Deno 2.8, `deno check` and the LSP include `lib.node` in every
-type-check by default, so Node ambient types like `Buffer`, `NodeJS.Timeout`,
-and `process` resolve without any configuration:
-
-```ts
-// 2.8+: type-checks with no extra setup
-const buf: Buffer = Buffer.from("hello");
-const t: NodeJS.Timeout = setTimeout(() => {}, 0);
-```
-
-The bundled `lib.node` tracks the major version of `@types/node` that matches
-the Node release Deno reports in `process.versions.node`. If you need to pin a
-specific `@types/node` version (for example to match the Node version your
-project standardizes on), add it as an explicit dependency:
-
-```jsonc title="deno.json"
-{
-  "imports": {
-    "@types/node": "npm:@types/node@^22"
-  }
-}
-```
-
-On versions before 2.8, or if you've opted out of `lib.node`, you can still load
-the types with a reference directive:
-
-```ts
-/// <reference types="npm:@types/node" />
-```
-
-## Run npm binaries
-
-You can run npm CLI tools (packages with `bin` entries) directly without
-`npm install` by using an `npm:` specifier:
-
-```console
-npm:<package-name>[@<version-requirement>][/<binary-name>]
-```
-
-For example:
-
-```sh
-$ deno run -R npm:cowsay@1.5.0 "Hello there!"
- ______________
-< Hello there! >
- --------------
-        \   ^__^
-         \  (oo)\_______
-            (__)\       )\/\
-                ||----w |
-                ||     ||
-
-$ deno run -R npm:cowsay@1.5.0/cowthink "What to eat?"
- ______________
-( What to eat? )
- --------------
-        o   ^__^
-         o  (oo)\_______
-            (__)\       )\/\
-                ||----w |
-                ||     ||
-```
-
-## node_modules
+## Control node_modules
 
 When you run `npm install`, npm creates a `node_modules` directory in your
 project which houses the dependencies as specified in the `package.json` file.
-
-By default, Deno instead uses
-[npm specifiers](/runtime/fundamentals/node/#using-npm-packages) to resolve npm
-packages to a central global npm cache and does not create a `node_modules`
-directory. This uses less space, keeps your project directory clean, and is the
-recommended setup for new Deno projects.
+By default, Deno instead resolves npm packages from a central global cache and
+does not create a `node_modules` directory. This uses less space, keeps your
+project directory clean, and is the recommended setup for new Deno projects.
 
 There may however be cases where you need a local `node_modules` directory in
 your Deno project, even if you don't have a `package.json` (eg. when using
 frameworks like Next.js or Svelte or when depending on npm packages that use
 Node-API).
 
-### Choosing a node_modules mode
+### Choose a node_modules mode
 
 | Mode   | When to use                                  | How to enable                                              |
 | ------ | -------------------------------------------- | ---------------------------------------------------------- |
@@ -602,7 +492,7 @@ recognize this workflow from Node.js projects. It is recommended for projects
 using frameworks like Next.js, Remix, Svelte, Qwik etc, or tools like Vite,
 Parcel or Rollup.
 
-### node_modules layout: isolated vs hoisted
+### Pick a layout: isolated vs hoisted
 
 When a local `node_modules` directory exists, Deno can lay it out in two ways.
 The default (**isolated**) installs each package into a content-addressed
@@ -653,7 +543,7 @@ Stick with the default isolated mode unless a tool you depend on requires the
 hoisted layout. Isolated mode catches phantom dependencies that hoisted layouts
 hide.
 
-## Node-API addons
+## Use packages with native addons
 
 Deno supports [Node-API addons](https://nodejs.org/api/n-api.html) used by
 popular npm packages like [`esbuild`](https://www.npmjs.com/package/esbuild),
@@ -669,19 +559,143 @@ As of Deno 2.0, npm packages using Node-API addons are supported when a local
 Like all native FFI, pass `--allow-ffi` to grant explicit permission. Review
 [Security and permissions](/runtime/reference/permissions/#ffi-(foreign-function-interface)).
 
-:::note
-
-Many addons rely on npm lifecycle scripts (for example, `postinstall`). Deno
-supports them, but they are not run by default for security reasons. See the
+**If it doesn't work:** many addons rely on npm lifecycle scripts (for example,
+`postinstall`) to build or download their native binaries. Deno supports them,
+but they are not run by default for security reasons. See the
 [`deno install` docs](/runtime/reference/cli/install/).
 
-:::
+## Control package export conditions
 
-## Migrating from Node to Deno
+Package exports can be
+[conditioned](https://nodejs.org/api/packages.html#conditional-exports) on the
+resolution mode. The conditions satisfied by an import from a Deno ESM module
+are as follows:
 
-Running a Node.js project with Deno usually requires little to no change. See
-the [Migrating from Node.js to Deno guide](/runtime/migrate/) for the details,
-optional toolchain improvements, and a Node-to-Deno command cheatsheet.
+```json
+["deno", "node", "import", "module-sync", "default"]
+```
+
+This means that the first condition listed in a package export whose key equals
+any of these strings will be matched. For `require()` resolution, including
+`createRequire()`, the conditions are:
+
+```json
+["require", "node", "module-sync", "default"]
+```
+
+Deno also applies `module-sync` when analyzing CommonJS modules that re-export
+through `require()`.
+
+You can expand the import conditions list using the `--conditions` CLI flag:
+
+```shell
+deno run --conditions development,react-server main.ts
+```
+
+```json
+[
+  "development",
+  "react-server",
+  "deno",
+  "node",
+  "import",
+  "module-sync",
+  "default"
+]
+```
+
+## Get Node and npm type definitions
+
+Starting in Deno 2.8, `deno check` and the LSP include `lib.node` in every
+type-check by default, so Node ambient types like `Buffer`, `NodeJS.Timeout`,
+and `process` resolve without any configuration:
+
+```ts
+// 2.8+: type-checks with no extra setup
+const buf: Buffer = Buffer.from("hello");
+const t: NodeJS.Timeout = setTimeout(() => {}, 0);
+```
+
+The bundled `lib.node` tracks the major version of `@types/node` that matches
+the Node release Deno reports in `process.versions.node`. If you need to pin a
+specific `@types/node` version (for example to match the Node version your
+project standardizes on), add it as an explicit dependency:
+
+```jsonc title="deno.json"
+{
+  "imports": {
+    "@types/node": "npm:@types/node@^22"
+  }
+}
+```
+
+On versions before 2.8, or if you've opted out of `lib.node`, you can still load
+the types with a reference directive:
+
+```ts
+/// <reference types="npm:@types/node" />
+```
+
+The same directive lets you use types from the `NodeJS` namespace, like
+`BufferEncoding`, in your own signatures:
+
+```ts title="buffer-types.ts"
+/// <reference types="npm:@types/node" />
+
+// Now you can use NodeJS namespace types
+function writeToBuffer(data: string, encoding: NodeJS.BufferEncoding): Buffer {
+  return Buffer.from(data, encoding);
+}
+```
+
+### Types for npm packages
+
+Many npm packages ship with types, you can import these and use them with types
+directly:
+
+```ts
+import chalk from "npm:chalk@5";
+```
+
+Some packages do not ship with types but you can specify their types with the
+[`@ts-types`](/runtime/fundamentals/typescript) directive. For example, using a
+[`@types`](https://www.typescriptlang.org/docs/handbook/2/type-declarations.html#definitelytyped--types)
+package:
+
+```ts
+// @ts-types="npm:@types/express@^4.17"
+import express from "npm:express@^4.17";
+```
+
+### When a package's types look wrong
+
+The official TypeScript compiler `tsc` supports different
+[moduleResolution](https://www.typescriptlang.org/tsconfig#moduleResolution)
+settings. Deno only supports the modern `node16` resolution. Unfortunately many
+npm packages fail to correctly provide types under node16 module resolution,
+which can result in `deno check` reporting type errors, that `tsc` does not
+report.
+
+If a default export from an `npm:` import appears to have a wrong type (with the
+right type seemingly being available under the `.default` property), it's most
+likely that the package provides wrong types under node16 module resolution for
+imports from ESM. You can verify this by checking if the error also occurs with
+`tsc --module node16` and `"type": "module"` in `package.json` or by consulting
+the [Are the types wrong?](https://arethetypeswrong.github.io/) website
+(particularly the "node16 from ESM" row).
+
+If you want to use a package that doesn't support TypeScript's node16 module
+resolution, you can:
+
+1. Open an issue at the issue tracker of the package about the problem. (And
+   perhaps contribute a fix :) (Although, unfortunately, there is a lack of
+   tooling for packages to support both ESM and CJS, since default exports
+   require different syntaxes. See also
+   [microsoft/TypeScript#54593](https://github.com/microsoft/TypeScript/issues/54593))
+2. Use a [CDN](/runtime/fundamentals/modules/#url_imports), that rebuilds the
+   packages for Deno support, instead of an `npm:` identifier.
+3. Ignore the type errors you get in your code base with `// @ts-expect-error`
+   or `// @ts-ignore`.
 
 ## Private registries
 

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -89,18 +89,14 @@ The `node:module` built-in includes the
 [`registerHooks()`](/runtime/reference/loader_hooks/) API, which you can use to
 customize module resolution and loading from inside your program.
 
-**If it doesn't work:** a bare import like `import * as os from "os"` fails,
-because the `node:` prefix is required. Deno tells you how to fix it:
-
-```sh
-$ deno run main.mjs
-error: Import "os" not a dependency
-  hint: If you want to use a built-in Node module, add a "node:" prefix (ex. "node:os").
-    at file:///main.mjs:1:21
-```
-
-The same hints and additional quick-fixes are provided by the Deno LSP in your
-editor.
+**Bare imports work too.** Since Deno 2.9, a specifier that matches a Node
+built-in resolves to it even without the prefix, so `import * as os from "os"`
+runs with no prefix and no flag. Before 2.9 the bare form errored unless you
+passed `--unstable-bare-node-builtins`. Prefer the explicit `node:` form anyway:
+it is unambiguous, it is what the Deno LSP's quick-fixes insert, and it works in
+Node.js too. A `deno.json` `imports` entry or `package.json` dependency of the
+same name still wins over the built-in, and a `node_modules` package no longer
+shadows it, matching Node.js.
 
 <a href="/api/node/" class="docs-cta runtime-cta">Explore built-in Node APIs</a>
 


### PR DESCRIPTION
One of three competing ground-up rewrites of the Node compatibility page,
opened as drafts for side-by-side review; only one will merge. This version
organizes the page by what the reader is trying to do: each section is a
goal (use an npm package, use a Node built-in, run an existing project, make
CommonJS work, control node_modules, use native addons, get type
definitions), opening with a working example, then the rules, then an
inline "if it doesn't work" note so troubleshooting lives next to the task
instead of in a separate section. An honest "How compatible is it?" section
near the top carries the test-suite stat. New snippets were executed on
Deno 2.8; the private-registries section, linked anchors, and oldUrl
redirects are unchanged from the fact-checked baseline in #3241. Compare
with version A (#3244) and version B (#3245).