### PR TITLE
docs: tag cookbook categories as Reference on the examples page

### DIFF
--- a/_components/LandingPage.tsx
+++ b/_components/LandingPage.tsx
@@ -9,7 +9,6 @@ import {
   cookbookCategories,
   featuredItems,
   sidebar,
-  startHere,
 } from "../examples/_data.ts";
 
 function FeaturedStar() {
@@ -103,32 +102,6 @@ export default function LandingPage(
             <button type="submit" className="btn">Request guide</button>
           </form>
         </details>
-
-        <section className="mb-10">
-          <h2 className="text-lg md:text-xl font-semibold mb-4">
-            New to Deno? Start here
-          </h2>
-          <ol className="flex flex-wrap gap-2 !pl-0 !list-none !mt-0">
-            {startHere.map((item, i) => (
-              <li key={item.href} className="!mt-0">
-                <a
-                  href={item.href}
-                  className="group inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-foreground-tertiary bg-background-secondary !no-underline hover:border-primary transition-colors duration-150"
-                >
-                  <span
-                    className="flex items-center justify-center w-5 h-5 rounded-full bg-primary text-white text-xs font-semibold shrink-0"
-                    aria-hidden="true"
-                  >
-                    {i + 1}
-                  </span>
-                  <span className="font-medium !text-foreground-primary group-hover:underline underline-offset-4 decoration-primary">
-                    {item.title}
-                  </span>
-                </a>
-              </li>
-            ))}
-          </ol>
-        </section>
 
         <section className="mb-10">
           <h2 className="text-lg md:text-xl font-semibold mb-4">Featured</h2>

--- a/_components/LandingPage.tsx
+++ b/_components/LandingPage.tsx
@@ -5,7 +5,12 @@ import {
 } from "../examples/_components/LearningList.tsx";
 import { TutorialIcon } from "../examples/_components/TutorialIcon.tsx";
 import { VideoIcon } from "../examples/_components/VideoIcon.tsx";
-import { featuredItems, sidebar } from "../examples/_data.ts";
+import {
+  cookbookCategories,
+  featuredItems,
+  sidebar,
+  startHere,
+} from "../examples/_data.ts";
 
 function FeaturedStar() {
   return (
@@ -38,6 +43,7 @@ export default function LandingPage(
           title={item.title}
           items={item.items}
           descriptions={descriptions}
+          isReference={cookbookCategories.includes(item.title)}
         />
       );
     },
@@ -97,6 +103,32 @@ export default function LandingPage(
             <button type="submit" className="btn">Request guide</button>
           </form>
         </details>
+
+        <section className="mb-10">
+          <h2 className="text-lg md:text-xl font-semibold mb-4">
+            New to Deno? Start here
+          </h2>
+          <ol className="flex flex-wrap gap-2 !pl-0 !list-none !mt-0">
+            {startHere.map((item, i) => (
+              <li key={item.href} className="!mt-0">
+                <a
+                  href={item.href}
+                  className="group inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-foreground-tertiary bg-background-secondary !no-underline hover:border-primary transition-colors duration-150"
+                >
+                  <span
+                    className="flex items-center justify-center w-5 h-5 rounded-full bg-primary text-white text-xs font-semibold shrink-0"
+                    aria-hidden="true"
+                  >
+                    {i + 1}
+                  </span>
+                  <span className="font-medium !text-foreground-primary group-hover:underline underline-offset-4 decoration-primary">
+                    {item.title}
+                  </span>
+                </a>
+              </li>
+            ))}
+          </ol>
+        </section>
 
         <section className="mb-10">
           <h2 className="text-lg md:text-xl font-semibold mb-4">Featured</h2>

--- a/examples/_components/LearningList.tsx
+++ b/examples/_components/LearningList.tsx
@@ -19,13 +19,20 @@ export function LearningList(
     title: string;
     items: SidebarItem[];
     descriptions?: Record<string, string>;
+    isReference?: boolean;
   },
 ) {
   const anchor = props.title.toLowerCase().replace(/\s+/g, "-");
   return (
     <section className="mb-10">
       <h2 id={anchor} className="text-lg md:text-xl font-semibold mb-4 mt-0">
-        {props.title}&nbsp;
+        {props.title}
+        {props.isReference && (
+          <span className="ml-2 align-middle text-xs font-medium uppercase tracking-wide text-foreground-secondary border border-foreground-tertiary rounded px-1.5 py-0.5">
+            Reference
+          </span>
+        )}
+        &nbsp;
         <a class="header-anchor" href={`#${anchor}`}>
           <span class="sr-only">Jump to heading</span>
           <span aria-hidden="true" class="anchor-end">#</span>

--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -2067,5 +2067,32 @@ export const featuredItems = [
   },
 ];
 
+// A short, ordered path for people new to Deno, rendered as a numbered strip
+// at the top of the landing page.
+export const startHere = [
+  { title: "Run a script", href: "/examples/run_script_tutorial/" },
+  { title: "Hello World", href: "/examples/hello_world/" },
+  {
+    title: "Built in TypeScript support",
+    href: "/examples/typescript_support/",
+  },
+  {
+    title: "Initialize a project",
+    href: "/examples/initialize_project_tutorial/",
+  },
+  { title: "Simple API server", href: "/examples/simple_api_tutorial/" },
+  { title: "Writing tests", href: "/examples/writing_tests/" },
+];
+
+// Categories that are copy-paste reference snippets rather than
+// walkthrough-style guides. The landing page tags these as "Reference" so
+// newcomers can tell them apart from tutorial-grade content.
+export const cookbookCategories = [
+  "File system",
+  "System",
+  "Web standard APIs",
+  "Encoding",
+];
+
 export const sectionTitle = "Examples";
 export const sectionHref = "/examples/";

--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -2067,23 +2067,6 @@ export const featuredItems = [
   },
 ];
 
-// A short, ordered path for people new to Deno, rendered as a numbered strip
-// at the top of the landing page.
-export const startHere = [
-  { title: "Run a script", href: "/examples/run_script_tutorial/" },
-  { title: "Hello World", href: "/examples/hello_world/" },
-  {
-    title: "Built in TypeScript support",
-    href: "/examples/typescript_support/",
-  },
-  {
-    title: "Initialize a project",
-    href: "/examples/initialize_project_tutorial/",
-  },
-  { title: "Simple API server", href: "/examples/simple_api_tutorial/" },
-  { title: "Writing tests", href: "/examples/writing_tests/" },
-];
-
 // Categories that are copy-paste reference snippets rather than
 // walkthrough-style guides. The landing page tags these as "Reference" so
 // newcomers can tell them apart from tutorial-grade content.


### PR DESCRIPTION
Tags the reference-style snippet categories (File system, System, Web
standard APIs, Encoding) with a small Reference label so they read as a
cookbook to copy from rather than tutorial-grade guides. This is a light,
data-driven treatment (a cookbookCategories list in _data.ts).

An earlier version of this PR also added a numbered "New to Deno? Start
here" strip at the top of the page, but that overlapped with the existing
Featured section and crowded a landing page that already stacks Featured,
a type-filter bar, and a category nav above the lists, so it was dropped.