### PR TITLE
docs: worker messaging, deno serve vs run, README task fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The link checker needs to run against a live server. Here's the workflow:
 2. **Run the link checker** (in another terminal):
 
    ```console
-   deno task check:links:local
+   deno task check:links
    ```
 
 This will check all links on your local site and report any issues.
@@ -108,7 +108,7 @@ git commit --no-verify
 
 **Note for Windows users**: If you're using Git Bash or WSL, the pre-commit hook
 should work normally. If you encounter issues, you can manually run
-`deno task check:links:local` before committing.
+`deno task check:links` before committing.
 
 The link checker also runs automatically in CI for all deployments.
 

--- a/runtime/reference/cli/serve.md
+++ b/runtime/reference/cli/serve.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-05-01
+last_modified: 2026-06-17
 title: "deno serve"
 oldUrl: /runtime/manual/tools/serve/
 command: serve
@@ -32,6 +32,24 @@ By default, the server listens on port **8000**. Override it with `--port`:
 ```sh
 deno serve --port=3000 server.ts
 ```
+
+## `deno serve` vs `deno run`
+
+Both approaches start an HTTP server, and the difference is who calls
+[`Deno.serve()`](/api/deno/~/Deno.serve):
+
+- With `deno serve`, Deno calls [`Deno.serve()`](/api/deno/~/Deno.serve) for
+  you. Your file just exports a default object with a `fetch` handler. Deno owns
+  the listener, which lets it add features such as running multiple instances
+  across threads with [`--parallel`](#horizontal-scaling).
+- With `deno run`, you call [`Deno.serve()`](/api/deno/~/Deno.serve) yourself
+  inside the program. This gives you full control over the listen options and
+  the surrounding code, and is the right choice when the server is one part of a
+  larger program.
+
+Use `deno serve` when the program is primarily an HTTP server and you want Deno
+to manage it; use `deno run` with [`Deno.serve()`](/api/deno/~/Deno.serve) when
+you need to control how and when the server starts.
 
 ## Default export shape
 

--- a/runtime/reference/web_platform_apis.md
+++ b/runtime/reference/web_platform_apis.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-20
+last_modified: 2026-06-17
 title: "Web Platform APIs"
 description: "A guide to the Web Platform APIs available in Deno. Learn about fetch, events, workers, storage, and other web standard APIs, including implementation details and deviations from browser specifications."
 oldUrl:
@@ -337,6 +337,37 @@ self.onmessage = (evt) => {
   console.log(evt.data);
 };
 ```
+
+### Sending messages back to the main thread
+
+Communication goes both ways. The main thread sends data to the worker with
+`worker.postMessage()` and listens for replies with `worker.onmessage`. Inside
+the worker, `self.onmessage` receives messages and `self.postMessage()` sends
+results back:
+
+```ts title="main.ts"
+const worker = new Worker(import.meta.resolve("./worker.ts"), {
+  type: "module",
+});
+
+// Receive results from the worker
+worker.onmessage = (evt) => {
+  console.log("result from worker:", evt.data);
+};
+
+// Send work to the worker
+worker.postMessage(41);
+```
+
+```ts title="worker.ts"
+self.onmessage = (evt) => {
+  const result = evt.data + 1;
+  // Send the result back to the main thread
+  self.postMessage(result);
+};
+```
+
+Running `deno run --allow-read main.ts` prints `result from worker: 42`.
 
 ### Instantiation permissions
 


### PR DESCRIPTION
Three small fixes from feedback issues:

- The Web Workers section gains a bidirectional example showing the worker
  sending results back to the main thread with `self.postMessage()` and the
  main thread receiving them via `worker.onmessage`. The example was run on
  Deno 2.8.
- The `deno serve` reference explains when to use `deno serve` versus calling
  `Deno.serve()` yourself under `deno run`.
- The README referenced a `check:links:local` task that does not exist; it now
  points to the actual `check:links` task.

Closes #439, closes #2436, closes #2605.