### PR TITLE
docs: fix rotted examples and add a typecheck gate to prevent recurrence

### DIFF
--- a/examples/_pages/examples_test.ts
+++ b/examples/_pages/examples_test.ts
@@ -1,8 +1,22 @@
 import { join } from "@std/path";
 import { walk } from "@std/fs";
 import { assertEquals, assertNotMatch } from "@std/assert";
+import { parseExample } from "../utils/parseExample.ts";
 
 const decoder = new TextDecoder();
+
+/** The `--unstable-*` flags an example declares in its `@run` line. The
+ * typecheck below enables exactly the unstable APIs the example needs, so
+ * it stays correct as Deno's flag set changes without a hardcoded list. */
+function unstableFlags(run: string | undefined): string[] {
+  return run?.match(/--unstable-[a-z-]+/g) ?? [];
+}
+
+async function typecheck(args: string[]): Promise<Deno.CommandOutput> {
+  return await new Deno.Command(Deno.execPath(), {
+    args: ["check", ...args],
+  }).output();
+}
 
 Deno.test("Check examples", async (t) => {
   for await (const item of walk("./examples/scripts/")) {
@@ -16,6 +30,44 @@ Deno.test("Check examples", async (t) => {
       }).output();
       assertEquals(result.code, 0);
       assertNotMatch(decoder.decode(result.stdout), /\(resolve error\)/);
+    });
+
+    // Typecheck each example so that a dependency changing its API is
+    // caught here rather than shipping a broken snippet. The graph check
+    // above only confirms imports resolve, not that the code still
+    // compiles.
+    await t.step("Typecheck: " + path, async () => {
+      const content = await Deno.readTextFile(path);
+      const parsed = parseExample(item.name, content);
+      const flags = unstableFlags(parsed.run);
+
+      // Single-file examples can be checked in place.
+      if (parsed.files.length <= 1) {
+        const result = await typecheck([...flags, path]);
+        assertEquals(result.code, 0, decoder.decode(result.stderr));
+        return;
+      }
+
+      // Multi-file examples embed their companion files inline with
+      // `// File:` markers, so they cannot be checked standalone.
+      // Reconstruct the files into a temp directory and typecheck every
+      // TypeScript entry together so cross-file imports resolve.
+      const dir = await Deno.makeTempDir();
+      try {
+        const entries: string[] = [];
+        for (const file of parsed.files) {
+          const rel = file.name.replace(/^\.\//, "");
+          const code = file.snippets.map((s) => s.code).join("\n");
+          await Deno.writeTextFile(join(dir, rel), code);
+          if (rel.endsWith(".ts") || rel.endsWith(".js")) {
+            entries.push(join(dir, rel));
+          }
+        }
+        const result = await typecheck([...flags, ...entries]);
+        assertEquals(result.code, 0, decoder.decode(result.stderr));
+      } finally {
+        await Deno.remove(dir, { recursive: true });
+      }
     });
   }
 });

--- a/examples/scripts/importing_bytes.ts
+++ b/examples/scripts/importing_bytes.ts
@@ -2,7 +2,7 @@
  * @title Importing binary files
  * @difficulty beginner
  * @tags cli
- * @run <url>
+ * @run --unstable-raw-imports <url>
  * @resource {https://github.com/whatwg/html/issues/9444} HTML specification proposal
  * @group Unstable APIs
  *

--- a/examples/scripts/npm.ts
+++ b/examples/scripts/npm.ts
@@ -15,13 +15,14 @@
 // Import the express module from npm using an npm: prefix, and appending a
 // version number. Dependencies from npm can be configured in an import map
 // also.
-import express from "npm:express@4.18.2";
+// @ts-types="npm:@types/express@4"
+import express, { type Request, type Response } from "npm:express@4.18.2";
 
 // Create an express server
 const app = express();
 
 // Configure a route that will process HTTP GET requests
-app.get("/", (_req, res) => {
+app.get("/", (_req: Request, res: Response) => {
   res.send("Welcome to the Dinosaur API!");
 });
 

--- a/examples/scripts/parsing_serializing_toml.ts
+++ b/examples/scripts/parsing_serializing_toml.ts
@@ -25,7 +25,7 @@ path = "cli/main.rs"
 name = "deno_core"
 path = "src/foo.rs"
 `;
-const data = parse(text);
+const data = parse(text) as { int: number; bin: { name: string }[] };
 console.log(data.int);
 console.log(data.bin.length);
 

--- a/examples/scripts/parsing_serializing_yaml.ts
+++ b/examples/scripts/parsing_serializing_yaml.ts
@@ -19,7 +19,7 @@ baz:
   - qux
   - quux
 `;
-const data = parse(text);
+const data = parse(text) as { foo: string; baz: string[] };
 console.log(data.foo);
 console.log(data.baz.length);
 

--- a/examples/scripts/writing_files.ts
+++ b/examples/scripts/writing_files.ts
@@ -21,9 +21,6 @@ await Deno.writeFile("hello.txt", bytes, { mode: 0o644 });
 // You can also write a string instead of a byte array.
 await Deno.writeTextFile("hello.txt", "Hello World");
 
-// Or you can write binary data as a string.
-await Deno.writeTextFile("hello.txt", "Hello World", { encoding: "utf8" });
-
 // To append to a text file, set the `append` parameter to `true`.
 await Deno.writeTextFile("server.log", "Request: ...", { append: true });
 


### PR DESCRIPTION
The examples CI test only ran deno info, which confirms imports resolve
but does not typecheck. So when a dependency changes its API, the example
compiles broken and ships green. This PR fixes the examples that had
already rotted this way and adds a gate so it cannot happen silently
again.

## The rot

Running deno check across every example (with each script's own unstable
flags from its @run line) found four already broken on main:

- writing_files.ts passed an encoding option to Deno.writeTextFile that
  no longer exists in WriteFileOptions. The line is redundant anyway
  (the line above already writes a string), so it is removed.
- npm.ts left the Express route handler parameters as implicit any. They
  are now typed via @types/express with an inline @ts-types directive.
- parsing_serializing_yaml.ts and parsing_serializing_toml.ts accessed
  properties on the result of @std parse, which now returns unknown
  rather than any. Each parsed value is annotated with its shape.

Every fixed script was run and produces the same output as before, so
the captured-output comments are unchanged.

## The gate

The examples test now typechecks each script in addition to the existing
graph check. It reads the unstable flags an example declares in its @run
line (so it tracks Deno's flag set without a hardcoded list), and for
multi-file examples, whose companion files are embedded inline with
`// File:` markers, it reconstructs the files into a temp directory and
typechecks them together so cross-file imports resolve.

Building the gate surfaced one more issue on its own: importing_bytes
uses an unstable raw byte import but its @run line omitted
--unstable-raw-imports, so the documented run command would fail. That
flag is now declared.

The full suite passes (9 tests, 763 steps, ~53s). A type error injected
into any example now fails the run rather than shipping.