### PR TITLE
ci: fail CI when a changed page's last_modified is not bumped

### DIFF
--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -1,0 +1,27 @@
+name: Freshness
+on:
+  pull_request:
+    branches: main
+
+jobs:
+  freshness:
+    name: last_modified freshness check
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Check last_modified freshness
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: deno task check:freshness

--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ files in their respective content directories.
 Static files (like screenshots) can be included directly in the `runtime`,
 `deploy`, or `kv` folders, and referenced by relative URLs in your markdown.
 
+### Keep `last_modified` fresh
+
+Every content page carries a `last_modified: YYYY-MM-DD` field in its
+frontmatter. Whenever you change a page, bump that date to the day of the change
+in the same pull request. CI enforces this: the `frontmatter_test` checks that
+every page has a valid `last_modified`, and the Freshness workflow fails when a
+page is edited without bumping it. Run `deno task check:freshness` locally to
+check your branch.
+
 ### Guides teach, reference enumerates
 
 A topic's depth lives in exactly one place. Guide pages (like `/runtime/test/`

--- a/ai/index.md
+++ b/ai/index.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-02-19
 title: "AI entrypoint"
 description: "Overview and key resources for LLMs and AI agents using the Deno docs"
 url: /ai/

--- a/deno.json
+++ b/deno.json
@@ -41,6 +41,7 @@
     "lume:reference": "deno run --env-file -P=lume lume/cli.ts --config=_config-reference.ts",
     "prod": "deno run --allow-read --allow-env --allow-net server.ts",
     "test": "deno test -A",
+    "check:freshness": "deno run --allow-read --allow-run=git --allow-env scripts/check_freshness.ts",
     "check:links": "deno run --no-lock --allow-net --allow-env .github/workflows/better_link_checker.ts",
     "lint:update": "deno run -A update_lint_rules.ts",
     "generate:search": "deno run -A orama/generate_orama_index_full.ts",

--- a/examples/sandbox/access_output.md
+++ b/examples/sandbox/access_output.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-02-09
 title: "Streaming access string and binary output"
 description: "Learn how to stream string and binary output from commands in a sandbox."
 url: /examples/sandbox_access_output/

--- a/examples/sandbox/command_cancellation.md
+++ b/examples/sandbox/command_cancellation.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-27
 title: "Command cancellation"
 description: "Learn how to cancel commands in a sandbox."
 url: /examples/sandbox_command_cancellation/

--- a/examples/sandbox/environment_variables.md
+++ b/examples/sandbox/environment_variables.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-27
 title: "Set and get environment variables"
 description: "Learn how to set and get environment variables in a sandbox."
 url: /examples/sandbox_environment_variables/

--- a/examples/sandbox/error_handling.md
+++ b/examples/sandbox/error_handling.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-02-09
 title: "Error handling"
 description: "Learn how to handle errors in a sandbox."
 url: /examples/sandbox_error_handling/

--- a/examples/sandbox/javascript_repl.md
+++ b/examples/sandbox/javascript_repl.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-27
 title: "Interactive JavaScript REPL"
 description: "Learn how to provide an interactive Deno REPL in a sandbox."
 url: /examples/sandbox_javascript_repl/

--- a/examples/sandbox/memory.md
+++ b/examples/sandbox/memory.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-02-09
 title: "Configure sandbox memory"
 description: "Learn how to configure the memory allocated to a sandbox"
 url: /examples/sandbox_memory/

--- a/examples/sandbox/spawn_subprocess.md
+++ b/examples/sandbox/spawn_subprocess.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-12
 title: "Spawn a subprocess and get buffered output"
 description: "Learn how to spawn a subprocess, and get buffered output in a sandbox."
 url: /examples/sandbox_spawn_subprocess/

--- a/examples/sandbox/ssh_access.md
+++ b/examples/sandbox/ssh_access.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-02-09
 title: "Provide SSH access to a sandbox"
 description: "Learn how to provide SSH access to a sandbox."
 url: /examples/sandbox_ssh_access/

--- a/examples/sandbox/stream_output.md
+++ b/examples/sandbox/stream_output.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-27
 title: "Stream output to a local file"
 description: "Learn how to stream output to a local file in a sandbox."
 url: /examples/sandbox_stream_output/

