### PR TITLE
docs: clarify installation, completions, and bundle type-checking

### DIFF
--- a/runtime/getting_started/installation.md
+++ b/runtime/getting_started/installation.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-15
+last_modified: 2026-06-17
 title: Installation
 description: "A Guide to installing Deno on different operating systems. Includes instructions for Windows, macOS, and Linux using various package managers, manual installation methods, and Docker containers."
 oldUrl:
@@ -114,8 +114,12 @@ winget install DenoLand.Deno
 > via npm. We recommend the official install script (shell or PowerShell) for
 > better performance.</small>
 
-Deno does not publish an official apt repository. On Debian or Ubuntu, use the
-shell installer above for the recommended installation path.
+Deno does not publish an official apt repository, and the versions packaged by
+Linux distributions (such as Debian, Ubuntu, Arch, or the Snap Store) are
+community maintained and often lag behind the latest release. For the most
+up-to-date version on any Linux distribution, use the shell installer above (or
+the [manual download](#manual-download)), which always installs the current
+release.
 
 ### Cross-platform package managers
 
@@ -173,6 +177,18 @@ Each release ships one archive per platform, containing a single executable:
 Unzip the archive and place the `deno` executable somewhere on your `PATH`. You
 will have to set the executable bit on macOS and Linux. Each asset has a
 matching `.sha256sum` file for verifying the download.
+
+On Linux a common choice is `~/.local/bin` (per-user) or `/usr/local/bin`
+(system-wide). For example:
+
+```sh
+unzip deno-x86_64-unknown-linux-gnu.zip
+mkdir -p ~/.local/bin
+mv deno ~/.local/bin/
+chmod +x ~/.local/bin/deno
+# ensure the directory is on your PATH, then verify
+deno --version
+```
 
 ## Docker
 

--- a/runtime/reference/cli/bundle.md
+++ b/runtime/reference/cli/bundle.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-12
+last_modified: 2026-06-17
 title: "deno bundle"
 oldUrl: /runtime/manual/cli/bundler/
 command: bundle
@@ -45,6 +45,22 @@ Keep a dependency out of the bundle with `--external`:
 ```sh
 deno bundle --external npm:sharp -o output.js main.ts
 ```
+
+## Type checking
+
+`deno bundle` does not type-check your code by default. Enable type-checking
+with the `--check` flag:
+
+```sh
+# type-check local modules while bundling
+deno bundle --check -o output.js main.ts
+
+# also type-check remote modules
+deno bundle --check=all -o output.js main.ts
+```
+
+You can also skip type-checking explicitly with `--no-check`, and
+`--no-check=remote` ignores diagnostics from remote modules only.
 
 For more on bundling strategies with Deno, see the
 [Bundling](/runtime/reference/bundling/) guide.

--- a/runtime/reference/cli/completions.md
+++ b/runtime/reference/cli/completions.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-04-24
+last_modified: 2026-06-17
 title: "deno completions"
 oldUrl: /runtime/manual/tools/completions/
 command: completions
@@ -10,6 +10,15 @@ description: "Generate shell completions for Deno"
 
 You can use the output script to configure autocompletion for `deno` commands.
 For example: `deno un` -> <kbd>Tab</kbd> -> `deno uninstall`.
+
+:::note
+
+If you installed Deno with Homebrew, shell completions are installed and kept up
+to date for you, as long as your shell is configured to load completions from
+Homebrew's completions directory. In that case you do not need to run
+`deno completions` manually.
+
+:::
 
 ## Examples
 


### PR DESCRIPTION
Small documentation gaps from feedback issues:

- The installation page now explains that Linux distribution and Snap packages
  are community maintained and can lag behind the latest release, and points to
  the shell installer or manual download for the current version. The manual
  download section gains typical Linux `PATH` locations and a verification step.
- The completions page notes that Homebrew installs keep shell completions up
  to date automatically.
- The `deno bundle` reference documents the `--check` / `--no-check`
  type-checking flags (it does not type-check by default), verified against
  Deno 2.8.

Closes #2676, closes #2678, closes #2857, closes #1065, closes #2386.