### PR TITLE
docs: make example margin notes read as plain prose

### DIFF
--- a/examples/_components/SnippetComponent.tsx
+++ b/examples/_components/SnippetComponent.tsx
@@ -15,7 +15,7 @@ export default function SnippetComponent(props: {
       <div
         class={`select-none text-sm ${props.snippet.text ? "pb-4" : " "} ${
           props.snippet.code
-            ? "italic md:text-balance md:text-right col-span-5 sm:col-span-3 md:pb-0 snippet-comment"
+            ? "leading-relaxed text-foreground-secondary col-span-5 sm:col-span-3 md:pb-0 md:pt-1 snippet-comment"
             : "col-span-full mt-8"
         }`}
       >


### PR DESCRIPTION
The two-column example layout renders commentary as italic, right-aligned
margin notes beside the code. Feedback on the recent example batches was
that this reads strangely: the right alignment makes paragraphs ragged on
the left edge and the italics tire the eye over a long page.

This PR is the conservative counterpart to #3247 (pick one). It keeps the
two-column structure, so the at-a-glance density of the current pages is
unchanged, and only restyles the notes: plain upright text, left aligned,
secondary foreground color, relaxed line height, and a small top offset
to align the first line with the code beside it. The diff is a single
class change in SnippetComponent.

Before:

![before](https://raw.githubusercontent.com/denoland/docs/snippet-layout-screenshots/before_two_col_main.png)

After (refined two-column):

![refined](https://raw.githubusercontent.com/denoland/docs/snippet-layout-screenshots/refined_convert_uint8array.png)