### PR TITLE
docs: add web utility examples for markdown, templating, QR, PDF, images, and MCP

### DIFF
--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -1976,6 +1976,42 @@ export const items = [
     type: "example",
     category: "Network",
   },
+  {
+    title: "Render markdown to HTML",
+    href: "/examples/render_markdown/",
+    type: "example",
+    category: "Web frameworks and libraries",
+  },
+  {
+    title: "Render HTML templates with Eta",
+    href: "/examples/html_templating/",
+    type: "example",
+    category: "Web frameworks and libraries",
+  },
+  {
+    title: "Generate a QR code",
+    href: "/examples/generate_qr_code/",
+    type: "example",
+    category: "Web frameworks and libraries",
+  },
+  {
+    title: "Generate a PDF",
+    href: "/examples/generate_pdf/",
+    type: "example",
+    category: "Web frameworks and libraries",
+  },
+  {
+    title: "Resize and convert images",
+    href: "/examples/resize_images/",
+    type: "example",
+    category: "Web frameworks and libraries",
+  },
+  {
+    title: "Build an MCP server",
+    href: "/examples/mcp_server/",
+    type: "example",
+    category: "AI",
+  },
 ];
 
 // Section order on the landing page and in the sidebar.

--- a/examples/scripts/generate_pdf.ts
+++ b/examples/scripts/generate_pdf.ts
@@ -1,0 +1,57 @@
+/**
+ * @title Generate a PDF
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -W <url>
+ * @resource {https://pdf-lib.js.org/} pdf-lib documentation
+ * @group Web frameworks and libraries
+ *
+ * The pdf-lib package creates and edits PDF documents in pure JavaScript,
+ * so it runs anywhere Deno does, including Deno Deploy. Use it to produce
+ * invoices, tickets, or reports on the fly without a headless browser or a
+ * native PDF toolchain.
+ */
+import { PDFDocument, rgb, StandardFonts } from "npm:pdf-lib";
+
+// A document is a container for pages. Create one, then add pages with an
+// explicit size in points (72 points per inch, so this is US Letter).
+const pdf = await PDFDocument.create();
+const page = pdf.addPage([612, 792]);
+
+// Fonts must be embedded before use. The 14 standard fonts need no font
+// file; embedFont returns a handle you pass when drawing text.
+const helvetica = await pdf.embedFont(StandardFonts.Helvetica);
+const bold = await pdf.embedFont(StandardFonts.HelveticaBold);
+
+// The coordinate origin is the bottom-left corner, so larger y values are
+// higher on the page. Draw a heading near the top.
+page.drawText("Invoice", {
+  x: 50,
+  y: 720,
+  size: 28,
+  font: bold,
+  color: rgb(0.1, 0.1, 0.1),
+});
+
+// Lay out a few lines of body text below it, stepping y down for each.
+const lines = ["Item: Deno subscription", "Amount: $0.00", "Status: Paid"];
+let y = 680;
+for (const line of lines) {
+  page.drawText(line, { x: 50, y, size: 12, font: helvetica });
+  y -= 20;
+}
+
+// Vector drawing primitives let you add rules, boxes, and backgrounds.
+page.drawLine({
+  start: { x: 50, y: 700 },
+  end: { x: 562, y: 700 },
+  thickness: 1,
+  color: rgb(0.8, 0.8, 0.8),
+});
+
+// save serializes the whole document to PDF bytes, which start with the
+// %PDF- magic number. Write them to a file or return them from a server.
+const bytes = await pdf.save();
+await Deno.writeFile("invoice.pdf", bytes);
+console.log(new TextDecoder().decode(bytes.slice(0, 5))); // %PDF-
+console.log(`wrote ${bytes.length} bytes`); // wrote 1049 bytes

