### PR TITLE
docs: deno fmt no longer supports Sass

### DIFF
--- a/runtime/reference/cli/fmt.md
+++ b/runtime/reference/cli/fmt.md
@@ -121,7 +121,6 @@ deno fmt --ignore=dist/,build/
 | [Nunjucks][Nunjucks] | `.njk`                                                 |                                                                                        |
 | [Vento][Vento]       | `.vto`                                                 |                                                                                        |
 | YAML                 | `.yml`, `.yaml`                                        |                                                                                        |
-| Sass                 | `.sass`                                                |                                                                                        |
 | SCSS                 | `.scss`                                                |                                                                                        |
 | LESS                 | `.less`                                                |                                                                                        |
 | Jupyter Notebook     | `.ipynb`                                               |                                                                                        |


### PR DESCRIPTION
Indented Sass (`.sass`) is no longer a supported format for `deno fmt`.
The CSS formatter was switched from malva to lax-css, which drops support
for the indented Sass syntax. SCSS and Less remain supported.

This lands in Deno 2.9 (denoland/deno#35160).