### PR TITLE
docs: clarify permissions and lint configuration

### DIFF
--- a/lint/rules/ban-unused-ignore.md
+++ b/lint/rules/ban-unused-ignore.md
@@ -16,8 +16,8 @@ detects unused, superfluous ignore directives.
 **Invalid:**
 
 ```typescript
-// Actually this line is valid since `export` means "used",
-// so this directive is superfluous
+// `export` counts as a use, so `foo` is not actually unused and the
+// directive below suppresses nothing. This rule flags it as superfluous.
 // deno-lint-ignore no-unused-vars
 export const foo = 42;
 ```
@@ -25,5 +25,11 @@ export const foo = 42;
 **Valid:**
 
 ```typescript
+// The directive is unnecessary here, so it is simply removed.
 export const foo = 42;
+
+// Here the directive is doing real work: `bar` is genuinely unused, so the
+// no-unused-vars directive is necessary and ban-unused-ignore leaves it alone.
+// deno-lint-ignore no-unused-vars
+const bar = 42;
 ```

--- a/lint/rules/eqeqeq.md
+++ b/lint/rules/eqeqeq.md
@@ -23,3 +23,12 @@ if ("hello world" != input) {}
 if (a === 5) {}
 if ("hello world" !== input) {}
 ```
+
+This rule has no configuration options. If you intentionally want to use `==` or
+`!=` for a specific comparison (for example `value != null` to match both `null`
+and `undefined`), suppress the rule on that line with an ignore directive:
+
+```typescript
+// deno-lint-ignore eqeqeq
+if (value != null) {}
+```

--- a/runtime/fundamentals/security.md
+++ b/runtime/fundamentals/security.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-14
+last_modified: 2026-06-17
 title: "Security and permissions"
 description: "A guide to Deno's security model: secure-by-default execution, the permission sandbox, evaluating and executing untrusted code, and the permission broker. See the Permissions reference for the flags."
 ---
@@ -84,6 +84,20 @@ reads to one directory, `--allow-env=API_KEY` to a single variable, and so on. A
 bare `--allow-net` with no value grants the whole category, which is broader
 than most programs need.
 
+When an operation is refused (because the permission was not granted or was
+explicitly denied), Deno throws a `NotCapable` error. You can catch it like any
+other error if you want to handle missing permissions gracefully:
+
+```ts
+try {
+  await Deno.readTextFile("/etc/hosts");
+} catch (err) {
+  if (err instanceof Deno.errors.NotCapable) {
+    console.error("Missing read permission, run again with --allow-read");
+  }
+}
+```
+
 When stdout is a terminal and you have not passed a flag, Deno pauses and asks
 instead of failing, so you can grant access interactively as it is requested:
 
@@ -123,6 +137,13 @@ is effectively granting full access:
   system calls directly. Once loaded, it can read files, open sockets, or do
   anything the operating system lets the process do, regardless of which
   `--allow-*` flags you passed.
+
+Be careful when combining `--allow-write` with `--allow-run`. Write access to a
+directory that contains an allowed executable (or to the executable itself) lets
+a program overwrite that binary, or replace it with a symlink, so the next
+subprocess it spawns runs attacker-controlled code with the host's privileges.
+Avoid granting write access to directories that hold binaries you allow with
+`--allow-run`.
 
 Treat both as equivalent to `--allow-all` when deciding whether to trust the
 code you are running.

--- a/runtime/fundamentals/security.md
+++ b/runtime/fundamentals/security.md
@@ -140,10 +140,9 @@ is effectively granting full access:
 
 Be careful when combining `--allow-write` with `--allow-run`. Write access to a
 directory that contains an allowed executable (or to the executable itself) lets
-a program overwrite that binary, or replace it with a symlink, so the next
-subprocess it spawns runs attacker-controlled code with the host's privileges.
-Avoid granting write access to directories that hold binaries you allow with
-`--allow-run`.
+a program overwrite that binary, so the next subprocess it spawns runs
+attacker-controlled code with the host's privileges. Avoid granting write access
+to directories that hold binaries you allow with `--allow-run`.
 
 Treat both as equivalent to `--allow-all` when deciding whether to trust the
 code you are running.

--- a/runtime/reference/cli/lint.md
+++ b/runtime/reference/cli/lint.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-12
+last_modified: 2026-06-17
 title: "deno lint"
 oldUrl:
   - /runtime/tools/linter/
@@ -79,6 +79,12 @@ Customize which rules are active in your `deno.json`:
 - **`tags`** — rule sets to enable. Available tags: `recommended`, `fresh`
 - **`include`** — additional individual rules to enable
 - **`exclude`** — rules to disable even if included by a tag
+
+Many rules do not belong to any tag (for example `eqeqeq` or `no-console`).
+Those rules are not enabled by `tags` and must be turned on by listing them
+individually in `include`. You can check whether a rule has a tag with
+`deno lint --rules` or on each rule's page in the [lint rules](/lint/)
+reference.
 
 See the [Configuration](/runtime/reference/deno_json/#linting) page for all
 available options.

--- a/runtime/reference/permissions.md
+++ b/runtime/reference/permissions.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-21
+last_modified: 2026-06-17
 title: "Permissions"
 description: "Reference for Deno's permission system: how the runtime sandbox works and how to grant or deny file system, network, environment, system, subprocess, FFI, and import access with the --allow and --deny flags."
 oldUrl:
@@ -381,6 +381,21 @@ deno run --allow-sys --deny-sys="networkInterfaces" script.ts
 # Deny all access to system information, disabling permission prompts.
 deno run --deny-sys script.ts
 ```
