### PR TITLE
docs: document missing unstable feature flags

### DIFF
--- a/runtime/reference/cli/unstable_flags.md
+++ b/runtime/reference/cli/unstable_flags.md
@@ -218,24 +218,6 @@ Enable the
 feature is now stable, so this flag is unnecessary in
 [Deno 2.4](https://deno.com/blog/v2.4)+.
 
-## `--unstable-raw-imports`
-
-Enable importing the raw contents of a file by adding an import attribute that
-declares the type. The imported value depends on the type you request:
-
-```ts title="example.ts"
-// import the file as a string
-import text from "./data.txt" with { type: "text" };
-// import the file as a Uint8Array
-import bytes from "./image.png" with { type: "bytes" };
-// import a stylesheet as a CSSStyleSheet
-import sheet from "./styles.css" with { type: "css" };
-
-console.log(typeof text); // string
-console.log(bytes.constructor.name); // Uint8Array
-console.log(sheet.constructor.name); // CSSStyleSheet
-```
-
 ## `--unstable-bundle`
 
 Enable the unstable [`Deno.bundle`](/api/deno/~/Deno.bundle) runtime API for
@@ -252,10 +234,6 @@ in which semver specifiers are resolved.
 
 Download npm dependencies only as they are actually referenced by an import,
 rather than installing every npm package listed in `package.json` on startup.
-
-## `--unstable-lockfile-v5`
-
-Use version 5 of the lockfile format.
 
 ## `--unstable-no-legacy-abort`
 

--- a/runtime/reference/cli/unstable_flags.md
+++ b/runtime/reference/cli/unstable_flags.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-05
+last_modified: 2026-06-17
 title: "Unstable feature flags"
 oldUrl:
   - /runtime/tools/unstable_flags/
@@ -217,6 +217,51 @@ Enable the
 [OpenTelemetry integration for Deno](/runtime/fundamentals/open_telemetry). This
 feature is now stable, so this flag is unnecessary in
 [Deno 2.4](https://deno.com/blog/v2.4)+.
+
+## `--unstable-raw-imports`
+
+Enable importing the raw contents of a file by adding an import attribute that
+declares the type. The imported value depends on the type you request:
+
+```ts title="example.ts"
+// import the file as a string
+import text from "./data.txt" with { type: "text" };
+// import the file as a Uint8Array
+import bytes from "./image.png" with { type: "bytes" };
+// import a stylesheet as a CSSStyleSheet
+import sheet from "./styles.css" with { type: "css" };
+
+console.log(typeof text); // string
+console.log(bytes.constructor.name); // Uint8Array
+console.log(sheet.constructor.name); // CSSStyleSheet
+```
+
+## `--unstable-bundle`
+
+Enable the unstable [`Deno.bundle`](/api/deno/~/Deno.bundle) runtime API for
+bundling JavaScript and TypeScript programmatically. See also the
+[`deno bundle`](/runtime/reference/cli/bundle/) command.
+
+## `--unstable-lazy-dynamic-imports`
+
+Lazily loads statically analyzable dynamic imports when not running with type
+checking, rather than loading them up front. Note that this may change the order
+in which semver specifiers are resolved.
+
+## `--unstable-npm-lazy-caching`
+
+Download npm dependencies only as they are actually referenced by an import,
+rather than installing every npm package listed in `package.json` on startup.
+
+## `--unstable-lockfile-v5`
+
+Use version 5 of the lockfile format.
+
+## `--unstable-no-legacy-abort`
+
+Use the abort signal in [`Deno.serve`](/api/deno/~/Deno.serve) without the
+legacy behavior. With this flag the server is not aborted when a request is
+handled successfully.
 
 ## `--unstable`
 


### PR DESCRIPTION
Several granular `--unstable-*` flags exist in the CLI but were missing
from the unstable feature flags reference page. This adds reference
entries for them so they are discoverable from the docs and not only from
`deno --help=unstable`.

The new entries are `--unstable-bundle`, `--unstable-lazy-dynamic-imports`,
`--unstable-npm-lazy-caching` and `--unstable-no-legacy-abort`. The
`--unstable-raw-imports` and `--unstable-lockfile-v5` sections were dropped
per review (raw imports are no longer gated by the flag as of Deno 2.8, and
lockfile-v5 is no longer relevant).

Closes #1730, closes #2747.

Note: #3257 (CSS / raw imports) is intentionally left open, since raw imports
are now stable and should be documented as a stable feature rather than under
unstable flags.