--- a/examples/scripts/generate_qr_code.ts
+++ b/examples/scripts/generate_qr_code.ts
@@ -1,0 +1,35 @@
+/**
+ * @title Generate a QR code
+ * @difficulty beginner
+ * @tags cli, deploy
+ * @run -W <url>
+ * @resource {https://jsr.io/@libs/qrcode} @libs/qrcode on JSR
+ * @group Web frameworks and libraries
+ *
+ * A QR code encodes a short piece of text, usually a URL, as a scannable
+ * image. The @libs/qrcode module on JSR generates them with no native
+ * dependencies, returning an SVG string, a data array, or terminal output.
+ */
+import { qrcode } from "jsr:@libs/qrcode";
+
+// The default output is an SVG string, ready to embed in a page or write
+// to a file. SVG scales to any size without blurring, which suits print
+// and high-resolution screens.
+const svg = qrcode("https://deno.com", { output: "svg" });
+await Deno.writeTextFile("deno-qr.svg", svg);
+console.log(svg.startsWith("<?xml")); // true
+
+// The error-correction level trades data capacity for resilience: a higher
+// level still scans when part of the code is damaged or covered, at the
+// cost of a denser image. Levels are LOW, MEDIUM, QUARTILE, and HIGH.
+const robust = qrcode("https://deno.com", {
+  output: "svg",
+  ecl: "HIGH",
+});
+console.log(robust.length > svg.length); // true
+
+// Without an output option you get the raw module matrix: a 2D array of
+// booleans where true is a dark cell. Use it to render the code yourself,
+// for example onto a canvas or into another image format.
+const matrix = qrcode("https://deno.com");
+console.log(`${matrix.length}x${matrix[0].length} grid`); // 29x29 grid

--- a/examples/scripts/html_templating.ts
+++ b/examples/scripts/html_templating.ts
@@ -1,0 +1,52 @@
+/**
+ * @title Render HTML templates with Eta
+ * @difficulty beginner
+ * @tags cli, deploy
+ * @run -RW <url>
+ * @resource {https://eta.js.org/} Eta documentation
+ * @resource {https://docs.deno.com/examples/http_server/} Example: HTTP server
+ * @group Web frameworks and libraries
+ *
+ * When JSX is more than you need, a string template engine renders HTML
+ * from plain templates and data. Eta is a small, fast engine with no
+ * dependencies that works well in Deno: templates are just text with
+ * embedded expressions, and the data is passed in as an object.
+ */
+import { Eta } from "jsr:@eta-dev/eta";
+
+// Render a template directly from a string. The it object holds the data;
+// <%= %> escapes its value for safe insertion into HTML, and <% %> runs
+// statements such as loops.
+const eta = new Eta();
+
+const html = eta.renderString(
+  `<h1><%= it.title %></h1>
+<ul>
+<% it.items.forEach(function (item) { %>
+  <li><%= item %></li>
+<% }) %>
+</ul>`,
+  { title: "Shopping list", items: ["Eggs", "Milk & honey"] },
+);
+console.log(html);
+// <h1>Shopping list</h1>
+// <ul>
+//   <li>Eggs</li>
+//   <li>Milk &amp; honey</li>
+// </ul>
+
+// Note that the ampersand in "Milk & honey" was escaped to &amp;, which is
+// what prevents user data from breaking the page or injecting markup. Use
+// <%~ %> only for values you trust and want inserted as raw HTML.
+
+// For real projects, keep templates in files and let Eta load them. Point
+// views at a directory, then render by file name; partials and layouts
+// resolve relative to it.
+const fileEta = new Eta({ views: "./templates" });
+await Deno.mkdir("./templates", { recursive: true });
+await Deno.writeTextFile(
+  "./templates/card.eta",
+  `<article><h2><%= it.name %></h2></article>`,
+);
+
+console.log(fileEta.render("card", { name: "Deno" })); // <article><h2>Deno</h2></article>

