### PR TITLE
docs: expand the AI examples (Claude chat + tool use)

### DIFF
--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -1191,6 +1191,12 @@ export const items = [
     category: "AI",
   },
   {
+    title: "Connect to Claude (Anthropic API)",
+    href: "/examples/anthropic_chat_completion/",
+    type: "example",
+    category: "AI",
+  },
+  {
     title: "Connect to OpenAI - Chat completion",
     href: "/examples/openai_chat_completion/",
     type: "example",

--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -1197,6 +1197,12 @@ export const items = [
     category: "AI",
   },
   {
+    title: "Build an agent with tool use",
+    href: "/examples/anthropic_tool_use/",
+    type: "example",
+    category: "AI",
+  },
+  {
     title: "Connect to OpenAI - Chat completion",
     href: "/examples/openai_chat_completion/",
     type: "example",

--- a/examples/scripts/anthropic_chat_completion.ts
+++ b/examples/scripts/anthropic_chat_completion.ts
@@ -1,0 +1,42 @@
+/**
+ * @title Connect to Claude (Anthropic API)
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N -E <url>
+ * @resource {https://www.npmjs.com/package/@anthropic-ai/sdk} @anthropic-ai/sdk on npm
+ * @resource {https://docs.claude.com/en/api/overview} Claude API reference
+ * @group AI
+ *
+ * The official Anthropic SDK runs in Deno straight from npm. This example
+ * streams a chat response from Claude so tokens print as they arrive, which
+ * keeps long replies responsive and avoids request timeouts. Set your key in
+ * the ANTHROPIC_API_KEY environment variable before running.
+ */
+
+import Anthropic from "npm:@anthropic-ai/sdk";
+
+// The client reads the API key from the ANTHROPIC_API_KEY environment variable
+// by default, so there is nothing to pass to the constructor.
+const client = new Anthropic();
+
+// Open a streaming request. Streaming is the recommended default for anything
+// that might produce a long reply: tokens arrive incrementally instead of in
+// one large response at the end.
+const stream = client.messages.stream({
+  model: "claude-opus-4-8",
+  max_tokens: 1024,
+  messages: [
+    { role: "user", content: "In one sentence, what makes Deno distinctive?" },
+  ],
+});
+
+// The `text` event yields each text delta as the model produces it. Write the
+// chunks straight to stdout so they render as a single, growing reply.
+stream.on("text", (delta) => {
+  Deno.stdout.writeSync(new TextEncoder().encode(delta));
+});
+
+// Wait for the stream to finish and read the complete message. The final
+// message also carries token usage, which is useful for cost tracking.
+const message = await stream.finalMessage();
+console.log(`\n\nOutput tokens: ${message.usage.output_tokens}`);

--- a/examples/scripts/anthropic_tool_use.ts
+++ b/examples/scripts/anthropic_tool_use.ts
@@ -1,0 +1,90 @@
+/**
+ * @title Build an agent with tool use
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N -E <url>
+ * @resource {https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview} Claude tool use overview
+ * @resource {https://www.npmjs.com/package/@anthropic-ai/sdk} @anthropic-ai/sdk on npm
+ * @group AI
+ *
+ * Tool use lets Claude call functions you define and act on the results. You
+ * describe each tool with a JSON schema, and when Claude decides to use one it
+ * returns a tool_use request instead of a final answer. You run the tool, send
+ * the result back, and repeat until Claude is done. This loop is the core of
+ * an agent. Set ANTHROPIC_API_KEY before running.
+ */
+
+import Anthropic from "npm:@anthropic-ai/sdk";
+
+const client = new Anthropic();
+
+// Describe the tool with a JSON schema. A clear description and prescriptive
+// "when to call it" wording help Claude decide to use it at the right time.
+const tools: Anthropic.Tool[] = [
+  {
+    name: "get_weather",
+    description:
+      "Get the current weather for a city. Call this whenever the user asks " +
+      "about weather conditions.",
+    input_schema: {
+      type: "object",
+      properties: {
+        city: { type: "string", description: "City name, e.g. Tokyo" },
+      },
+      required: ["city"],
+    },
+  },
+];
+
+// The actual implementation. In a real app this would call a weather API; here
+// it returns canned data so the example runs without extra setup.
+function getWeather(city: string): string {
+  const data: Record<string, string> = {
+    Tokyo: "18°C, clear",
+    Paris: "12°C, light rain",
+    Oslo: "4°C, snow",
+  };
+  return data[city] ?? `No data for ${city}`;
+}
+
+// The API is stateless, so we carry the full conversation in `messages`.
+const messages: Anthropic.MessageParam[] = [
+  { role: "user", content: "Compare the weather in Tokyo and Oslo right now." },
+];
+
+// Agent loop: keep calling the model until it stops requesting tools.
+while (true) {
+  const response = await client.messages.create({
+    model: "claude-opus-4-8",
+    max_tokens: 1024,
+    tools,
+    messages,
+  });
+
+  // No tool requested means Claude produced its final answer.
+  if (response.stop_reason !== "tool_use") {
+    for (const block of response.content) {
+      if (block.type === "text") console.log(block.text);
+    }
+    break;
+  }
+
+  // Record the assistant turn; it holds the tool_use blocks we must answer.
+  messages.push({ role: "assistant", content: response.content });
+
+  // Run every requested tool and gather the results.
+  const toolResults: Anthropic.ToolResultBlockParam[] = [];
+  for (const block of response.content) {
+    if (block.type === "tool_use" && block.name === "get_weather") {
+      const { city } = block.input as { city: string };
+      toolResults.push({
+        type: "tool_result",
+        tool_use_id: block.id,
+        content: getWeather(city),
+      });
+    }
+  }
+
+  // Feed the results back so Claude can continue from where it left off.
+  messages.push({ role: "user", content: toolResults });
+}


### PR DESCRIPTION
The examples AI category had only three entries, and the sole
model-provider example was for OpenAI. Given Deno's TypeScript audience,
the absence of an Anthropic example was a conspicuous gap. This is the
first step of a broader effort to grow the AI section.

The first example, Connect to Claude, streams a chat response through
the official @anthropic-ai/sdk loaded straight from npm, using the
ANTHROPIC_API_KEY environment variable for auth. It streams rather than
buffering so long replies stay responsive and avoid request timeouts.

The second example, Build an agent with tool use, shows Claude calling a
developer-defined tool through a manual agent loop over the Messages API:
describe a tool with a JSON schema, run it when Claude requests it, send
the result back, and repeat until Claude produces a final answer. Both
examples depend only on @anthropic-ai/sdk so they run in Deno with no
extra setup, and both sit alongside the existing OpenAI example.