--- a/examples/sandbox/template_literals.md
+++ b/examples/sandbox/template_literals.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-27
 title: "Template literal commands with variable interpolation"
 description: "Learn how to use template literal commands with variable interpolation in a sandbox."
 url: /examples/sandbox_template_literals/

--- a/examples/sandbox/timeout_control.md
+++ b/examples/sandbox/timeout_control.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-02-09
 title: "Control sandbox timeout"
 description: "Learn how to control how long your sandbox stays alive using the timeout option."
 url: /examples/sandbox_timeout_control/

--- a/examples/sandbox/upload_files.md
+++ b/examples/sandbox/upload_files.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-27
 title: "Upload files and directories"
 description: "Learn how to upload files and directories to a sandbox."
 url: /examples/sandbox_upload_files/

--- a/examples/sandbox/vscode_instance.md
+++ b/examples/sandbox/vscode_instance.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-27
 title: "Provide a VSCode instance in a sandbox"
 description: "Learn how to provide a VSCode instance in a sandbox."
 url: /examples/sandbox_vscode_instance/

--- a/examples/sandbox/web_framework.md
+++ b/examples/sandbox/web_framework.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-27
 title: "Serve a web framework"
 description: "Create a package.json, install deps, run a web framework (Express), and expose it publicly from a sandbox"
 url: /examples/sandbox_web_framework/

--- a/examples/tutorials/add_remove_dependencies.md
+++ b/examples/tutorials/add_remove_dependencies.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Add and remove dependencies"
 description: "Manage project dependencies with deno add and deno remove: npm and JSR packages, version pinning, dev dependencies, and aliasing packages in your import map."
 url: /examples/add_remove_dependencies_tutorial/

--- a/examples/tutorials/deno_github_actions.md
+++ b/examples/tutorials/deno_github_actions.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Run Deno in GitHub Actions"
 description: "Set up a GitHub Actions workflow for a Deno project: install Deno with setup-deno, cache dependencies, run fmt, lint and test, install with a frozen lockfile, and test across Deno versions."
 url: /examples/deno_github_actions_tutorial/

--- a/examples/tutorials/dependency_lockfile.md
+++ b/examples/tutorials/dependency_lockfile.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Lock dependencies with deno.lock"
 description: "Use deno.lock for reproducible installs: what the lockfile records, reviewing lockfile diffs, frozen lockfiles for CI with --frozen and deno ci, and regenerating or relocating the lockfile."
 url: /examples/dependency_lockfile_tutorial/

--- a/examples/tutorials/import_maps.md
+++ b/examples/tutorials/import_maps.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Re-map import paths"
 description: "Use the imports field in deno.json as an import map: path aliases like @/ for src/, bare names for local modules, and scoped overrides for transitive imports."
 url: /examples/import_maps_tutorial/

--- a/examples/tutorials/local_unpublished_packages.md
+++ b/examples/tutorials/local_unpublished_packages.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Use local and unpublished packages"
 description: "Work with code that isn't on a registry: link a local package copy with the links field, import straight from HTTPS URLs including private GitHub repos, and know which specifiers Deno does not support."
 url: /examples/local_unpublished_packages_tutorial/

--- a/examples/tutorials/migrate_node_project.md
+++ b/examples/tutorials/migrate_node_project.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Use Deno in an existing Node.js project"
 description: "Run an existing Node.js project with Deno without rewriting it: install from package.json, run npm scripts with deno task, use node: built-ins, and adopt Deno's built-in tooling incrementally."
 url: /examples/migrate_node_project_tutorial/

--- a/examples/tutorials/npm_lifecycle_scripts.md
+++ b/examples/tutorials/npm_lifecycle_scripts.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Run npm lifecycle scripts"
 description: "Allow npm postinstall and other lifecycle scripts in Deno with deno approve-scripts, and persist approvals with the allowScripts field in deno.json."
 url: /examples/npm_lifecycle_scripts_tutorial/

--- a/examples/tutorials/private_registries.md
+++ b/examples/tutorials/private_registries.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Use private npm registries"
 description: "Configure Deno to install npm packages from private registries: .npmrc scoped registries and auth tokens, the NPM_CONFIG_REGISTRY override, DENO_AUTH_TOKENS, and worked setups for Azure Artifacts and JFrog Artifactory."
 url: /examples/private_registries_tutorial/