+
+Node compatibility APIs route through the same permission. Functions from
+[`node:os`](https://nodejs.org/api/os.html) map to these `--allow-sys` API
+names:
+
+| `node:os` function              | `--allow-sys` API name |
+| ------------------------------- | ---------------------- |
+| `os.cpus()`                     | `cpus`                 |
+| `os.totalmem()`, `os.freemem()` | `systemMemoryInfo`     |
+| `os.hostname()`                 | `hostname`             |
+| `os.networkInterfaces()`        | `networkInterfaces`    |
+| `os.userInfo()`                 | `uid`, `gid`           |
+| `os.release()`                  | `osRelease`            |
+| `os.uptime()`                   | `osUptime`             |
+| `os.loadavg()`                  | `loadavg`              |
 
 ## Subprocesses
 

--- a/runtime/reference/permissions.md
+++ b/runtime/reference/permissions.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-17
+last_modified: 2026-05-21
 title: "Permissions"
 description: "Reference for Deno's permission system: how the runtime sandbox works and how to grant or deny file system, network, environment, system, subprocess, FFI, and import access with the --allow and --deny flags."
 oldUrl:
@@ -381,21 +381,6 @@ deno run --allow-sys --deny-sys="networkInterfaces" script.ts
 # Deny all access to system information, disabling permission prompts.
 deno run --deny-sys script.ts
 ```
-
-Node compatibility APIs route through the same permission. Functions from
-[`node:os`](https://nodejs.org/api/os.html) map to these `--allow-sys` API
-names:
-
-| `node:os` function              | `--allow-sys` API name |
-| ------------------------------- | ---------------------- |
-| `os.cpus()`                     | `cpus`                 |
-| `os.totalmem()`, `os.freemem()` | `systemMemoryInfo`     |
-| `os.hostname()`                 | `hostname`             |
-| `os.networkInterfaces()`        | `networkInterfaces`    |
-| `os.userInfo()`                 | `uid`, `gid`           |
-| `os.release()`                  | `osRelease`            |
-| `os.uptime()`                   | `osUptime`             |
-| `os.loadavg()`                  | `loadavg`              |
 
 ## Subprocesses
 


### PR DESCRIPTION
A batch of small clarifications from feedback issues, each verified against
Deno 2.8:

- The security guide now documents the `NotCapable` error thrown when access
  is denied, with an example of catching it, and warns that granting
  `--allow-write` over a directory that holds an `--allow-run` binary lets a
  program overwrite that binary and escape the sandbox.
- The `eqeqeq` rule page notes it has no options and shows how to allow an
  intentional `!= null` with an ignore directive.
- The `ban-unused-ignore` page has clearer necessary-vs-superfluous examples.
- The lint docs explain that untagged rules must be enabled individually via
  `include`.

Closes #1642, closes #2846, closes #2692, closes #2890, closes #2434.

Note: the node:os to --allow-sys mapping table was removed per review, so
#2708 is left open.