### PR TITLE
docs: retire database video pages and harden quick examples

### DIFF
--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -1157,20 +1157,6 @@ export const items = [
     category: "Databases",
   },
   {
-    title: "Mongoose (video)",
-    href: "/examples/mongoose/",
-    externalURL: "https://www.youtube.com/watch?v=dmZ9Ih0CR9g",
-    type: "video",
-    category: "Databases",
-  },
-  {
-    title: "Prisma (video)",
-    href: "/examples/prisma/",
-    externalURL: "https://www.youtube.com/watch?v=P8VzA_XSF8w",
-    type: "video",
-    category: "Databases",
-  },
-  {
     title: "DuckDB",
     href: "/examples/duckdb/",
     type: "example",

--- a/examples/scripts/postgres.ts
+++ b/examples/scripts/postgres.ts
@@ -17,7 +17,9 @@ import postgres from "npm:postgres";
 
 // Read the connection settings from the standard libpq environment
 // variables. Locally you might set PGDATABASE=test and nothing else;
-// in production a managed database provides all of them.
+// in production a managed database provides all of them. A common pattern
+// is to keep these in a .env file and load it with the --env-file flag,
+// for example: deno run --env-file -N -E main.ts
 const sql = postgres({
   host: Deno.env.get("PGHOST") ?? "localhost",
   port: Number(Deno.env.get("PGPORT") ?? 5432),

--- a/examples/scripts/postgres.ts
+++ b/examples/scripts/postgres.ts
@@ -3,29 +3,43 @@
  * @difficulty intermediate
  * @tags cli, deploy
  * @run -N -E <url>
+ * @resource {https://www.npmjs.com/package/postgres} postgres on npm
  * @group Databases
  *
  * Using the npm Postgres client, you can connect to a Postgres database
- * running anywhere.
+ * running anywhere. Connection settings belong in environment variables
+ * rather than in the source, so the same code runs against your local
+ * database and production.
  */
 
 // Import the Postgres package from npm
 import postgres from "npm:postgres";
 
-// Initialize the client with connection information for your database, and
-// create a connection.
+// Read the connection settings from the standard libpq environment
+// variables. Locally you might set PGDATABASE=test and nothing else;
+// in production a managed database provides all of them.
 const sql = postgres({
-  user: "user",
-  database: "test",
-  hostname: "localhost",
-  port: 5432,
+  host: Deno.env.get("PGHOST") ?? "localhost",
+  port: Number(Deno.env.get("PGPORT") ?? 5432),
+  user: Deno.env.get("PGUSER") ?? "postgres",
+  password: Deno.env.get("PGPASSWORD"),
+  database: Deno.env.get("PGDATABASE") ?? "postgres",
 });
 
-// Execute a SQL query
-const result = await sql`
-  SELECT ID, NAME FROM PEOPLE
-`;
-console.log(result);
-
-// Close the connection to the database
-await sql.end();
+// Execute a SQL query. Connections open lazily on first use, so this is
+// the first place a bad address or password surfaces; handle it instead
+// of leaking a stack trace, and close the connection pool either way.
+// Connection failures arrive as an AggregateError with the cause on its
+// code property, for example ECONNREFUSED when nothing is listening.
+try {
+  const people = await sql`
+    SELECT id, name FROM people
+  `;
+  console.log(people);
+} catch (error) {
+  const reason = (error as { code?: string }).code ?? String(error);
+  console.error("Query failed:", reason); // Query failed: ECONNREFUSED
+} finally {
+  // Close the connection to the database
+  await sql.end();
+}

--- a/examples/scripts/redis.ts
+++ b/examples/scripts/redis.ts
@@ -5,6 +5,7 @@
  * @run -N -E <url>
  * @resource {https://jsr.io/@iuioiua/redis} redis on jsr.io
  * @resource {https://redis.io/docs/getting-started/} Getting started with Redis
+ * @resource {https://docs.deno.com/examples/redis_tutorial/} Tutorial: Build a caching layer with Redis
  * @group Databases
  *
  * Using the jsr:@iuioiua/redis module, you can connect to a Redis database running anywhere.

--- a/examples/tutorials/initialize_project.md
+++ b/examples/tutorials/initialize_project.md
@@ -14,7 +14,21 @@ easily.
 Initialize a new project by running the following command:
 
 ```sh
-deno init my_project
+$ deno init my_project
+✅ Project initialized
+
+Run these commands to get started
+
+  cd my_project
+
+  # Run the server
+  deno run --allow-net main.ts
+
+  # Run the server and watch for file changes
+  deno task dev
+
+  # Run the tests
+  deno test
 ```
 
 Where `my_project` is the name of your project. You can
@@ -31,7 +45,10 @@ cd my_project
 Then you can run the project directly using the `deno task` command:
 
 ```sh
-deno run dev
+$ deno task dev
+Task dev deno run --watch --allow-net main.ts
+Watcher Process started.
+Listening on http://0.0.0.0:8000/ (http://localhost:8000/)
 ```
 
 Take a look in the `deno.json` file in your new project. You should see a `dev`
@@ -39,7 +56,7 @@ task in the "tasks" field.
 
 ```json title="deno.json"
 "tasks": {
-  "dev": "deno run --watch main.ts"
+  "dev": "deno run --watch --allow-net main.ts"
 },
 ```
 
@@ -53,21 +70,26 @@ action if you open the `main.ts` file and make a change.
 In the project directory run:
 
 ```sh
-deno test
+$ deno test
+Check main_test.ts
+running 2 tests from ./main_test.ts
+returns html on / ... ok (11ms)
+returns json on /api ... ok (0ms)
+
+ok | 2 passed | 0 failed (13ms)
 ```
 
 This will execute all the tests in the project. You can read more about
 [testing in Deno](/runtime/test/) and we'll cover tests in a little more depth
 in a later tutorial. At the moment you have one test file, `main_test.ts`, which
-tests the `add` function in `main.ts`.
+tests the request handler in `main.ts`.
 
 ### Adding to your project
 
 The `main.ts` file serves as the entry point for your application. It’s where
 you’ll write your main program logic. When developing your project you will
-start by removing the default addition program and replace it with your own
-code. For example, if you’re building a web server, this is where you’d set up
-your routes and handle requests.
+start by replacing the default HTTP server with your own code; its routes and
+request handler are a starting point to build on.
 
 Beyond the initial files, you’ll likely create additional modules (files) to
 organize your code. Consider grouping related functionality into separate files.

--- a/examples/tutorials/mongoose.md
+++ b/examples/tutorials/mongoose.md
@@ -14,9 +14,7 @@ models data for [MongoDB](https://www.mongodb.com/). It simplifies writing
 MongoDB validation, casting, and other relevant business logic.
 
 This tutorial will show you how to setup Mongoose and MongoDB with your Deno
-project. You can follow along in text below or watch the video version:
-
-<lite-youtube videoid="dmZ9Ih0CR9g"></lite-youtube>
+project.
 
 [View source](https://github.com/denoland/examples/tree/main/with-mongoose).
 

--- a/examples/tutorials/mongoose.md
+++ b/examples/tutorials/mongoose.md
@@ -6,6 +6,7 @@ url: /examples/mongoose_tutorial/
 oldUrl:
   - /runtime/manual/examples/how_to_with_npm/mongoose/
   - /runtime/tutorials/how_to_with_npm/mongoose/
+  - /examples/mongoose/
 ---
 
 [Mongoose](https://mongoosejs.com/) is a popular, schema-based library that
@@ -13,10 +14,11 @@ models data for [MongoDB](https://www.mongodb.com/). It simplifies writing
 MongoDB validation, casting, and other relevant business logic.
 
 This tutorial will show you how to setup Mongoose and MongoDB with your Deno
-project.
+project. You can follow along in text below or watch the video version:
 
-[View source](https://github.com/denoland/examples/tree/main/with-mongoose) or
-[check out the video guide](https://youtu.be/dmZ9Ih0CR9g).
+<lite-youtube videoid="dmZ9Ih0CR9g"></lite-youtube>
+
+[View source](https://github.com/denoland/examples/tree/main/with-mongoose).
 
 ## Creating a Mongoose Model
 

--- a/examples/tutorials/prisma.md
+++ b/examples/tutorials/prisma.md
@@ -6,6 +6,7 @@ url: /examples/prisma_tutorial/
 oldUrl:
   - /runtime/manual/examples/how_to_with_npm/prisma/
   - /runtime/tutorials/how_to_with_npm/prisma/
+  - /examples/prisma/
 ---
 
 [Prisma](https://prisma.io) has been one of our top requested modules to work
@@ -13,7 +14,10 @@ with in Deno. The demand is understandable, given that Prisma's developer
 experience is top notch and plays well with so many persistent data storage
 technologies.
 
-We're excited to show you how to use Prisma with Deno.
+We're excited to show you how to use Prisma with Deno. You can follow along in
+text below or watch the video version:
+
+<lite-youtube videoid="P8VzA_XSF8w"></lite-youtube>
 
 In this How To guide, we'll setup a simple RESTful API in Deno using Oak and
 Prisma.

--- a/examples/tutorials/prisma.md
+++ b/examples/tutorials/prisma.md
@@ -21,8 +21,7 @@ Prisma.
 
 Let's get started.
 
-[View source](https://github.com/denoland/examples/tree/main/with-prisma) or
-[check out the video guide](https://youtu.be/P8VzA_XSF8w).
+[View source](https://github.com/denoland/examples/tree/main/with-prisma).
 
 ## Setup the application
 

--- a/examples/tutorials/prisma.md
+++ b/examples/tutorials/prisma.md
@@ -14,10 +14,7 @@ with in Deno. The demand is understandable, given that Prisma's developer
 experience is top notch and plays well with so many persistent data storage
 technologies.
 
-We're excited to show you how to use Prisma with Deno. You can follow along in
-text below or watch the video version:
-
-<lite-youtube videoid="P8VzA_XSF8w"></lite-youtube>
+We're excited to show you how to use Prisma with Deno.
 
 In this How To guide, we'll setup a simple RESTful API in Deno using Oak and
 Prisma.

--- a/examples/tutorials/redis.md
+++ b/examples/tutorials/redis.md
@@ -9,7 +9,9 @@ oldUrl:
 ---
 
 [Redis](https://redis.io/) is an in-memory data store you can use for caching,
-as a message broker, or for streaming data.
+as a message broker, or for streaming data. If you just need to connect and send
+commands, see the [Redis quick start](/examples/redis/); this tutorial builds
+something more complete on top of it.
 
 [View source here.](https://github.com/denoland/examples/tree/main/with-redis)
 

--- a/examples/videos/mongoose.md
+++ b/examples/videos/mongoose.md
@@ -1,7 +1,0 @@
----
-title: "Connect to Mongoose and MongoDB"
-description: "Learn how to connect a Deno application to MongoDB using the Mongoose library."
-url: /examples/mongoose/
-videoUrl: https://www.youtube.com/watch?v=dmZ9Ih0CR9g
-layout: video.tsx
----

--- a/examples/videos/prisma.md
+++ b/examples/videos/prisma.md
@@ -1,7 +1,0 @@
----
-title: "Connect to Prisma"
-description: "Learn how to use the Prisma ORM to connect to and query a database from a Deno application."
-url: /examples/prisma/
-videoUrl: https://www.youtube.com/watch?v=P8VzA_XSF8w
-layout: video.tsx
----


### PR DESCRIPTION
Three small quality passes on the examples catalog that were parked
during the recent expansion, all from the consolidation section of the
content backlog.

The Mongoose and Prisma video pages duplicated their tutorials: same
topic, two catalog entries, and the relabeled titles ("Prisma" next to
"Prisma (video)") made the redundancy obvious. The recordings also
predate the current tutorials and risk contradicting them, while the
written tutorials are the higher-quality source. So the standalone video
pages are removed and their old URLs redirect to the tutorials; the
videos remain reachable on the YouTube channel. The catalog drops from
316 to 314 items. Redis keeps both of its pages since the quick start
(connect and send commands) and the tutorial (build a caching layer)
cover different ground; they now cross-link each other instead.

The Postgres quick example previously hardcoded credentials and let
connection failures escape as a raw stack trace. It now reads the
standard PG* environment variables with sensible localhost fallbacks and
handles query failure by reporting the error code; the failure path was
verified against a closed port (prints "Query failed: ECONNREFUSED") and
the pool is closed in a finally block either way.

The project initialization tutorial showed bare commands with no
expected output and had drifted from what deno init actually generates
(it described the old "add function" template; the current template is a
small HTTP server with two tests, and the dev task includes
--allow-net). The tutorial now shows the real captured output of deno
init, deno task dev, and deno test, so readers can verify each step as
they follow along.