### PR TITLE
docs: add OpenAI mirror examples for the AI section

### DIFF
--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -1034,6 +1034,36 @@ export const items = [
     type: "example",
     category: "AI",
   },
+  {
+    title: "Stream a chat response from OpenAI",
+    href: "/examples/openai_streaming/",
+    type: "example",
+    category: "AI",
+  },
+  {
+    title: "Build an agent with OpenAI function calling",
+    href: "/examples/openai_tool_use/",
+    type: "example",
+    category: "AI",
+  },
+  {
+    title: "Stream an OpenAI response to the browser",
+    href: "/examples/openai_sse/",
+    type: "example",
+    category: "AI",
+  },
+  {
+    title: "Get structured JSON output from OpenAI",
+    href: "/examples/openai_structured_output/",
+    type: "example",
+    category: "AI",
+  },
+  {
+    title: "RAG: ground an OpenAI answer in your documents",
+    href: "/examples/openai_rag/",
+    type: "example",
+    category: "AI",
+  },
 
   // Deploying Deno projects
   {

--- a/examples/scripts/openai_rag.ts
+++ b/examples/scripts/openai_rag.ts
@@ -1,0 +1,76 @@
+/**
+ * @title RAG: ground an OpenAI answer in your documents
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N -E <url>
+ * @resource {https://platform.openai.com/docs/guides/embeddings} OpenAI embeddings
+ * @resource {https://www.npmjs.com/package/openai} openai on npm
+ * @group AI
+ *
+ * Retrieval-augmented generation grounds an answer in your own data. This
+ * example embeds a small knowledge base and the question with OpenAI's
+ * embeddings API, finds the closest passages by cosine similarity, and passes
+ * them to the chat model as context. Set OPENAI_API_KEY before running.
+ */
+
+import OpenAI from "npm:openai";
+
+const client = new OpenAI();
+
+// A tiny knowledge base. In a real app these passages would live in a vector
+// database rather than an array.
+const documents = [
+  "Deno is secure by default: network, file system, and environment access " +
+  "must be granted explicitly with flags like --allow-net.",
+  "Deno has a built-in test runner. Write Deno.test() and run `deno test`.",
+  "Deno supports npm packages through the npm: specifier, for example " +
+  "import express from 'npm:express'.",
+];
+
+// Embed an array of strings and return their vectors.
+async function embed(input: string[]): Promise<number[][]> {
+  const res = await client.embeddings.create({
+    model: "text-embedding-3-small",
+    input,
+  });
+  return res.data.map((d) => d.embedding);
+}
+
+// Cosine similarity scores how close two embedding vectors are.
+function cosine(a: number[], b: number[]): number {
+  let dot = 0, normA = 0, normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+const question = "How do I run tests in Deno?";
+
+// Embed the documents once (this is the "index") and the incoming question.
+const docVectors = await embed(documents);
+const [queryVector] = await embed([question]);
+
+// Rank documents by similarity to the question and keep the top two.
+const retrieved = documents
+  .map((text, i) => ({ text, score: cosine(queryVector, docVectors[i]) }))
+  .sort((a, b) => b.score - a.score)
+  .slice(0, 2);
+
+// Hand the retrieved passages to the model as context and ask it to answer
+// from them, which keeps the response grounded in your data.
+const context = retrieved.map((d) => `- ${d.text}`).join("\n");
+const completion = await client.chat.completions.create({
+  model: "gpt-4o",
+  messages: [
+    {
+      role: "user",
+      content: `Answer the question using only the context below.\n\n` +
+        `Context:\n${context}\n\nQuestion: ${question}`,
+    },
+  ],
+});
+
+console.log(completion.choices[0].message.content);

--- a/examples/scripts/openai_sse.ts
+++ b/examples/scripts/openai_sse.ts
@@ -1,0 +1,89 @@
+/**
+ * @title Stream an OpenAI response to the browser
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N -E <url>
+ * @resource {https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events} MDN: Server-sent events
+ * @resource {https://www.npmjs.com/package/openai} openai on npm
+ * @group AI
+ *
+ * A chat UI needs tokens to appear as the model produces them. This server
+ * streams an OpenAI response to the browser over server-sent events: the
+ * browser opens an EventSource, and each delta from the OpenAI SDK is
+ * forwarded as one SSE message. Open http://localhost:8000 after starting it,
+ * with OPENAI_API_KEY set.
+ */
+
+import OpenAI from "npm:openai";
+
+const client = new OpenAI();
+
+// A minimal page that opens an EventSource and appends each token as it
+// arrives. Deltas are JSON-encoded on the server, so newlines survive.
+const PAGE = `<!doctype html>
+<meta charset="utf-8" />
+<title>Streaming OpenAI</title>
+<pre id="out"></pre>
+<script>
+  const out = document.getElementById("out");
+  const source = new EventSource("/chat");
+  source.onmessage = (e) => { out.textContent += JSON.parse(e.data); };
+  source.addEventListener("done", () => source.close());
+</script>`;
+
+function handler(req: Request): Response {
+  const url = new URL(req.url);
+
+  // Serve the page itself at the root.
+  if (url.pathname !== "/chat") {
+    return new Response(PAGE, { headers: { "content-type": "text/html" } });
+  }
+
+  // The prompt can come from the query string; fall back to a default.
+  const prompt = url.searchParams.get("q") ??
+    "In two sentences, explain why streaming improves a chat UI.";
+
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    async start(controller) {
+      const stream = await client.chat.completions.create({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: prompt }],
+        stream: true,
+      });
+
+      try {
+        // Forward every delta as one SSE message. JSON.stringify keeps
+        // newlines from breaking the `data:` framing.
+        for await (const chunk of stream) {
+          const delta = chunk.choices[0]?.delta?.content;
+          if (delta) {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(delta)}\n\n`),
+            );
+          }
+        }
+        // A named event lets the browser close the connection cleanly.
+        controller.enqueue(encoder.encode('event: done\ndata: ""\n\n'));
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        controller.enqueue(
+          encoder.encode(`event: error\ndata: ${JSON.stringify(message)}\n\n`),
+        );
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  // The text/event-stream content type is what makes this SSE; no-store keeps
+  // proxies from buffering the tokens.
+  return new Response(body, {
+    headers: {
+      "content-type": "text/event-stream",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+Deno.serve(handler);

--- a/examples/scripts/openai_streaming.ts
+++ b/examples/scripts/openai_streaming.ts
@@ -1,0 +1,35 @@
+/**
+ * @title Stream a chat response from OpenAI
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N -E <url>
+ * @resource {https://platform.openai.com/docs/api-reference/chat} OpenAI chat completions
+ * @resource {https://www.npmjs.com/package/openai} openai on npm
+ * @group AI
+ *
+ * The official OpenAI SDK runs in Deno straight from npm. This example streams
+ * a chat response so tokens print as they arrive, which keeps long replies
+ * responsive and avoids request timeouts. Set OPENAI_API_KEY before running.
+ */
+
+import OpenAI from "npm:openai";
+
+// The client reads the API key from the OPENAI_API_KEY environment variable.
+const client = new OpenAI();
+
+// Passing stream: true returns an async iterable of partial chunks instead of
+// one response at the end.
+const stream = await client.chat.completions.create({
+  model: "gpt-4o",
+  messages: [
+    { role: "user", content: "In one sentence, what makes Deno distinctive?" },
+  ],
+  stream: true,
+});
+
+// Each chunk carries a small delta; print the text pieces as they arrive.
+for await (const chunk of stream) {
+  const delta = chunk.choices[0]?.delta?.content;
+  if (delta) Deno.stdout.writeSync(new TextEncoder().encode(delta));
+}
+console.log();

--- a/examples/scripts/openai_structured_output.ts
+++ b/examples/scripts/openai_structured_output.ts
@@ -1,0 +1,53 @@
+/**
+ * @title Get structured JSON output from OpenAI
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N -E <url>
+ * @resource {https://platform.openai.com/docs/guides/structured-outputs} OpenAI structured outputs
+ * @resource {https://www.npmjs.com/package/openai} openai on npm
+ * @group AI
+ *
+ * When you need machine-readable output, constrain the response to a JSON
+ * schema with response_format. The model returns JSON matching the schema, so
+ * you can parse it directly instead of coaxing structure out of prose. Set
+ * OPENAI_API_KEY before running.
+ */
+
+import OpenAI from "npm:openai";
+
+const client = new OpenAI();
+
+// Describe the exact shape you want back. Strict structured outputs require
+// every property to be required and additionalProperties: false.
+const schema = {
+  type: "object",
+  properties: {
+    name: { type: "string" },
+    field: { type: "string" },
+    languages: { type: "array", items: { type: "string" } },
+  },
+  required: ["name", "field", "languages"],
+  additionalProperties: false,
+};
+
+const response = await client.chat.completions.create({
+  model: "gpt-4o",
+  messages: [
+    {
+      role: "user",
+      content:
+        "Ada Lovelace was an English mathematician, regarded as the first " +
+        "computer programmer.",
+    },
+  ],
+  // response_format constrains the reply to the schema.
+  response_format: {
+    type: "json_schema",
+    json_schema: { name: "person", schema, strict: true },
+  },
+});
+
+// The message content is JSON that matches the schema, ready to parse.
+const person = JSON.parse(response.choices[0].message.content ?? "{}");
+console.log(person);
+// { name: "Ada Lovelace", field: "mathematics", languages: ["English"] }

--- a/examples/scripts/openai_tool_use.ts
+++ b/examples/scripts/openai_tool_use.ts
@@ -1,0 +1,83 @@
+/**
+ * @title Build an agent with OpenAI function calling
+ * @difficulty intermediate
+ * @tags cli, deploy
+ * @run -N -E <url>
+ * @resource {https://platform.openai.com/docs/guides/function-calling} OpenAI function calling
+ * @resource {https://www.npmjs.com/package/openai} openai on npm
+ * @group AI
+ *
+ * Function calling lets the model call functions you define and act on the
+ * results. You describe each tool with a JSON schema; when the model decides
+ * to use one it returns a tool call instead of a final answer. You run it,
+ * send the result back, and repeat until the model is done. This loop is the
+ * core of an agent. Set OPENAI_API_KEY before running.
+ */
+
+import OpenAI from "npm:openai";
+
+const client = new OpenAI();
+
+// Describe the tool with a JSON schema and a prescriptive description so the
+// model knows when to call it.
+const tools: OpenAI.Chat.Completions.ChatCompletionTool[] = [
+  {
+    type: "function",
+    function: {
+      name: "get_weather",
+      description:
+        "Get the current weather for a city. Call this whenever the user " +
+        "asks about weather conditions.",
+      parameters: {
+        type: "object",
+        properties: {
+          city: { type: "string", description: "City name, e.g. Tokyo" },
+        },
+        required: ["city"],
+      },
+    },
+  },
+];
+
+// The actual implementation. A real app would call a weather API here.
+function getWeather(city: string): string {
+  const data: Record<string, string> = {
+    Tokyo: "18°C, clear",
+    Oslo: "4°C, snow",
+  };
+  return data[city] ?? `No data for ${city}`;
+}
+
+const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
+  { role: "user", content: "Compare the weather in Tokyo and Oslo right now." },
+];
+
+// Agent loop: keep calling the model until it stops requesting tools.
+while (true) {
+  const response = await client.chat.completions.create({
+    model: "gpt-4o",
+    messages,
+    tools,
+  });
+  const message = response.choices[0].message;
+
+  // Record the assistant turn; it holds any tool calls we must answer.
+  messages.push(message);
+
+  // No tool calls means the model produced its final answer.
+  if (!message.tool_calls) {
+    console.log(message.content);
+    break;
+  }
+
+  // Run each requested tool and append its result as a tool message.
+  for (const call of message.tool_calls) {
+    if (call.type !== "function") continue;
+    const { city } = JSON.parse(call.function.arguments);
+    messages.push({
+      role: "tool",
+      tool_call_id: call.id,
+      content: getWeather(city),
+    });
+  }
+}


### PR DESCRIPTION
These mirror the recently added Claude examples with OpenAI
counterparts, so the AI section covers both providers symmetrically and
readers can compare them side by side. Each uses the official openai SDK
loaded from npm and the OPENAI_API_KEY environment variable.

The five examples are: streaming a chat response, an agent loop built on
function calling, streaming a response to the browser over server-sent
events, structured JSON output via response_format with a json_schema,
and retrieval-augmented generation using OpenAI's embeddings API for the
retrieval step. They sit next to the existing Connect to OpenAI example.
The MCP client example was not mirrored because the Model Context
Protocol is provider-agnostic. All five type-check against the openai
SDK.