### PR TITLE
docs: content sweep wave B — bundling, lint plugins, VS Code caching

### DIFF
--- a/runtime/reference/bundling.md
+++ b/runtime/reference/bundling.md
@@ -60,17 +60,30 @@ single output file.
 
 ## Options Overview
 
-| Flag                    | Description                                          |
-| ----------------------- | ---------------------------------------------------- |
-| `-o`, `--output <file>` | Write bundled output to a file                       |
-| `--outdir <dir>`        | Write bundled output to a directory                  |
-| `--minify`              | Minify the output for production                     |
-| `--format <format>`     | Output format (`esm` by default)                     |
-| `--code-splitting`      | Enable code splitting                                |
-| `--platform <platform>` | Bundle for `browser` or `deno` (default: `deno`)     |
-| `--sourcemap`           | Include source maps (`linked`, `inline`, `external`) |
-| `--watch`               | Automatically rebuild on file changes                |
-| `--inline-imports`      | Inline imported modules (`true` or `false`)          |
+| Flag                    | Description                                              |
+| ----------------------- | -------------------------------------------------------- |
+| `-o`, `--output <file>` | Write bundled output to a file                           |
+| `--outdir <dir>`        | Write bundled output to a directory                      |
+| `--minify`              | Minify the output for production                         |
+| `--format <format>`     | Output format (`esm` by default)                         |
+| `--code-splitting`      | Enable code splitting                                    |
+| `--platform <platform>` | Bundle for `browser` or `deno` (default: `deno`)         |
+| `--sourcemap`           | Include source maps (`linked`, `inline`, `external`)     |
+| `--watch`               | Automatically rebuild on file changes                    |
+| `--inline-imports`      | Inline imported modules (`true` or `false`)              |
+| `--packages <how>`      | How to handle packages: `bundle` (default) or `external` |
+| `--external <pkg>`      | Exclude a module or package from the bundle              |
+| `--keep-names`          | Keep original function and class names                   |
+
+For the full flag list, run `deno bundle --help`.
+
+:::tip Bundling a single-file executable
+
+To produce a standalone binary rather than a JavaScript file, use
+[`deno compile`](/runtime/reference/cli/compile/), which can also bundle and
+minify its input with the `--bundle` and `--minify` flags.
+
+:::
 
 ---
 
@@ -234,7 +247,7 @@ Now, let's bundle:
 $ deno bundle --platform=browser app.jsx -o bundle.js
 ⚠️ deno bundle is experimental and subject to changes
 Bundled 9 modules in 99ms
-  app.bundle.js 874.67KB
+  bundle.js 874.67KB
 ```
 
 At this point, we're ready to serve our page, let's use

--- a/runtime/reference/lint_plugins.md
+++ b/runtime/reference/lint_plugins.md
@@ -4,12 +4,10 @@ title: "Lint Plugins"
 description: "Guide to creating and using custom lint plugins in Deno. Learn how to write custom lint rules, use selectors for AST matching, implement fixes, and test your plugins using Deno's lint plugin API."
 ---
 
-:::caution
+:::note
 
-This is an experimental feature and requires Deno `2.2.0` or newer.
-
-The plugin API is currently marked as "unstable" since it is subject to changes
-in the future.
+The lint plugin API is available in Deno `2.2.0` and later, with no unstable
+flag required. The API is still evolving and may change in a future release.
 
 :::
 

--- a/runtime/reference/vscode.md
+++ b/runtime/reference/vscode.md
@@ -171,18 +171,18 @@ Individual hosts/origins can be enabled or disabled by editing the **Deno >
 Suggest > Imports: Hosts** setting - `deno.suggest.imports.hosts` in the
 appropriate `settings.json`.
 
-## Caching remote modules
+## Caching dependencies
 
-Deno supports remote modules and will fetch remote modules and store them
-locally in a cache. When you do something like `deno run`, `deno test`,
-`deno info` or `deno install` on the command line, the Deno CLI will go and try
-to fetch any remote modules and their dependencies and populate the cache.
+Deno downloads your dependencies (npm and JSR packages, and any remote URL
+modules) once and stores them in a local cache. When you run a command like
+`deno run`, `deno test`, `deno info`, or `deno install`, the CLI fetches any
+dependencies that aren't cached yet and populates the cache.
 
-While developing code in the editor, if the module is not in the cache, you will
-get a diagnostic such as
-`Uncached or missing remote URL: "https://deno.land/example/mod.ts"` for any
-missing remote modules. Deno will not automatically try to cache the module,
-unless it is a completion from a registry import suggestion (see above).
+While developing in the editor, if a dependency isn't cached you'll get a
+diagnostic such as
+`Uncached or missing remote URL: "https://deno.land/x/example/mod.ts"` for the
+missing dependency. Deno will not automatically cache it, unless it is a
+completion from a registry import suggestion (see above).
 
 In addition to running a command on a command line, the extension provides ways
 to cache dependencies within the editor. A missing dependency will have a _quick


### PR DESCRIPTION
Second wave of the runtime content sweep. Three touch-ups, each verified
against Deno 2.8 or the Deno source before changing.

bundling.md showed an example output line `app.bundle.js 874.67KB` while the
command used `-o bundle.js`; running the command confirms the output is named
after the `-o` target, so it now reads `bundle.js`. The flags table omitted
several real bundler flags, so `--packages`, `--external`, and `--keep-names`
are added from `deno bundle --help`, and a tip cross-links `deno compile
--bundle/--minify` for producing a standalone binary.

lint_plugins.md carried a caution banner calling the plugin API experimental
and implying it needs an unstable flag. The API runs with no flag on Deno 2.8
(there is no `--unstable-lint`, and it is not in the unstable-features list),
so the banner becomes an accurate note: available since 2.2.0, no flag
required, still evolving.

vscode.md framed dependency caching entirely around remote URL modules, which
is dated in a JSR/npm-first world. The section is broadened to cover npm and
JSR packages too, while keeping the real LSP diagnostic string (`Uncached or
missing remote URL: ...`, from cli/lsp/diagnostics.rs, which has no
package-type-specific variant).