### PR TITLE
docs: expand the Config files page with an example and package.json story

### DIFF
--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -1,18 +1,51 @@
 ---
-last_modified: 2026-03-09
+last_modified: 2026-06-14
 title: "Config files"
-description: "How Deno projects are configured: the deno.json file, .jsonc support and discovery, how package.json is used for Node compatibility, and an overview of what you can configure. See the deno.json reference for every field."
+description: "How Deno projects are configured: first-class package.json support, the deno.json file for Deno's own tooling, .jsonc support and discovery, and an overview of what you can configure. See the deno.json reference for every field."
 oldUrl:
   - /runtime/manual/getting_started/configuration_file/
 ---
 
-You can configure Deno using a `deno.json` file. It is where you define tasks,
-manage dependencies, and adjust the TypeScript compiler, linter, formatter, and
-other Deno tools.
+Deno reads two configuration files: Node's `package.json` and its own
+`deno.json`. Both are first-class and both are optional, so Deno works with
+either one or both together. The rule of thumb:
 
-A configuration file is optional. Deno runs a single script with no `deno.json`
-at all; you add one when you want to script common commands, pin dependencies,
-or change a tool's defaults. A minimal file looks like this:
+- Use a **`package.json`** for dependencies and scripts. Deno reads it directly,
+  so most Node.js projects run with no changes and you do not need a `deno.json`
+  at all.
+- Add a **`deno.json`** when you want to configure Deno's own tooling, such as
+  the formatter, linter, TypeScript compiler, or tasks.
+
+## package.json
+
+Deno has first-class `package.json` support. Point Deno at an existing Node.js
+project and it resolves the same npm dependencies from `package.json` and runs
+the project's `scripts` with [`deno task`](/runtime/reference/cli/task/), with
+no `deno.json` and no conversion step:
+
+```sh
+deno install        # install the dependencies from package.json
+deno task <script>  # run a script defined in package.json
+```
+
+A `package.json` configures your project's dependencies and scripts, but it does
+not configure Deno itself. Deno-specific settings such as the formatter, linter,
+TypeScript compiler options, and lockfile behavior live only in `deno.json`.
+When both files are present, Deno reads dependencies from each and takes its own
+configuration from `deno.json`.
+
+This is what lets you adopt Deno incrementally: keep running an app on Node
+while using Deno as a faster drop-in package manager, run your existing scripts
+with `deno task`, and add a `deno.json` for Deno's toolchain when you are ready.
+The [Migrate from Node.js](/runtime/migrate/) guide walks through each step, and
+[Node compatibility in Deno](/runtime/fundamentals/node/) covers how the runtime
+maps Node's APIs and module resolution.
+
+## deno.json
+
+`deno.json` is where you configure Deno itself: tasks, dependencies, and tools
+like the TypeScript compiler, linter, and formatter. It is optional; a minimal
+file looks like this:
 
 ```json title="deno.json"
 {
@@ -28,41 +61,16 @@ or change a tool's defaults. A minimal file looks like this:
 }
 ```
 