--- a/examples/tutorials/testing_library.md
+++ b/examples/tutorials/testing_library.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Use Testing Library with Deno"
 description: "Test DOM behavior with @testing-library/dom and happy-dom in deno test: querying by role and text, simulating events, and the permissions the setup needs."
 url: /examples/testing_library_tutorial/

--- a/examples/tutorials/vite.md
+++ b/examples/tutorials/vite.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-13
 title: "Use Vite with Deno"
 description: "Step-by-step tutorial on building a front-end app with Vite and Deno. Learn how to scaffold a project, install dependencies, run the dev server with hot module replacement, and build for production."
 url: /examples/vite_tutorial/

--- a/examples/tutorials/workspaces_monorepo.md
+++ b/examples/tutorials/workspaces_monorepo.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Configure a monorepo with workspaces"
 description: "Set up a Deno workspace with multiple packages: member names and exports, glob patterns, root-only options, shared imports, and centralized dependency versions with catalogs."
 url: /examples/workspaces_monorepo_tutorial/

--- a/examples/videos/all-in-one_tooling.md
+++ b/examples/videos/all-in-one_tooling.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2025-03-10
 title: "All-in-one tooling"
 description: "Learn about Deno's built-in developer tools. Watch how to use the integrated formatter, linter, and test runner to improve code quality without additional configuration or third-party dependencies."
 url: /examples/all-in-one_tooling/

--- a/examples/videos/backward_compat_with_node_npm.md
+++ b/examples/videos/backward_compat_with_node_npm.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Compatibility with Node & npm"
 description: "Learn how to integrate Deno into existing Node.js projects using npm modules and Node standard libraries, without major rewrites."
 url: /examples/backward_compat_with_node_npm/

--- a/examples/videos/browser_apis_in_deno.md
+++ b/examples/videos/browser_apis_in_deno.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2025-03-10
 title: "Browser APIs in Deno"
 description: "Explore web standard APIs in Deno's server-side environment. Learn how to use fetch, streams, text encoders, and other browser-compatible features while building modern applications with familiar web APIs."
 url: /examples/browser_apis_in_deno/

--- a/examples/videos/build_api_server_ts.md
+++ b/examples/videos/build_api_server_ts.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2025-03-10
 title: "Build an API server with TypeScript"
 description: "A guide to creating a RESTful API server using Hono and TypeScript in Deno. Watch how to implement CRUD operations, handle routing, manage data persistence, and build a production-ready backend service."
 url: /examples/build_api_server_ts/

--- a/examples/videos/byte_and_text_imports.md
+++ b/examples/videos/byte_and_text_imports.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Byte and text imports"
 description: "Learn how to import bytes and text files directly into your module graph for automatic tree shaking and more."
 url: /examples/byte_and_text_imports/

--- a/examples/videos/command_line_utility.md
+++ b/examples/videos/command_line_utility.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Build a Command Line Utility"
 description: "Learn to build a command line tool with Deno's standard library, parse flags, handle errors, and compile cross-platform executables."
 url: /examples/command_line_utility/

--- a/examples/videos/configuration_with_deno_json.md
+++ b/examples/videos/configuration_with_deno_json.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Configuration with Deno JSON"
 description: "Learn how to use deno.json to manage dependencies, configure tasks, customize formatting and linting, and work with import maps."
 url: /examples/configuration_with_deno_json/

--- a/examples/videos/deno_bench.md
+++ b/examples/videos/deno_bench.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2025-10-15
 title: "Benchmarking with Deno bench"
 description: "Learn how to measure code performance using Deno's built-in benchmarking tool. Discover baseline comparisons, grouped benchmarks, and precise measurement techniques for optimizing your TypeScript and JavaScript code."
 url: /examples/deno_bench/

--- a/examples/videos/deno_coverage.md
+++ b/examples/videos/deno_coverage.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2025-03-10
 title: "Deno coverage"
 description: "Learn how to measure test coverage in Deno projects. Watch how to generate coverage reports, analyze code coverage metrics, and use the HTML report feature."
 url: /examples/deno_coverage/

--- a/examples/videos/deno_dev_environment.md
+++ b/examples/videos/deno_dev_environment.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2025-03-10
 title: "Your Deno Dev Environment"
 description: "Learn how to set up your Deno development environment. Watch how to install Deno, configure VS Code, enable type checking and autocomplete, and optimize your TypeScript development workflow."
 url: /examples/deno_dev_environment/

