### PR TITLE
docs: add structured output, RAG, and MCP client AI examples

### DIFF
--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -1023,6 +1023,24 @@ export const items = [
     category: "AI",
   },
   {
+    title: "Get structured JSON output from Claude",
+    href: "/examples/anthropic_structured_output/",
+    type: "example",
+    category: "AI",
+  },
+  {
+    title: "RAG: ground Claude's answer in your documents",
+    href: "/examples/anthropic_rag/",
+    type: "example",
+    category: "AI",
+  },
+  {
+    title: "Connect to an MCP server from a client",
+    href: "/examples/mcp_client/",
+    type: "example",
+    category: "AI",
+  },
+  {
     title: "Connect to OpenAI - Chat completion",
     href: "/examples/openai_chat_completion/",
     type: "example",

--- a/examples/scripts/anthropic_rag.ts
+++ b/examples/scripts/anthropic_rag.ts
@@ -1,0 +1,96 @@
+/**
+ * @title RAG: ground Claude's answer in your documents
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N -E <url>
+ * @resource {https://docs.voyageai.com/docs/embeddings} Voyage AI embeddings
+ * @resource {https://www.npmjs.com/package/@anthropic-ai/sdk} @anthropic-ai/sdk on npm
+ * @group AI
+ *
+ * Retrieval-augmented generation grounds an answer in your own data. Anthropic
+ * has no embeddings endpoint, so this example embeds a small knowledge base
+ * and the question with Voyage AI, finds the closest passages by cosine
+ * similarity, and passes them to Claude as context. Set ANTHROPIC_API_KEY and
+ * VOYAGE_API_KEY before running.
+ */
+
+import Anthropic from "npm:@anthropic-ai/sdk";
+
+const anthropic = new Anthropic();
+
+// A tiny knowledge base. In a real app these passages would live in a vector
+// database rather than an array.
+const documents = [
+  "Deno is secure by default: network, file system, and environment access " +
+  "must be granted explicitly with flags like --allow-net.",
+  "Deno has a built-in test runner. Write Deno.test() and run `deno test`.",
+  "Deno supports npm packages through the npm: specifier, for example " +
+  "import express from 'npm:express'.",
+];
+
+// Embed text with Voyage AI's REST API. input_type marks whether the text is
+// a stored document or a search query, which improves retrieval quality.
+async function embed(
+  input: string[],
+  inputType: "document" | "query",
+): Promise<number[][]> {
+  const res = await fetch("https://api.voyageai.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${Deno.env.get("VOYAGE_API_KEY")}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "voyage-3.5-lite",
+      input,
+      input_type: inputType,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Voyage error ${res.status}: ${await res.text()}`);
+  }
+  const json = await res.json();
+  return json.data.map((d: { embedding: number[] }) => d.embedding);
+}
+
+// Cosine similarity scores how close two embedding vectors are.
+function cosine(a: number[], b: number[]): number {
+  let dot = 0, normA = 0, normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+const question = "How do I run tests in Deno?";
+
+// Embed the documents once (this is the "index") and the incoming question.
+const docVectors = await embed(documents, "document");
+const [queryVector] = await embed([question], "query");
+
+// Rank documents by similarity to the question and keep the top two.
+const retrieved = documents
+  .map((text, i) => ({ text, score: cosine(queryVector, docVectors[i]) }))
+  .sort((a, b) => b.score - a.score)
+  .slice(0, 2);
+
+// Hand the retrieved passages to Claude as context and ask it to answer from
+// them, which keeps the response grounded in your data.
+const context = retrieved.map((d) => `- ${d.text}`).join("\n");
+const message = await anthropic.messages.create({
+  model: "claude-opus-4-8",
+  max_tokens: 1024,
+  messages: [
+    {
+      role: "user",
+      content: `Answer the question using only the context below.\n\n` +
+        `Context:\n${context}\n\nQuestion: ${question}`,
+    },
+  ],
+});
+
+for (const block of message.content) {
+  if (block.type === "text") console.log(block.text);
+}

--- a/examples/scripts/anthropic_structured_output.ts
+++ b/examples/scripts/anthropic_structured_output.ts
@@ -1,0 +1,54 @@
+/**
+ * @title Get structured JSON output from Claude
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N -E <url>
+ * @resource {https://platform.claude.com/docs/en/build-with-claude/structured-outputs} Claude structured outputs
+ * @resource {https://www.npmjs.com/package/@anthropic-ai/sdk} @anthropic-ai/sdk on npm
+ * @group AI
+ *
+ * When you need machine-readable output, constrain Claude's response to a
+ * JSON schema with output_config.format. The model returns JSON matching the
+ * schema, so you can parse it directly instead of coaxing structure out of
+ * prose or writing fragile string parsing. Set ANTHROPIC_API_KEY first.
+ */
+
+import Anthropic from "npm:@anthropic-ai/sdk";
+
+const client = new Anthropic();
+
+// Describe the exact shape you want back. Structured outputs require every
+// object to set additionalProperties: false.
+const schema = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    field: { type: "string" },
+    languages: { type: "array", items: { type: "string" } },
+  },
+  required: ["name", "field", "languages"],
+  additionalProperties: false,
+};
+
+const response = await client.messages.create({
+  model: "claude-opus-4-8",
+  max_tokens: 1024,
+  // output_config.format constrains the whole response to the schema.
+  output_config: { format: { type: "json_schema", schema } },
+  messages: [
+    {
+      role: "user",
+      content:
+        "Ada Lovelace was an English mathematician, regarded as the first " +
+        "computer programmer.",
+    },
+  ],
+});
+
+// The response text is JSON that matches the schema, ready to parse.
+const block = response.content.find((b) => b.type === "text");
+if (block?.type === "text") {
+  const person = JSON.parse(block.text);
+  console.log(person);
+  // { name: "Ada Lovelace", field: "mathematics", languages: ["English"] }
+}

--- a/examples/scripts/mcp_client.ts
+++ b/examples/scripts/mcp_client.ts
@@ -1,0 +1,57 @@
+/**
+ * @title Connect to an MCP server from a client
+ * @difficulty intermediate
+ * @tags cli
+ * @run -R <url>
+ * @resource {https://modelcontextprotocol.io/} Model Context Protocol
+ * @resource {https://github.com/modelcontextprotocol/typescript-sdk} MCP TypeScript SDK
+ * @group AI
+ *
+ * The other side of the Model Context Protocol: a client connects to a
+ * server, discovers the tools it advertises, and calls them. This example
+ * links a client to a small server over an in-memory transport so it runs on
+ * its own. In practice the server is a separate process reached over stdio or
+ * HTTP. See the "Build an MCP server" example for the server side.
+ */
+
+import { Client } from "npm:@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "npm:@modelcontextprotocol/sdk/server/mcp.js";
+import { InMemoryTransport } from "npm:@modelcontextprotocol/sdk/inMemory.js";
+import { z } from "npm:zod";
+
+// A minimal server so the client has something to talk to.
+const server = new McpServer({ name: "dinosaur-facts", version: "1.0.0" });
+server.registerTool(
+  "get_dinosaur_fact",
+  {
+    description: "Get a fact about a given dinosaur",
+    inputSchema: { name: z.string().describe("The dinosaur's name") },
+  },
+  ({ name }: { name: string }) => ({
+    content: [{ type: "text", text: `${name} was a dinosaur.` }],
+  }),
+);
+
+// A client identifies itself with a name and version, like the server does.
+const client = new Client({ name: "facts-client", version: "1.0.0" });
+
+// A linked pair wires the two transports together in memory, with no
+// subprocess or network. Connect each side to its end of the pair.
+const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+await server.connect(serverTransport);
+await client.connect(clientTransport);
+
+// Discover what the server offers. Each tool carries a name, description, and
+// input schema, which is how an AI client knows what it can call.
+const { tools } = await client.listTools();
+console.log("Available tools:", tools.map((t: { name: string }) => t.name));
+
+// Call a tool by name with arguments matching its schema.
+const result = await client.callTool({
+  name: "get_dinosaur_fact",
+  arguments: { name: "Velociraptor" },
+});
+console.log(result.content);
+
+// Close the connection when done.
+await client.close();


### PR DESCRIPTION
Three more examples to round out the AI section, each a common
real-world task.

Get structured JSON output from Claude constrains the response to a JSON
schema with output_config.format, so the result parses directly instead
of needing fragile prose parsing. RAG: ground Claude's answer in your
documents shows retrieval-augmented generation end to end: because
Anthropic has no embeddings endpoint, it embeds a small knowledge base
and the question with Voyage AI, ranks passages by cosine similarity,
and passes the top matches to Claude as context. Connect to an MCP
server from a client is the client side of the Model Context Protocol,
linked to a small server over an in-memory transport so it runs on its
own, and pairs with the existing Build an MCP server example.

The two Claude examples depend only on @anthropic-ai/sdk; RAG also needs
a VOYAGE_API_KEY; the MCP client uses the MCP TypeScript SDK. All three
type-check against the real SDKs.