-The configuration file supports `.json` and
+It supports `.json` and
 [`.jsonc`](https://code.visualstudio.com/docs/languages/json#_json-with-comments)
 extensions, so with `deno.jsonc` you can add comments and trailing commas.
 
 Deno automatically detects a `deno.json` or `deno.jsonc` file in your current
 working directory or any parent directory, which is what makes a project's
 settings apply to every file under it. Use the `--config` flag to point at a
-different file.
-
-In a monorepo, a root `deno.json` can define a
+different file. In a monorepo, a root `deno.json` can define a
 [workspace](/runtime/fundamentals/workspaces/) whose members each carry their
 own `deno.json`.
-
-## Using deno.json and package.json together
-
-Deno has first-class `package.json` support, so it works with `deno.json`,
-`package.json`, or both together. Most Node.js projects run in Deno with no
-changes: point Deno at an existing project and it resolves the same npm
-dependencies from `package.json` and runs the project's `scripts` with
-[`deno task`](/runtime/reference/cli/task/). You do not need to add a
-`deno.json` to run a Node project at all.
-
-A `package.json` does not, however, configure Deno itself. Deno-specific
-settings such as the linter, formatter, TypeScript compiler options, tasks, and
-lockfile behavior are read only from `deno.json`. When both files are present,
-Deno reads dependencies from each and uses `deno.json` for its own
-configuration.
-
-This dual support is what lets you adopt Deno incrementally. You can keep
-running an app on Node while using Deno as a faster drop-in package manager, run
-your existing `package.json` scripts with `deno task`, and add a `deno.json` to
-pick up Deno's built-in toolchain when you are ready. The
-[Migrate from Node.js](/runtime/migrate/) guide walks through each step, and
-[Node compatibility in Deno](/runtime/fundamentals/node/) covers how the runtime
-maps Node's APIs and module resolution.
 
 ## What you can configure
 

--- a/runtime/fundamentals/configuration.md
+++ b/runtime/fundamentals/configuration.md
@@ -6,31 +6,63 @@ oldUrl:
   - /runtime/manual/getting_started/configuration_file/
 ---
 
-You can configure Deno using a `deno.json` file. This file can be used to
-configure the TypeScript compiler, linter, formatter, and other Deno tools.
+You can configure Deno using a `deno.json` file. It is where you define tasks,
+manage dependencies, and adjust the TypeScript compiler, linter, formatter, and
+other Deno tools.
+
+A configuration file is optional. Deno runs a single script with no `deno.json`
+at all; you add one when you want to script common commands, pin dependencies,
+or change a tool's defaults. A minimal file looks like this:
+
+```json title="deno.json"
+{
+  "tasks": {
+    "dev": "deno run --watch main.ts"
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1"
+  },
+  "fmt": {
+    "lineWidth": 100
+  }
+}
+```
 
 The configuration file supports `.json` and
 [`.jsonc`](https://code.visualstudio.com/docs/languages/json#_json-with-comments)
-extensions.
+extensions, so with `deno.jsonc` you can add comments and trailing commas.
 
-Deno will automatically detect a `deno.json` or `deno.jsonc` configuration file
-if it's in your current working directory or parent directories. The `--config`
-flag can be used to specify a different configuration file.
+Deno automatically detects a `deno.json` or `deno.jsonc` file in your current
+working directory or any parent directory, which is what makes a project's
+settings apply to every file under it. Use the `--config` flag to point at a
+different file.
 
-## package.json support
+In a monorepo, a root `deno.json` can define a
+[workspace](/runtime/fundamentals/workspaces/) whose members each carry their
+own `deno.json`.
 
-For compatibility with Node.js projects, Deno also reads an existing
-`package.json`. You don't need to add a `deno.json` to run a Node project: Deno
-resolves the project's dependencies from `package.json`, and you can run its
-`scripts` with [`deno task`](/runtime/reference/cli/task/).
+## Using deno.json and package.json together
 
-A `package.json` is not, however, a way to configure Deno itself. Deno-specific
-settings such as the linter, formatter, TypeScript compiler options, and
-lockfile are read only from `deno.json`. When both files are present, Deno reads
-dependencies from each and uses `deno.json` for its own configuration.
+Deno has first-class `package.json` support, so it works with `deno.json`,
+`package.json`, or both together. Most Node.js projects run in Deno with no
+changes: point Deno at an existing project and it resolves the same npm
+dependencies from `package.json` and runs the project's `scripts` with
+[`deno task`](/runtime/reference/cli/task/). You do not need to add a
+`deno.json` to run a Node project at all.
 
-Read more about
-[Node compatibility in Deno](/runtime/fundamentals/node/#node-compatibility).
+A `package.json` does not, however, configure Deno itself. Deno-specific
+settings such as the linter, formatter, TypeScript compiler options, tasks, and
+lockfile behavior are read only from `deno.json`. When both files are present,
+Deno reads dependencies from each and uses `deno.json` for its own
+configuration.
+
+This dual support is what lets you adopt Deno incrementally. You can keep
+running an app on Node while using Deno as a faster drop-in package manager, run
+your existing `package.json` scripts with `deno task`, and add a `deno.json` to
+pick up Deno's built-in toolchain when you are ready. The
+[Migrate from Node.js](/runtime/migrate/) guide walks through each step, and
+[Node compatibility in Deno](/runtime/fundamentals/node/) covers how the runtime
+maps Node's APIs and module resolution.
 
 ## What you can configure
 


### PR DESCRIPTION
The Config files page was almost pure navigation: prose plus a list of links
into the deno.json reference, without ever showing what a deno.json actually
looks like. This adds a minimal example up front, states that a configuration
file is optional, explains that config is discovered up the directory tree so
a project's settings apply to every file under it, and links the workspaces
page for monorepos.

It also leans further into package.json. The section now frames the
deno.json-and-package.json dual model directly: Deno reads dependencies and
scripts from package.json while its own tooling settings come only from
deno.json, and the two can coexist. That sets up the incremental adoption
story, so the section links the Migrate from Node.js guide for the
walkthrough and the Node compatibility page for how the runtime maps Node's
APIs and module resolution. The stale node-compatibility anchor is dropped in
favor of a clean link to the page.