--- a/examples/videos/deno_fmt.md
+++ b/examples/videos/deno_fmt.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Formatting with Deno fmt"
 description: "Learn tips and tricks for using deno fmt, Deno's fast, customizable built-in code formatter, in any workflow."
 url: /examples/deno_fmt/

--- a/examples/videos/deno_test.md
+++ b/examples/videos/deno_test.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Getting started with Deno test"
 description: "Learn the basics of writing and running tests with Deno's built-in test runner."
 url: /examples/deno_test/

--- a/examples/videos/deploy_deno_to_aws_lambda.md
+++ b/examples/videos/deploy_deno_to_aws_lambda.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Deploy Deno to AWS Lambda"
 description: "Learn how to deploy a Deno application to AWS Lambda using a Dockerfile and the aws-lambda-adapter community runtime."
 url: /examples/deploy_deno_to_aws_lambda/

--- a/examples/videos/deploying_deno_with_docker.md
+++ b/examples/videos/deploying_deno_with_docker.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Deploying Deno with Docker"
 description: "Learn how to containerize a Deno application with Docker and deploy it to a compatible cloud environment."
 url: /examples/deploying_deno_with_docker/

--- a/examples/videos/esmodules.md
+++ b/examples/videos/esmodules.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "ECMAScript Modules"
 description: "Learn how Deno uses standard ECMAScript modules to import and share JavaScript and TypeScript code."
 url: /examples/esmodules/

--- a/examples/videos/image_bundling_deno_compile.md
+++ b/examples/videos/image_bundling_deno_compile.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Image bundling with deno compile"
 description: "Learn how to embed image assets in a deno compile executable using bytes imports, demonstrated with a Flappybird game."
 url: /examples/image_bundling_deno_compile/

--- a/examples/videos/interoperability_with_nodejs.md
+++ b/examples/videos/interoperability_with_nodejs.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Interoperability with Node.js"
 description: "Learn how to use Node.js built-in APIs, npm modules, and JSR packages in your Deno projects."
 url: /examples/interoperability_with_nodejs/

--- a/examples/videos/intro_to_deno_apis.md
+++ b/examples/videos/intro_to_deno_apis.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Introduction to Deno APIs"
 description: "Explore Deno's built-in APIs for file system operations, command line arguments, environment variables, and serving HTTP requests."
 url: /examples/intro_to_deno_apis/

--- a/examples/videos/publishing_modules_with_jsr.md
+++ b/examples/videos/publishing_modules_with_jsr.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Publishing Modules with JSR"
 description: "Discover JSR, the TypeScript-first registry for modern JavaScript, and learn how to install and publish packages with it."
 url: /examples/publishing_modules_with_jsr/

--- a/examples/videos/react_app_video.md
+++ b/examples/videos/react_app_video.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Build a React app"
 description: "Watch how to build a React app with a Deno backend, from project setup to a working application."
 url: /examples/react_app_video/

--- a/examples/videos/realtime_websocket_app.md
+++ b/examples/videos/realtime_websocket_app.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Build a Realtime WebSocket Application"
 description: "Learn how to build a realtime application in Deno using the standard WebSocket API."
 url: /examples/realtime_websocket_app/

--- a/examples/videos/snapshot_python.md
+++ b/examples/videos/snapshot_python.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-02-26
 title: "Safe Cloud Code Execution with Snapshots"
 description: "Deno Sandbox lets you spin up isolated cloud VMs programmatically.  With the snapshots feature, you can pre-install an entire environment once and boot it without waiting for installs every time after."
 url: /examples/snapshot_python_video/

--- a/examples/videos/ts_jsx.md
+++ b/examples/videos/ts_jsx.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "TypeScript and JSX"
 description: "Learn how Deno runs TypeScript and JSX out of the box, with zero configuration or extra tooling required."
 url: /examples/ts_jsx/

--- a/examples/videos/vue_app_video.md
+++ b/examples/videos/vue_app_video.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Build a Vue app"
 description: "Watch how to build a Vue app with a Deno backend, from project setup to a working application."
 url: /examples/vue_app_video/