--- a/examples/scripts/mcp_server.ts
+++ b/examples/scripts/mcp_server.ts
@@ -1,0 +1,65 @@
+/**
+ * @title Build an MCP server
+ * @difficulty intermediate
+ * @tags cli
+ * @resource {https://modelcontextprotocol.io/} Model Context Protocol
+ * @resource {https://github.com/modelcontextprotocol/typescript-sdk} MCP TypeScript SDK
+ * @group AI
+ *
+ * The Model Context Protocol (MCP) is the standard way to expose tools and
+ * data to AI assistants like Claude. An MCP server advertises tools the
+ * model can call; the official TypeScript SDK runs in Deno through npm.
+ * This server exposes a single tool over stdio, the transport desktop AI
+ * clients use to launch and talk to local servers.
+ */
+import { McpServer } from "npm:@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "npm:@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "npm:zod";
+
+// A server has a name and version that clients use to identify it.
+const server = new McpServer({
+  name: "dinosaur-facts",
+  version: "1.0.0",
+});
+
+// Register a tool the model can call. The inputSchema is a Zod schema: the
+// SDK validates arguments against it and advertises the shape to the
+// client, so the model knows what to pass. The handler returns content
+// blocks, here a single piece of text.
+const facts: Record<string, string> = {
+  tyrannosaurus: "Tyrannosaurus rex could bite with 12,800 pounds of force.",
+  velociraptor: "Velociraptor was about the size of a turkey.",
+};
+
+server.registerTool(
+  "get_dinosaur_fact",
+  {
+    description: "Get a fact about a given dinosaur",
+    inputSchema: { name: z.string().describe("The dinosaur's name") },
+  },
+  ({ name }: { name: string }) => {
+    const fact = facts[name.toLowerCase()] ?? `No facts about ${name} yet.`;
+    return { content: [{ type: "text", text: fact }] };
+  },
+);
+
+// Connect the server to a transport. StdioServerTransport reads JSON-RPC
+// messages from stdin and writes replies to stdout, which is how a desktop
+// client runs the server as a subprocess. The server now waits for
+// requests; it prints nothing on its own, so keep logging off stdout.
+const transport = new StdioServerTransport();
+await server.connect(transport);
+
+// To use this server with Claude Desktop, add it to the client config and
+// point the command at Deno:
+//
+//   {
+//     "mcpServers": {
+//       "dinosaur-facts": {
+//         "command": "deno",
+//         "args": ["run", "-R", "mcp_server.ts"]
+//       }
+//     }
+//   }
+//
+// Or inspect it interactively with: npx @modelcontextprotocol/inspector

--- a/examples/scripts/render_markdown.ts
+++ b/examples/scripts/render_markdown.ts
@@ -1,0 +1,57 @@
+/**
+ * @title Render markdown to HTML
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -WE <url>
+ * @resource {https://jsr.io/@deno/gfm} @deno/gfm on JSR
+ * @resource {https://docs.deno.com/examples/front_matter/} Example: Extract front matter from markdown
+ * @group Web frameworks and libraries
+ *
+ * The @deno/gfm module renders GitHub Flavored Markdown to HTML, with the
+ * same tables, task lists, and syntax highlighting you see on GitHub. It is
+ * the renderer behind this documentation site, so it is a safe default for
+ * turning user content or markdown files into web pages.
+ */
+import { render } from "jsr:@deno/gfm";
+
+// Syntax highlighting is opt-in per language: import the matching Prism
+// grammar and the renderer will tokenize fenced code blocks in that
+// language. Import one line per language you want to highlight.
+import "npm:prismjs/components/prism-typescript.js";
+
+const markdown = `# Release notes
+
+Deno **2.0** is here. Highlights:
+
+- Stable APIs
+- A code block:
+
+\`\`\`ts
+const greeting: string = "hello";
+\`\`\`
+`;
+
+// render returns an HTML fragment, not a full document. Headings get
+// anchor links and code blocks are highlighted with token spans.
+const body = render(markdown);
+console.log(body.includes("<h1")); // true
+console.log(body.includes("token")); // true
+
+// To produce a standalone page, wrap the fragment and include the GFM
+// stylesheet. The CSS export styles the markup, and the markdown-body
+// class is the selector it targets.
+import { CSS } from "jsr:@deno/gfm";
+
+const page = `<!DOCTYPE html>
+<html>
+  <head><style>${CSS}</style></head>
+  <body class="markdown-body" data-color-mode="light">${body}</body>
+</html>`;
+
+await Deno.writeTextFile("release-notes.html", page);
+console.log("wrote release-notes.html");
+
+// Markdown is rendered by an untrusted-input-safe parser, but if you allow
+// raw HTML in the source, sanitize the output before serving it. The
+// render function strips scripts by default; pass allowMath or other
+// options when you need them.

