### PR TITLE
docs: add Docker images and dynamic completions to getting started

### DIFF
--- a/runtime/getting_started/installation.md
+++ b/runtime/getting_started/installation.md
@@ -176,8 +176,53 @@ matching `.sha256sum` file for verifying the download.
 
 ## Docker
 
-For more information and instructions on the official Docker images:
-[https://github.com/denoland/deno_docker](https://github.com/denoland/deno_docker)
+Official images are published to both
+[Docker Hub](https://hub.docker.com/r/denoland/deno) and the
+[GitHub Container Registry](https://github.com/denoland/deno/pkgs/container/deno)
+in several variants:
+
+| Tag                        | Base             |
+| -------------------------- | ---------------- |
+| `denoland/deno:debian`     | Debian (default) |
+| `denoland/deno:ubuntu`     | Ubuntu           |
+| `denoland/deno:alpine`     | Alpine Linux     |
+| `denoland/deno:distroless` | Distroless       |
+| `denoland/deno:bin`        | Binary only      |
+
+Each tag is also published with a version, for example `denoland/deno:2.3.1`,
+and pinning to a version is recommended for reproducible builds.
+
+A typical `Dockerfile` caches dependencies as a separate layer and runs as the
+non-root `deno` user:
+
+```dockerfile
+FROM denoland/deno:debian
+
+WORKDIR /app
+
+# Cache dependencies as their own layer
+COPY deno.* ./
+RUN deno install
+
+# Copy the rest of the source and cache the entrypoint
+COPY . .
+RUN deno cache main.ts
+
+USER deno
+EXPOSE 8000
+
+CMD ["run", "--allow-net", "main.ts"]
+```
+
+Build and run it:
+
+```shell
+docker build -t my-app .
+docker run -it -p 8000:8000 my-app
+```
+
+See the [deno_docker repository](https://github.com/denoland/deno_docker) for
+the full set of examples and configuration options.
 
 ## Installation location
 

--- a/runtime/getting_started/installation.md
+++ b/runtime/getting_started/installation.md
@@ -176,53 +176,13 @@ matching `.sha256sum` file for verifying the download.
 
 ## Docker
 
-Official images are published to both
+Deno publishes official images to
 [Docker Hub](https://hub.docker.com/r/denoland/deno) and the
-[GitHub Container Registry](https://github.com/denoland/deno/pkgs/container/deno)
-in several variants:
+[GitHub Container Registry](https://github.com/denoland/deno/pkgs/container/deno),
+in `debian`, `ubuntu`, `alpine`, `distroless`, and `bin` variants.
 
-| Tag                        | Base             |
-| -------------------------- | ---------------- |
-| `denoland/deno:debian`     | Debian (default) |
-| `denoland/deno:ubuntu`     | Ubuntu           |
-| `denoland/deno:alpine`     | Alpine Linux     |
-| `denoland/deno:distroless` | Distroless       |
-| `denoland/deno:bin`        | Binary only      |
-
-Each tag is also published with a version, for example `denoland/deno:2.3.1`,
-and pinning to a version is recommended for reproducible builds.
-
-A typical `Dockerfile` caches dependencies as a separate layer and runs as the
-non-root `deno` user:
-
-```dockerfile
-FROM denoland/deno:debian
-
-WORKDIR /app
-
-# Cache dependencies as their own layer
-COPY deno.* ./
-RUN deno install
-
-# Copy the rest of the source and cache the entrypoint
-COPY . .
-RUN deno cache main.ts
-
-USER deno
-EXPOSE 8000
-
-CMD ["run", "--allow-net", "main.ts"]
-```
-
-Build and run it:
-
-```shell
-docker build -t my-app .
-docker run -it -p 8000:8000 my-app
-```
-
-See the [deno_docker repository](https://github.com/denoland/deno_docker) for
-the full set of examples and configuration options.
+See [Deno and Docker](/runtime/reference/docker/) for Dockerfiles, multi-stage
+builds, Docker Compose, and other best practices.
 
 ## Installation location
 

--- a/runtime/getting_started/setup_your_environment.md
+++ b/runtime/getting_started/setup_your_environment.md
@@ -396,6 +396,18 @@ the fish config folder:
 deno completions fish > ~/.config/fish/completions/deno.fish
 ```
 
+### Dynamic completions
+
+Pass the `--dynamic` flag to generate completions that are aware of your
+project. Currently this lets your shell suggest the task names defined in your
+`deno.json` when you type `deno task <TAB>`:
+
+```shell
+deno completions --dynamic zsh > ~/.zsh/_deno
+```
+
+Dynamic completions are unstable and may change in a future release.
+
 ## Building your own LSP integration
 
 If you're building or maintaining a community integration with the Deno language


### PR DESCRIPTION
The getting started pages had two thin spots that the closed #3008 had
correctly flagged. The installation page's Docker section was a single
bare link to the deno_docker repo, even though the docs already have a
full Deno and Docker reference page; readers had no path to it. The
setup page documented shell completions but not the `--dynamic` flag, so
`deno task <TAB>` task-name completion went unmentioned.

This points the Docker section at the existing
`/runtime/reference/docker/` page and notes the published image variants
and registries, rather than duplicating Dockerfile guidance that already
lives in the reference. The completions section gains a short note on
`--dynamic`. The rest of #3008 (the landing and first-project rewrites)
was already superseded by the runtime landing rework, so only these two
additions were carried over.