--- a/examples/videos/what_is_deno.md
+++ b/examples/videos/what_is_deno.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "What is Deno?"
 description: "A short introduction to Deno, the secure JavaScript, TypeScript, and WebAssembly runtime built on web standards, and its history."
 url: /examples/what_is_deno/

--- a/frontmatter_test.ts
+++ b/frontmatter_test.ts
@@ -4,6 +4,20 @@ import { assert, assertEquals } from "@std/assert";
 
 const DIRS_TO_CHECK = ["./runtime", "./deploy", "./examples"];
 
+// Content pages that must carry a `last_modified` frontmatter field so the
+// freshness check (scripts/check_freshness.ts) has something to enforce.
+const LAST_MODIFIED_DIRS = [
+  "./runtime",
+  "./deploy",
+  "./examples",
+  "./sandbox",
+  "./subhosting",
+  "./ai",
+];
+// Generated or synced subtrees that aren't hand-edited content pages.
+const LAST_MODIFIED_EXCLUDES = ["runtime/reference/std/"];
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 Deno.test("Frontmatter titles must not contain backticks", async (t) => {
   for (const dir of DIRS_TO_CHECK) {
     for await (const entry of walk(dir, { exts: [".md", ".mdx"] })) {
@@ -42,5 +56,46 @@ Deno.test("CLI command page titles must be just the command name", async (t) => 
         `Title should be "${expected}", got "${attrs.title}". Put descriptions in the "description" field instead.`,
       );
     });
+  }
+});
+
+Deno.test("Content pages must have a valid last_modified field", async (t) => {
+  const today = new Date().toISOString().slice(0, 10);
+
+  for (const dir of LAST_MODIFIED_DIRS) {
+    for await (const entry of walk(dir, { exts: [".md", ".mdx"] })) {
+      const rel = entry.path.replace(/^\.\//, "");
+      if (LAST_MODIFIED_EXCLUDES.some((p) => rel.startsWith(p))) continue;
+
+      const content = await Deno.readTextFile(entry.path);
+      if (content.trim() === "") continue; // empty placeholder, not a page
+
+      await t.step(entry.path, () => {
+        assert(
+          content.startsWith("---"),
+          `Missing frontmatter; add a "last_modified: ${today}" field.`,
+        );
+
+        const { attrs } = extract<{ last_modified?: unknown }>(content);
+        const value = attrs.last_modified;
+        assert(
+          value != null,
+          `Missing "last_modified" field; add "last_modified: ${today}".`,
+        );
+
+        // YAML parses an unquoted date into a Date; accept either form.
+        const date = value instanceof Date
+          ? value.toISOString().slice(0, 10)
+          : String(value).trim();
+        assert(
+          DATE_RE.test(date),
+          `"last_modified" must be a YYYY-MM-DD date, got "${date}".`,
+        );
+        assert(
+          date <= today,
+          `"last_modified" is in the future ("${date}"); today is ${today}.`,
+        );
+      });
+    }
   }
 });

--- a/runtime/cli_apps/index.md
+++ b/runtime/cli_apps/index.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Build CLI apps"
 description: "Build command-line tools with Deno: read arguments and stdin, prompt the user, set exit codes, compile to a single self-contained executable, and distribute your tool."
 ---

--- a/runtime/fundamentals/cpu_profiling.md
+++ b/runtime/fundamentals/cpu_profiling.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "CPU profiling"
 description: "Profile Deno programs with the built-in CPU profiler: collecting profiles, Markdown and flamegraph reports, Chrome DevTools analysis, and profiling tips."
 ---

--- a/runtime/packages/private_repositories.md
+++ b/runtime/packages/private_repositories.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Private repositories"
 description: "Load remote modules from private repositories with DENO_AUTH_TOKENS: bearer tokens, basic auth, and a GitHub walkthrough."
 oldUrl:

--- a/runtime/packages/publishing.md
+++ b/runtime/packages/publishing.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Publishing packages"
 description: "Publish Deno packages to JSR with deno publish, build npm-compatible tarballs with deno pack, and choose the right registry for your library."
 oldUrl:

--- a/runtime/packages/supply_chain.md
+++ b/runtime/packages/supply_chain.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Supply chain management"
 description: "Keep Deno dependencies deterministic and safe: lockfile discipline, minimum dependency age, deno audit, intentional updates, and a recommended CI baseline."
 ---

--- a/runtime/reference/index.md
+++ b/runtime/reference/index.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Reference"
 description: "Look it up: the full deno CLI, configuration, the standard library, and runtime APIs."
 ---

--- a/runtime/run/index.md
+++ b/runtime/run/index.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-11
 title: "Run code"
 description: "Run JavaScript and TypeScript with Deno: the secure-by-default permission model, running files, URLs and stdin, watch mode, and project tasks."
 ---

--- a/runtime/test/coverage.md
+++ b/runtime/test/coverage.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Test coverage"
 description: "Collect coverage data with deno test --coverage and turn it into terminal summaries, HTML reports, and lcov files for CI with deno coverage."
 oldUrl:

--- a/runtime/test/doc_tests.md
+++ b/runtime/test/doc_tests.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Documentation tests"
 description: "Run the code examples in your JSDoc comments and markdown files as tests with deno test --doc, so your documentation never goes stale."
 oldUrl:

--- a/runtime/test/migrate_from_jest.md
+++ b/runtime/test/migrate_from_jest.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Migrating from Jest"
 description: "Move a Jest test suite to deno test: describe/it via node:test, expect mappings, mock function equivalents, snapshot testing, fake timers, and translating Jest configuration."
 ---

--- a/runtime/test/mocking.md
+++ b/runtime/test/mocking.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Mocking and test doubles"
 description: "Isolate the code under test with spies, stubs, mocks, and fake time using the Deno Standard Library's @std/testing package."
 oldUrl:

--- a/runtime/test/sanitizers.md
+++ b/runtime/test/sanitizers.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Test sanitizers"
 description: "Deno's test sanitizers catch leaking async operations, resources, and surprise exits in your tests. Learn what each sanitizer checks and how to enable them."
 oldUrl:

--- a/runtime/test/snapshots.md
+++ b/runtime/test/snapshots.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-06-12
 title: "Snapshot testing"
 description: "Capture program output as reference snapshots with @std/testing, compare against them on every run, and update them with deno test -- --update."
 oldUrl:

--- a/sandbox/apps.md
+++ b/sandbox/apps.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: "Programmatic management of Deno Deploy Apps"
 description: "Use the @deno/sandbox Client to create, list, update, and delete Deno Deploy apps programmatically."
 ---

--- a/sandbox/cli.md
+++ b/sandbox/cli.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-02-02
 title: "Management via CLI"
 description: "How to manage Deno Sandbox with the Deno CLI."
 ---

--- a/sandbox/create.md
+++ b/sandbox/create.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-28
 title: "Create a Deno Sandbox"
 description: "Learn how to provision a sandbox with the static Sandbox.create() method and configure runtime, network, and lifecycle options."
 ---

--- a/sandbox/expose_http.md
+++ b/sandbox/expose_http.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-02-13
 title: "Expose HTTP"
 description: "Learn how to expose HTTP endpoints from Deno Sandbox, enabling you to run web servers, APIs, and preview environments at the edge."
 ---

--- a/sandbox/getting_started.md
+++ b/sandbox/getting_started.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-28
 title: "Getting started"
 description: "Step-by-step walkthrough for enabling Deno Sandbox, creating your first microVM, running commands, exposing services, and managing secrets."
 ---

--- a/sandbox/index.md
+++ b/sandbox/index.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: "Deno Sandbox"
 description: "Overview of the Deno Sandbox microVM platform on Deploy, including capabilities, security model, and ideal use cases."
 ---

--- a/sandbox/promote.md
+++ b/sandbox/promote.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-28
 title: "Promote Deno Sandbox to Deploy Apps"
 description: "Learn how to promote a sandbox to a full Deno Deploy app for production use."
 ---

--- a/sandbox/security.md
+++ b/sandbox/security.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-28
 title: Security
 description: "Understand the defense-in-depth model behind Deno Sandbox: isolation, secrets, network controls, and auditing."
 ---

--- a/sandbox/ssh.md
+++ b/sandbox/ssh.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-01-28
 title: "SSH"
 description: "How to open secure SSH access into a sandbox for interactive debugging, editor sessions, or long-running processes."
 ---

--- a/sandbox/timeouts.md
+++ b/sandbox/timeouts.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-02-02
 title: "Sandbox Timeouts"
 description: "Understand how long Deno Sandbox stays alive, how to extend or reconnect to them, and when to promote work to a Deno Deploy app."
 ---

--- a/sandbox/volumes.md
+++ b/sandbox/volumes.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-04-20
 title: "Volumes & Snapshots"
 description: "Persistent storage and bootable images for Deno Sandbox"
 ---

--- a/scripts/check_freshness.ts
+++ b/scripts/check_freshness.ts
@@ -1,0 +1,167 @@
+// Freshness check: when a docs page that tracks a `last_modified` field is
+// changed in a pull request, that field must be bumped in the same PR.
+//
+// The check compares the PR against its merge-base with the target branch.
+// Pages that don't have a `last_modified` field at all are left alone, so
+// this only enforces freshness where we already opted in to tracking it.
+//
+// Run locally:   deno task check:freshness
+// Run in CI:     BASE_SHA=<base sha> deno task check:freshness
+
+import { extract } from "@std/front-matter/yaml";
+
+const DOC_EXTENSIONS = [".md", ".mdx"];
+
+async function git(...args: string[]): Promise<string> {
+  const { code, stdout, stderr } = await new Deno.Command("git", {
+    args,
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+  if (code !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed:\n${new TextDecoder().decode(stderr)}`,
+    );
+  }
+  return new TextDecoder().decode(stdout);
+}
+
+// Returns the blob at `ref:path`, or null if the path doesn't exist there.
+async function showFile(ref: string, path: string): Promise<string | null> {
+  const { code, stdout } = await new Deno.Command("git", {
+    args: ["show", `${ref}:${path}`],
+    stdout: "piped",
+    stderr: "null",
+  }).output();
+  if (code !== 0) return null;
+  return new TextDecoder().decode(stdout);
+}
+
+// Extracts and normalizes the `last_modified` field as a YYYY-MM-DD string,
+// or null if the file has no frontmatter or no `last_modified` field.
+function lastModified(content: string | null): string | null {
+  if (!content || !content.startsWith("---")) return null;
+  let attrs: { last_modified?: unknown };
+  try {
+    ({ attrs } = extract<{ last_modified?: unknown }>(content));
+  } catch {
+    return null;
+  }
+  const value = attrs.last_modified;
+  if (value == null) return null;
+  // YAML parses an unquoted date into a Date; normalize both forms to a string.
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  return String(value).trim();
+}
+
+function isDoc(path: string): boolean {
+  return DOC_EXTENSIONS.some((ext) => path.endsWith(ext));
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+async function resolveBase(): Promise<string> {
+  const fromEnv = Deno.env.get("BASE_SHA") ?? Deno.env.get("BASE_REF");
+  if (fromEnv) return fromEnv.trim();
+  // Local fallback: diff against the default branch.
+  for (const ref of ["origin/main", "main"]) {
+    const { code } = await new Deno.Command("git", {
+      args: ["rev-parse", "--verify", "--quiet", ref],
+      stdout: "null",
+      stderr: "null",
+    }).output();
+    if (code === 0) return ref;
+  }
+  throw new Error(
+    "Could not determine a base ref. Set BASE_SHA or ensure origin/main exists.",
+  );
+}
+
+async function main() {
+  const base = await resolveBase();
+  const mergeBase = (await git("merge-base", base, "HEAD")).trim();
+
+  const today = new Date().toISOString().slice(0, 10);
+  const violations: string[] = [];
+
+  // -M detects renames; status is e.g. "M", "A", "D", "R095".
+  const nameStatus = await git(
+    "diff",
+    "--name-status",
+    "-M",
+    `${mergeBase}..HEAD`,
+  );
+
+  for (const line of nameStatus.split("\n")) {
+    if (!line.trim()) continue;
+    const parts = line.split("\t");
+    const status = parts[0];
+    if (status === "D") continue; // deletions need no bump
+
+    const isRename = status.startsWith("R");
+    const oldPath = parts[1];
+    const newPath = isRename ? parts[2] : parts[1];
+    if (!isDoc(newPath)) continue;
+
+    const headContent = await showFile("HEAD", newPath);
+    const baseContent = status === "A"
+      ? null
+      : await showFile(mergeBase, oldPath);
+
+    // No real content change (e.g. a pure rename) needs no bump.
+    if (baseContent !== null && baseContent === headContent) continue;
+
+    const baseLM = lastModified(baseContent);
+    const headLM = lastModified(headContent);
+
+    // Page doesn't track last_modified on either side: out of scope.
+    if (baseLM === null && headLM === null) continue;
+
+    if (headLM === null) {
+      violations.push(
+        `${newPath}: the 'last_modified' field was removed; keep it and set it to ${today}.`,
+      );
+      continue;
+    }
+
+    if (!DATE_RE.test(headLM)) {
+      violations.push(
+        `${newPath}: 'last_modified' must be a YYYY-MM-DD date, got "${headLM}".`,
+      );
+      continue;
+    }
+
+    if (headLM > today) {
+      violations.push(
+        `${newPath}: 'last_modified' is in the future ("${headLM}"); today is ${today}.`,
+      );
+      continue;
+    }
+
+    // The core freshness rule: content changed but the date didn't move.
+    if (baseLM !== null && headLM === baseLM) {
+      violations.push(
+        `${newPath}: page changed but 'last_modified' was not updated (still ${headLM}); set it to ${today}.`,
+      );
+    }
+  }
+
+  if (violations.length > 0) {
+    console.error(
+      `\nFreshness check failed for ${violations.length} page(s):\n`,
+    );
+    for (const v of violations) console.error(`  - ${v}`);
+    console.error(
+      `\nWhen you change a page that tracks 'last_modified', bump that field to the date of the change.\n`,
+    );
+    Deno.exit(1);
+  }
+
+  console.log(
+    "Freshness check passed: all changed pages have a fresh 'last_modified'.",
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/subhosting/api/authentication.md
+++ b/subhosting/api/authentication.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: Authentication
 ---
 

--- a/subhosting/api/index.md
+++ b/subhosting/api/index.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: Subhosting Resources
 oldUrl:
   - /deploy/api/rest/

--- a/subhosting/manual/acceptable_use_policy.md
+++ b/subhosting/manual/acceptable_use_policy.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: Acceptable use policy
 ---
 

--- a/subhosting/manual/api_migration_guide.md
+++ b/subhosting/manual/api_migration_guide.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: "Migrating from subhosting API v1 to v2"
 description: "Detailed guide for migrating from the Deno Deploy subhosting API v1 to v2, covering endpoint changes, deployment model differences, and new features like labels and layers."
 oldUrl:

--- a/subhosting/manual/events.md
+++ b/subhosting/manual/events.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: Deployment events
 ---
 

--- a/subhosting/manual/index.md
+++ b/subhosting/manual/index.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: About Subhosting
 oldUrl:
   - /subhosting/

--- a/subhosting/manual/planning_your_implementation.md
+++ b/subhosting/manual/planning_your_implementation.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: Planning your implementation
 ---
 

--- a/subhosting/manual/pricing_and_limits.md
+++ b/subhosting/manual/pricing_and_limits.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: Pricing and Limits
 description: Overview of Deno Subhosting pricing plans, resource limits, deployment restrictions, and performance constraints for your applications.
 ---

--- a/subhosting/manual/quick_start.md
+++ b/subhosting/manual/quick_start.md
@@ -1,4 +1,5 @@
 ---
+last_modified: 2026-03-19
 title: Subhosting Quick Start
 oldUrl:
   - /deploy/manual/subhosting/projects_and_deployments/


### PR DESCRIPTION
Many of our docs pages carry a `last_modified` frontmatter field, but
nothing kept it honest: pages could be edited without bumping the date,
and many pages had no date at all. Over time the field drifted away from
reality and stopped being trustworthy.

This makes the field complete and self-maintaining. A frontmatter test
now requires every hand-edited content page under runtime, deploy,
examples, sandbox, subhosting, and ai to carry a valid `last_modified`
date (present, YYYY-MM-DD, not in the future); generated reference,
synced lint rules, and empty placeholders are out of scope. The 84 pages
that lacked the field are backfilled using each file's last git
content-change date, so the dates reflect reality rather than the day of
this commit.

On top of that, a dedicated Freshness workflow runs on every pull
request and fails when a page's content changes relative to the PR's
merge-base without the date being bumped in the same PR. The check lives
in scripts/check_freshness.ts and is available locally via
deno task check:freshness. Contributor docs in the README describe the
requirement.

This supersedes #3011, which took a heavier dev-server-plus-git-history
approach.