### PR TITLE
ci: exempt pages already dated today from the freshness check

### DIFF
--- a/scripts/check_freshness.ts
+++ b/scripts/check_freshness.ts
@@ -139,7 +139,12 @@ async function main() {
     }
 
     // The core freshness rule: content changed but the date didn't move.
-    if (baseLM !== null && headLM === baseLM) {
+    // A page already dated today is exempt: when the base version was itself
+    // last modified today (for example a second edit landing the same day, or a
+    // PR that touches a page already bumped on main today), the date cannot move
+    // without being set into the future, and "today" is already as fresh as it
+    // gets.
+    if (baseLM !== null && headLM === baseLM && headLM !== today) {
       violations.push(
         `${newPath}: page changed but 'last_modified' was not updated (still ${headLM}); set it to ${today}.`,
       );


### PR DESCRIPTION
The freshness check fails a changed page when its `last_modified` equals the
date on the base version, on the principle that an edit should bump the date.
That rule has a false positive for same-day edits.

When the base version of a page was already `last_modified` today, the date
cannot move without being set into the future, which the check also rejects.
This happens whenever a page is edited twice in one day, or when a pull
request touches a page that another PR already bumped to today on main. The
page becomes unlandable until the next calendar day, regardless of the date
the author sets.

The fix exempts `headLM === today` from the "date did not move" rule. A page
dated today is already as fresh as it can be, so demanding a further bump is
incorrect. Genuinely stale same-date edits still fail, because there the
unchanged date is in the past rather than today.

This came up while rebasing two approved PRs that both edit the installation
page on the same day it had already been bumped on main; with this change
they pass the check as-is.
