### PR TITLE
docs: add a Databases guide hub under Guides

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -66,6 +66,10 @@ export const sidebar = [
         href: "/runtime/fundamentals/http_server/",
       },
       {
+        title: "Databases",
+        href: "/runtime/databases/",
+      },
+      {
         title: "Testing",
         href: "/runtime/test/",
         disclosure: true,

--- a/runtime/databases/index.md
+++ b/runtime/databases/index.md
@@ -1,45 +1,136 @@
 ---
 last_modified: 2026-06-16
 title: "Databases"
-description: "Connect Deno to SQLite, Postgres, MySQL, MongoDB, Redis, and Deno KV, with runnable examples and ORM tutorials."
+description: "Use databases with Deno: the built-in node:sqlite and Deno KV, plus Postgres, MySQL, MongoDB, and Redis through the same npm drivers you use in Node.js."
 ---
 
-Deno connects to databases the same way Node does — through npm drivers, which
-run under [Node.js compatibility](/runtime/fundamentals/node/) — plus two
-batteries-included options: the built-in `node:sqlite` module and the built-in
-[Deno KV](#deno-kv). Each entry below links a runnable example or a tutorial.
+Deno ships two databases inside the runtime, with nothing to install:
 
-## SQL databases
+- **`node:sqlite`** — a built-in SQLite module (added in Deno 2.2).
+- **Deno KV** — a built-in key-value store that needs zero configuration on
+  [Deno Deploy](/deploy/).
 
-- **SQLite** — built in, no install, via `node:sqlite`:
-  [Connect to SQLite](/examples/sqlite/)
+For every other database — Postgres, MySQL, MongoDB, Redis, and the rest — you
+use the **same npm driver you would in Node.js**. Deno reads npm packages
+directly through [Node.js compatibility](/runtime/fundamentals/node/), so the
+connection code is identical to a Node project: import the driver and connect.
+
+## SQLite, built in
+
+SQLite runs in-process with no server and no dependency to add. Import
+`DatabaseSync` from `node:sqlite`, open a file, and run SQL:
+
+```ts title="main.ts"
+import { DatabaseSync } from "node:sqlite";
+
+// Open (or create) a database file
+const db = new DatabaseSync("test.db");
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS people (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT,
+    age INTEGER
+  );
+`);
+
+// Insert a row with bound parameters
+db.prepare("INSERT INTO people (name, age) VALUES (?, ?);").run("Bob", 40);
+
+// Query it back
+const rows = db.prepare("SELECT id, name, age FROM people").all();
+console.log(rows);
+
+db.close();
+```
+
+Because it reads and writes a file, run it with read and write permission:
+
+```sh
+deno run -R -W main.ts
+```
+
+See the [full SQLite example](/examples/sqlite/) for more operations.
+
+## Deno KV, built in
+
+[Deno KV](/deploy/kv/) is a key-value database built into the runtime. Open the
+default store with [`Deno.openKv()`](/api/deno/~/Deno.openKv); keys are arrays,
+so you can lay data out hierarchically and list by prefix:
+
+```ts title="main.ts"
+const kv = await Deno.openKv();
+
+// Store, then read back a single record
+await kv.set(["players", "alice"], { rank: "gold" });
+const alice = await kv.get(["players", "alice"]);
+console.log(alice.key, alice.value);
+
+// List every record under a key prefix, ordered lexicographically
+for await (const entry of kv.list({ prefix: ["players"] })) {
+  console.log(entry.key, entry.value);
+}
+
+await kv.delete(["players", "alice"]);
+```
+
+Deno KV is currently unstable, so run it with the `--unstable-kv` flag:
+
+```sh
+deno run --unstable-kv main.ts
+```
+
+It's a good fit for fast reads that don't need the query flexibility of SQL, and
+it works with zero configuration when you deploy to Deno Deploy. For atomic
+transactions, secondary indexes, and the full API, see the
+[Deno KV docs](/deploy/kv/) and the [Deno KV example](/examples/kv/).
+
+## Other databases (npm drivers)
+
+Any database with an npm driver works under Deno. Import the driver with an
+`npm:` specifier (or list it in `package.json`) and connect exactly as you would
+in Node.js. Keep connection settings in environment variables so the same code
+runs locally and in production. Here is Postgres with the `postgres` driver:
+
+```ts title="main.ts"
+import postgres from "npm:postgres";
+
+// Connection settings come from the standard PG* environment variables
+const sql = postgres();
+
+const people = await sql`SELECT id, name FROM people`;
+console.log(people);
+
+await sql.end();
+```
+
+This needs network and environment access (add `--env-file` if you keep the
+variables in a `.env` file):
+
+```sh
+deno run -N -E main.ts
+```
+
+The same pattern covers the rest. Each link below is a runnable example or a
+tutorial:
+
 - **Postgres** — [Connect to Postgres](/examples/postgres/), or
   [Supabase](/examples/supabase/)
 - **MySQL** — [Use MySQL with Deno](/examples/mysql2_tutorial/), or
   [PlanetScale](/examples/planetscale_tutorial/)
-- **DuckDB** — [Connect to DuckDB](/examples/duckdb/)
-
-## Document and key-value stores
-
 - **MongoDB** — [Connect to MongoDB](/examples/mongo/), or
   [Mongoose](/examples/mongoose_tutorial/)
 - **Redis** — [Redis quick start](/examples/redis/), or the
   [Redis tutorial](/examples/redis_tutorial/)
-
-## Deno KV
-
-[Deno KV](/deploy/kv/) is a key-value database built into the runtime, so there
-is nothing to install. It is currently unstable, so run with the `--unstable-kv`
-flag. See the [Deno KV docs](/deploy/kv/) and the
-[Deno KV example](/examples/kv/) to get started.
+- **DuckDB** — [Connect to DuckDB](/examples/duckdb/)
 
 ## ORMs
+
+ORMs that run on npm work the same way:
 
 - **Drizzle** — [Use Drizzle with Deno](/examples/drizzle_tutorial/)
 - **Prisma** — [Use Prisma with Deno](/examples/prisma_tutorial/)
 
-## More
-
 New to databases in Deno? The
 [Connecting to databases](/examples/connecting_to_databases_tutorial/) tutorial
-is an overview of the options above.
+walks through the options above.

--- a/runtime/databases/index.md
+++ b/runtime/databases/index.md
@@ -1,0 +1,45 @@
+---
+last_modified: 2026-06-16
+title: "Databases"
+description: "Connect Deno to SQLite, Postgres, MySQL, MongoDB, Redis, and Deno KV, with runnable examples and ORM tutorials."
+---
+
+Deno connects to databases the same way Node does — through npm drivers, which
+run under [Node.js compatibility](/runtime/fundamentals/node/) — plus two
+batteries-included options: the built-in `node:sqlite` module and the built-in
+[Deno KV](#deno-kv). Each entry below links a runnable example or a tutorial.
+
+## SQL databases
+
+- **SQLite** — built in, no install, via `node:sqlite`:
+  [Connect to SQLite](/examples/sqlite/)
+- **Postgres** — [Connect to Postgres](/examples/postgres/), or
+  [Supabase](/examples/supabase/)
+- **MySQL** — [Use MySQL with Deno](/examples/mysql2_tutorial/), or
+  [PlanetScale](/examples/planetscale_tutorial/)
+- **DuckDB** — [Connect to DuckDB](/examples/duckdb/)
+
+## Document and key-value stores
+
+- **MongoDB** — [Connect to MongoDB](/examples/mongo/), or
+  [Mongoose](/examples/mongoose_tutorial/)
+- **Redis** — [Redis quick start](/examples/redis/), or the
+  [Redis tutorial](/examples/redis_tutorial/)
+
+## Deno KV
+
+[Deno KV](/deploy/kv/) is a key-value database built into the runtime, so there
+is nothing to install. It is currently unstable, so run with the `--unstable-kv`
+flag. See the [Deno KV docs](/deploy/kv/) and the
+[Deno KV example](/examples/kv/) to get started.
+
+## ORMs
+
+- **Drizzle** — [Use Drizzle with Deno](/examples/drizzle_tutorial/)
+- **Prisma** — [Use Prisma with Deno](/examples/prisma_tutorial/)
+
+## More
+
+New to databases in Deno? The
+[Connecting to databases](/examples/connecting_to_databases_tutorial/) tutorial
+is an overview of the options above.


### PR DESCRIPTION
The database content was already well covered by examples and tutorials
(SQLite via the built-in `node:sqlite`, Postgres, MySQL, MongoDB, Redis,
DuckDB, Deno KV, plus Drizzle and Prisma tutorials), but there was no single
front door to it from the runtime sidebar.

This adds a thin Databases hub at `/runtime/databases/` and wires it into the
Guides group, after HTTP Server. The page frames Deno's three paths to a
database — npm drivers running under Node compatibility, the built-in
`node:sqlite`, and the built-in Deno KV — then links out to the existing
examples and tutorials rather than duplicating them, in keeping with the
guides-teach / examples-show split. Deno KV is listed with a short note that
it is unstable and a link to the existing KV docs.

It is intentionally a link hub, not a new long-form guide: the runnable depth
already lives in the examples and tutorials, and this just makes it
discoverable by task from the sidebar.
