### PR TITLE
docs: clarify several examples and tutorials

### DIFF
--- a/examples/scripts/checking_directory_existence.ts
+++ b/examples/scripts/checking_directory_existence.ts
@@ -22,8 +22,10 @@ await exists("./directory", { isDirectory: true }); // true
 await exists("./file", { isDirectory: true }); // false
 
 // Do not use the above function if performing a check directly before another operation on that folder.
-// Doing so creates a race condition. The `exists` function is not recommended for that usecase.
-// Consider this alternative which checks for existence of a folder without doing any other filesystem operations.
+// Doing so creates a time-of-check to time-of-use race condition: the folder can be created or removed
+// in the gap between `exists` returning and your next call, so the result may already be stale. That is
+// why `exists` is not recommended for that usecase. Prefer to attempt the operation directly and handle
+// the error, or probe with `Deno.lstat` as shown below and act on the result you get back.
 try {
   await Deno.lstat("./example_directory");
   console.log("Folder exists");

--- a/examples/scripts/permissions.ts
+++ b/examples/scripts/permissions.ts
@@ -4,11 +4,16 @@
  * @tags cli
  * @run <url>
  * @resource {https://docs.deno.com/api/deno/~/Deno.Permissions} Doc: Deno.Permissions
+ * @resource {https://docs.deno.com/runtime/fundamentals/security/} Doc: Permissions and the --allow-* flags
  * @group CLI
  *
  * There are times where depending on the state of permissions
  * granted to a process, we want to do different things. This is
  * made very easy to do with the Deno permissions API.
+ *
+ * This example covers the runtime permissions API. To grant permissions when
+ * launching a program from the command line with flags like `--allow-read` or
+ * `--allow-net`, see the permissions reference linked above.
  */
 
 // In the most simple case, we can just request a permission by it's name.

--- a/examples/tutorials/cloudflare_workers.md
+++ b/examples/tutorials/cloudflare_workers.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-11-04
+last_modified: 2026-06-17
 title: "Deploying Deno to Cloudflare Workers"
 description: "Step-by-step tutorial on deploying Deno functions to Cloudflare Workers. Learn how to configure denoflare, create worker modules, test locally, and deploy your code to Cloudflare's global edge network."
 url: /examples/cloudflare_workers_tutorial/
@@ -99,3 +99,10 @@ Next, you can view your new function in your Cloudflare account:
 ![New function on Cloudflare Workers](./images/how-to/cloudflare-workers/main-on-cloudflare.png)
 
 Boom!
+
+## Deploying a Fresh app
+
+If you are building with [Fresh](https://fresh.deno.dev/), the framework has its
+own deployment guidance. See the
+[Fresh documentation](https://fresh.deno.dev/docs/) for how to deploy a Fresh
+app to Cloudflare Workers and other platforms.

--- a/examples/tutorials/hashbang.md
+++ b/examples/tutorials/hashbang.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-21
+last_modified: 2026-06-17
 title: "Executable scripts"
 description: "Guide to creating executable scripts with Deno. Learn about hashbangs, file permissions, cross-platform compatibility, and how to create command-line tools that can run directly from the terminal."
 url: /examples/hashbang_tutorial/
@@ -49,6 +49,15 @@ argument name and `env` would fail to find a program called `deno run`. There
 are no `--allow-*` flags here because the script only reads from `Deno.args`,
 which is always available. Deno prompts for permissions only when the script
 tries to use a sandboxed API.
+
+:::note
+
+The `-S` flag is an extension provided by GNU coreutils and BSD/macOS `env`. It
+is not part of POSIX, so on systems that ship a more minimal `env` (for example
+some embedded or BusyBox environments) the hashbang may not work. On those
+systems, run the script explicitly with `deno run script.ts` instead.
+
+:::
 
 `Deno.args` is an array of the arguments that follow the script name on the
 command line. `Deno.args[0]` is the first one; `?? "world"` substitutes

--- a/examples/tutorials/next.md
+++ b/examples/tutorials/next.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-17
+last_modified: 2025-10-02
 title: "Build a Next.js App"
 description: "Walkthrough guide to building a Next.js application with Deno. Learn how to set up a project, create API routes, implement server-side rendering, and build a full-stack TypeScript application."
 url: /examples/next_tutorial/
@@ -73,16 +73,6 @@ deno task dev
 This will start the Next.js development server using Deno. The `deno task dev`
 command runs `dev` task in the package.json, which starts the Next.js
 development server with the necessary flags for CommonJS compatibility.
-
-:::note
-
-Recent versions of `create-next-app` enable Turbopack by default (the `dev`
-script is `next dev --turbopack`). Turbopack expects a Node.js executable and
-can fail under Deno with errors such as `program not found`. If you hit this,
-remove `--turbopack` from the `dev` script in `package.json` so Next.js falls
-back to its Webpack-based bundler.
-
-:::
 
 Visit [http://localhost:3000](http://localhost:3000) to see the app in the
 browser.

--- a/examples/tutorials/next.md
+++ b/examples/tutorials/next.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-10-02
+last_modified: 2026-06-17
 title: "Build a Next.js App"
 description: "Walkthrough guide to building a Next.js application with Deno. Learn how to set up a project, create API routes, implement server-side rendering, and build a full-stack TypeScript application."
 url: /examples/next_tutorial/
@@ -73,6 +73,16 @@ deno task dev
 This will start the Next.js development server using Deno. The `deno task dev`
 command runs `dev` task in the package.json, which starts the Next.js
 development server with the necessary flags for CommonJS compatibility.
+
+:::note
+
+Recent versions of `create-next-app` enable Turbopack by default (the `dev`
+script is `next dev --turbopack`). Turbopack expects a Node.js executable and
+can fail under Deno with errors such as `program not found`. If you hit this,
+remove `--turbopack` from the `dev` script in `package.json` so Next.js falls
+back to its Webpack-based bundler.
+
+:::
 
 Visit [http://localhost:3000](http://localhost:3000) to see the app in the
 browser.


### PR DESCRIPTION
Small clarifications gathered from docs feedback issues, each verified
against Deno 2.8 where relevant:

- The directory-existence example now explains the time-of-check to
  time-of-use race condition, so it is clear why `exists()` is discouraged
  immediately before another filesystem operation.
- The hashbang tutorial notes that `env -S` is a GNU/BSD extension rather
  than POSIX, and how to run the script explicitly where it is unavailable.
- The Cloudflare Workers tutorial links out to the Fresh deployment docs.
- The permissions example points to the `--allow-*` flags reference and
  clarifies that the example covers the runtime permissions API.

Closes #1871, closes #3191, closes #2539, closes #1902.

Note: the Next.js Turbopack note was dropped per review (#3185 was fixed on
the Deno side and is now closed).