### PR TITLE
docs: de-italicize the prose alongside example code

### DIFF
--- a/examples/_components/SnippetComponent.tsx
+++ b/examples/_components/SnippetComponent.tsx
@@ -15,7 +15,7 @@ export default function SnippetComponent(props: {
       <div
         class={`select-none text-sm ${props.snippet.text ? "pb-4" : " "} ${
           props.snippet.code
-            ? "italic md:text-balance md:text-right col-span-5 sm:col-span-3 md:pb-0 snippet-comment"
+            ? "md:text-balance md:text-right col-span-5 sm:col-span-3 md:pb-0 snippet-comment"
             : "col-span-full mt-8"
         }`}
       >


### PR DESCRIPTION
The prose commentary that runs alongside example code was rendered in
italics, which is harder to read for multi-line explanations. This drops
the italic styling so the commentary reads upright.

(Split out from the original combined PR; the difficulty-badge change is
now a separate PR.)