--- a/examples/scripts/resize_images.ts
+++ b/examples/scripts/resize_images.ts
@@ -1,0 +1,53 @@
+/**
+ * @title Resize and convert images
+ * @difficulty intermediate
+ * @tags cli
+ * @run -RWE --allow-ffi --allow-sys <url>
+ * @resource {https://sharp.pixelplumbing.com/} sharp documentation
+ * @group Web frameworks and libraries
+ *
+ * sharp is the standard high-performance image processing library, and it
+ * runs in Deno through npm. Use it to resize uploads, generate thumbnails,
+ * and convert between formats such as JPEG, PNG, WebP, and AVIF. Each
+ * operation chains onto the previous one and runs when you call an output
+ * method.
+ */
+import sharp from "npm:sharp";
+
+// For a self-contained example, synthesize a source image instead of
+// reading one from disk: a solid 400x300 image created from scratch.
+const source = await sharp({
+  create: {
+    width: 400,
+    height: 300,
+    channels: 3,
+    background: { r: 64, g: 120, b: 220 },
+  },
+}).png().toBuffer();
+await Deno.writeFile("source.png", source);
+
+// metadata reads an image's dimensions and format without decoding the
+// whole thing, useful for validating uploads before processing them.
+const meta = await sharp(source).metadata();
+console.log(`${meta.width}x${meta.height} ${meta.format}`); // 400x300 png
+
+// Resize to a target width and let the height scale to keep the aspect
+// ratio, then convert to WebP, which is much smaller than PNG for photos.
+// The chain ends at toFile, which writes the result.
+await sharp(source)
+  .resize({ width: 100 })
+  .webp({ quality: 80 })
+  .toFile("thumbnail.webp");
+
+const thumb = await sharp("thumbnail.webp").metadata();
+console.log(`${thumb.width}x${thumb.height} ${thumb.format}`); // 100x75 webp
+
+// resize can also crop to exact dimensions with the cover fit, which fills
+// the box and trims the overflow, the behavior you want for square avatars.
+await sharp(source)
+  .resize({ width: 150, height: 150, fit: "cover" })
+  .jpeg()
+  .toFile("avatar.jpg");
+
+const avatar = await sharp("avatar.jpg").metadata();
+console.log(`${avatar.width}x${avatar.height} ${avatar.format}`); // 150x150 jpeg


### PR DESCRIPTION
A batch of self-contained examples for common web and content tasks that
the catalog did not cover, all using libraries that run in Deno with no
build step. This takes the catalog from 315 to 321 items. Each topic was
on the content backlog under utilities and HTML processing, and the
external-service tutorials in that section are deliberately left out.

The new examples are: render markdown to HTML with syntax highlighting
using @deno/gfm (the renderer behind this docs site), render HTML
templates with Eta, generate a QR code with @libs/qrcode, generate a PDF
with pdf-lib, resize and convert images with sharp, and build an MCP
server with the official Model Context Protocol SDK. Markdown,
templating, QR, PDF, and image examples live under Web frameworks and
libraries; the MCP server is filed under AI.

Every example was run and its output captured rather than written by
hand. The MCP server was additionally verified end to end: a client
connected over real stdio, listed the tool, and called it, returning the
expected result. Permission flags in the run lines are the minimal set
each library actually needs, determined empirically, which is why the
sharp example carries --allow-ffi and --allow-sys for its native libvips
backend and the markdown example needs --allow-env for terminal color
detection.

Build is clean and the full test suite passes (9 tests, 533 steps).

Build an MCP server:

![mcp server](https://raw.githubusercontent.com/denoland/docs/snippet-layout-screenshots/webutil_mcp_server.png)

Render markdown to HTML:

![render markdown](https://raw.githubusercontent.com/denoland/docs/snippet-layout-screenshots/webutil_render_markdown.png)