### PR TITLE
docs: render example snippets as stacked prose and code blocks

### DIFF
--- a/examples/_components/ExamplePage.tsx
+++ b/examples/_components/ExamplePage.tsx
@@ -46,17 +46,25 @@ export default function ExamplePage({ example }: Props) {
             class="flex flex-col gap-4 md:gap-0 example-content"
             key={file.name}
           >
-            {file.snippets.map((snippet, i) => (
-              <SnippetComponent
-                key={i}
-                onlyOneSnippet={file.snippets.length === 1}
-                firstOfFile={i === 0 || !file.snippets[i - 1].code}
-                lastOfFile={i === file.snippets.length - 1 ||
-                  !file.snippets[i + 1].code}
-                filename={file.name}
-                snippet={snippet}
-              />
-            ))}
+            {file.snippets.map((snippet, i) => {
+              // In the stacked layout, prose separates code into visual
+              // blocks: a snippet with text starts a new block, and a block
+              // ends right before the next snippet with text.
+              const startsBlock = i === 0 || !!snippet.text ||
+                !file.snippets[i - 1].code;
+              const endsBlock = i === file.snippets.length - 1 ||
+                !!file.snippets[i + 1].text || !file.snippets[i + 1].code;
+              return (
+                <SnippetComponent
+                  key={i}
+                  onlyOneSnippet={startsBlock && endsBlock}
+                  firstOfFile={startsBlock}
+                  lastOfFile={endsBlock}
+                  filename={i === 0 ? file.name : ""}
+                  snippet={snippet}
+                />
+              );
+            })}
           </div>
         ))}
       </div>

--- a/examples/_components/SnippetComponent.tsx
+++ b/examples/_components/SnippetComponent.tsx
@@ -11,37 +11,25 @@ export default function SnippetComponent(props: {
   const html = Prism.highlight(props.snippet.code, Prism.languages.js, "js");
 
   return (
-    <div class="grid grid-cols-1 sm:grid-cols-10 gap-x-4 md:gap-x-6 lg:gap-x-8 example-block">
-      <div
-        class={`select-none text-sm ${props.snippet.text ? "pb-4" : " "} ${
-          props.snippet.code
-            ? "italic md:text-balance md:text-right col-span-5 sm:col-span-3 md:pb-0 snippet-comment"
-            : "col-span-full mt-8"
-        }`}
-      >
-        {props.snippet.text}
-      </div>
-      <div
-        class={`col-span-7 relative ${
-          props.snippet.code.length === 0 ? "hidden sm:block" : ""
-        }`}
-      >
-        {props.filename && (
-          <span
-            class={`font-mono text-xs absolute -top-3 left-0 z-10 p-1 rounded-sm bg-foreground-tertiary ${
-              props.firstOfFile ? "block" : "block sm:hidden"
-            }`}
-          >
-            {props.filename}
-          </span>
-        )}
-        <div class="-mx-4 h-full sm:mx-0 overflow-auto relative gfm-highlight">
-          {props.snippet.code && (
+    <div class="example-block flex flex-col">
+      {props.snippet.text && (
+        <div class="snippet-comment max-w-[70ch] mt-6 mb-3">
+          {props.snippet.text}
+        </div>
+      )}
+      {props.snippet.code && (
+        <div class="relative">
+          {props.filename && props.firstOfFile && (
+            <span class="font-mono text-xs absolute -top-3 left-3 z-10 p-1 rounded-sm bg-foreground-tertiary">
+              {props.filename}
+            </span>
+          )}
+          <div class="-mx-4 sm:mx-0 overflow-auto relative gfm-highlight">
             <div
               data-color-mode="light"
               data-dark-theme="dark"
               data-light-theme="light"
-              class="nocopy h-full markdown-body"
+              class="nocopy markdown-body"
             >
               <pre
                 class="highlight snippet-code language-ts rounded-none"
@@ -58,9 +46,9 @@ export default function SnippetComponent(props: {
                   ></code>
               </pre>
             </div>
-          )}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/style.css
+++ b/style.css
@@ -817,7 +817,7 @@
       @apply m-0;
     }
     pre.snippet-code[data-example-position="only"] {
-      @apply md:border-t md:border-b md:pt-4 h-full md:rounded-sm md:rounded-b;
+      @apply md:border-t md:border-b md:py-4 h-full md:rounded-sm;
     }
 
     pre.snippet-code[data-example-position="first"] {
@@ -826,12 +826,11 @@
     }
 
     pre.snippet-code[data-example-position="middle"] {
-      @apply md:border-t-0 md:border-b-0 md:pt-0 md:pb-16 h-full
-        md:rounded-none;
+      @apply md:border-t-0 md:border-b-0 md:py-0 h-full md:rounded-none;
     }
 
     pre.snippet-code[data-example-position="last"] {
-      @apply md:border-t-0 md:border-b md:pb-8 h-full md:rounded-t-none
+      @apply md:border-t-0 md:border-b md:pb-4 h-full md:rounded-t-none
         md:rounded-b;
     }
 


### PR DESCRIPTION
The two-column example layout renders commentary as italic, right-aligned
margin notes beside the code. Feedback on the recent example batches was
that this reads strangely: the eye jumps between columns, the right
alignment makes paragraphs ragged on the left edge, and long explanations
get squeezed into a narrow strip.

This PR is one of two alternative reworks, alongside #3248 (pick one). It
switches the example pages to a single-column flow: each piece of
commentary renders as a regular paragraph directly above the code it
describes, in document order. Code now splits into visual blocks at prose
boundaries rather than at grid rows, so a run of uninterrupted code stays
one connected block. Multi-file examples keep their filename chips on the
first block of each file. The column-alignment padding hacks in the
position CSS are no longer needed and were removed.

Before (current two-column layout):

![before](https://raw.githubusercontent.com/denoland/docs/snippet-layout-screenshots/before_two_col_main.png)

After (stacked):

![stacked](https://raw.githubusercontent.com/denoland/docs/snippet-layout-screenshots/stacked_convert_uint8array.png)

Multi-file example (web workers):

![multi-file](https://raw.githubusercontent.com/denoland/docs/snippet-layout-screenshots/stacked_web_workers.png)