### PR TITLE
docs: prose fixes on Desktop apps pages

### DIFF
--- a/runtime/desktop/bindings.md
+++ b/runtime/desktop/bindings.md
@@ -1,7 +1,7 @@
 ---
 last_modified: 2026-06-16
 title: "Bindings"
-description: "Call Deno-side functions from webview JavaScript via win.bind(): type-safe RPC over in-process channels, with no IPC and no serialization beyond the call boundary."
+description: "Call Deno-side functions from webview JavaScript via win.bind(): type-safe RPC over in-process channels, encoded at the boundary with no cross-process round-trip."
 ---
 
 :::info Coming in Deno 2.9

--- a/runtime/desktop/bindings.md
+++ b/runtime/desktop/bindings.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-16
+last_modified: 2026-06-18
 title: "Bindings"
 description: "Call Deno-side functions from webview JavaScript via win.bind(): type-safe RPC over in-process channels, encoded at the boundary with no cross-process round-trip."
 ---

--- a/runtime/desktop/comparison.md
+++ b/runtime/desktop/comparison.md
@@ -23,7 +23,7 @@ technologies. Here is how it compares to the alternatives.
 | **Language**                | JS/TS (Node.js)        | JS/TS (Bun)     | Rust + web frontend  | Rust             | JS/TS (Deno)            |
 | **Web engine**              | Bundled Chromium       | System WebView  | System WebView       | System WebView   | Bundled CEF or WebView  |
 | **Consistent rendering**    | Yes                    | No              | No                   | No               | Yes (CEF)               |
-| **Process model**           | Multi-process          | Multi-process   | Multi-process        | Single process   | Multi-thread            |
+| **Process model**           | Multi-process          | Multi-process   | Multi-process        | Single process   | Multi-thread (CEF) / process group (WebView) |
 | **Backend ↔ UI**            | IPC                    | IPC             | IPC                  | Native Rust      | In-process channels     |
 | **App size**                | ~100 MB+               | ~14 MB          | ~2–10 MB             | ~5 MB            | ~40 MB / ~150 MB (CEF)  |
 | **npm / Node compat**       | Yes                    | Yes             | No                   | No               | Yes                     |

--- a/runtime/desktop/comparison.md
+++ b/runtime/desktop/comparison.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-16
+last_modified: 2026-06-18
 title: "Comparison with other tools"
 description: "How deno desktop compares to Electron, Electrobun, Tauri, and Dioxus across language, engine, process model, app size, ecosystem, and what's built-in."
 ---

--- a/runtime/desktop/comparison.md
+++ b/runtime/desktop/comparison.md
@@ -18,22 +18,22 @@ technologies. Here is how it compares to the alternatives.
 
 ## At a glance
 
-|                             | Electron               | Electrobun      | Tauri                | Dioxus           | `deno desktop`          |
-| --------------------------- | ---------------------- | --------------- | -------------------- | ---------------- | ----------------------- |
-| **Language**                | JS/TS (Node.js)        | JS/TS (Bun)     | Rust + web frontend  | Rust             | JS/TS (Deno)            |
-| **Web engine**              | Bundled Chromium       | System WebView  | System WebView       | System WebView   | Bundled CEF or WebView  |
-| **Consistent rendering**    | Yes                    | No              | No                   | No               | Yes (CEF)               |
+|                             | Electron               | Electrobun      | Tauri                | Dioxus           | `deno desktop`                               |
+| --------------------------- | ---------------------- | --------------- | -------------------- | ---------------- | -------------------------------------------- |
+| **Language**                | JS/TS (Node.js)        | JS/TS (Bun)     | Rust + web frontend  | Rust             | JS/TS (Deno)                                 |
+| **Web engine**              | Bundled Chromium       | System WebView  | System WebView       | System WebView   | Bundled CEF or WebView                       |
+| **Consistent rendering**    | Yes                    | No              | No                   | No               | Yes (CEF)                                    |
 | **Process model**           | Multi-process          | Multi-process   | Multi-process        | Single process   | Multi-thread (CEF) / process group (WebView) |
-| **Backend ↔ UI**            | IPC                    | IPC             | IPC                  | Native Rust      | In-process channels     |
-| **App size**                | ~100 MB+               | ~14 MB          | ~2–10 MB             | ~5 MB            | ~40 MB / ~150 MB (CEF)  |
-| **npm / Node compat**       | Yes                    | Yes             | No                   | No               | Yes                     |
-| **Framework auto-detect**   | No                     | No              | No                   | No               | Yes                     |
-| **HMR**                     | No                     | Yes             | Yes (Vite-based)     | Yes (`dx serve`) | Yes                     |
-| **Built-in auto-update**    | Full binary            | bsdiff          | Plugin               | None             | bsdiff                  |
-| **Built-in installers**     | Yes                    | No              | Yes                  | No               | Partial (DMG, AppImage) |
-| **Cross-compile**           | Yes (electron-builder) | No (macOS only) | No (needs target OS) | No               | Yes (`--target`)        |
-| **macOS / Windows / Linux** | All three              | macOS only      | All three            | All three        | All three               |
-| **iOS / Android**           | No                     | No              | Yes                  | Yes              | Not yet                 |
+| **Backend ↔ UI**            | IPC                    | IPC             | IPC                  | Native Rust      | In-process channels                          |
+| **App size**                | ~100 MB+               | ~14 MB          | ~2–10 MB             | ~5 MB            | ~40 MB / ~150 MB (CEF)                       |
+| **npm / Node compat**       | Yes                    | Yes             | No                   | No               | Yes                                          |
+| **Framework auto-detect**   | No                     | No              | No                   | No               | Yes                                          |
+| **HMR**                     | No                     | Yes             | Yes (Vite-based)     | Yes (`dx serve`) | Yes                                          |
+| **Built-in auto-update**    | Full binary            | bsdiff          | Plugin               | None             | bsdiff                                       |
+| **Built-in installers**     | Yes                    | No              | Yes                  | No               | Partial (DMG, AppImage)                      |
+| **Cross-compile**           | Yes (electron-builder) | No (macOS only) | No (needs target OS) | No               | Yes (`--target`)                             |
+| **macOS / Windows / Linux** | All three              | macOS only      | All three            | All three        | All three                                    |
+| **iOS / Android**           | No                     | No              | Yes                  | Yes              | Not yet                                      |
 
 ## What `deno desktop` is good at
 

--- a/runtime/desktop/index.md
+++ b/runtime/desktop/index.md
@@ -110,3 +110,5 @@ webview navigates to, so you do not need to pass a port or hostname. See
   formats, installers.
 - [Comparison](/runtime/desktop/comparison/): how `deno desktop` relates to
   Electron, Tauri, Electrobun, Dioxus.
+- [`deno desktop` CLI reference](/runtime/reference/cli/desktop/): the command,
+  its flags, and the `deno.json` `desktop` schema.

--- a/runtime/desktop/index.md
+++ b/runtime/desktop/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-16
+last_modified: 2026-06-17
 title: "Desktop apps"
 description: "Build self-contained desktop applications from a Deno project, with framework auto-detection, hot reload, native windowing, auto-update, and cross-platform distribution."
 ---
@@ -39,8 +39,9 @@ integration.
   under `--hmr`. No code changes are required to take an existing web project to
   the desktop.
 - **In-process bindings instead of IPC.** Backend and UI communication goes
-  through in-process channels, not socket-based IPC, so there is no
-  serialization step between your Deno code and the webview.
+  through in-process channels, not socket-based IPC. Values are still encoded as
+  they cross the call boundary, but there is no cross-process round-trip between
+  your Deno code and the webview.
 - **Cross-compile from one machine.** The same machine can build for macOS,
   Windows, and Linux. Backends are downloaded as needed, not built locally.
 - **Built-in binary-diff auto-update.** Ship a single `latest.json` manifest and

--- a/runtime/desktop/notifications.md
+++ b/runtime/desktop/notifications.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-16
+last_modified: 2026-06-17
 title: "Notifications"
 description: "Show native OS notifications from deno desktop apps with the standard Web Notifications API: permission flow, options, and events."
 ---
@@ -110,6 +110,8 @@ round-trip through the `icon` property, but the OS notification is shown without
 an icon. To use a file on disk, read it and encode it as a `data:` URL:
 
 ```ts
+import { encodeBase64 } from "jsr:@std/encoding/base64";
+
 const bytes = await Deno.readFile("./icons/alert.png");
 const dataUrl = "data:image/png;base64," + encodeBase64(bytes);
 new Notification("Heads up", { icon: dataUrl });

--- a/runtime/desktop/serving.md
+++ b/runtime/desktop/serving.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-16
+last_modified: 2026-06-17
 title: "HTTP serving"
 description: "How Deno.serve() works inside a desktop app: automatic port binding, the DENO_SERVE_ADDRESS env var, and serving local UI to the embedded webview."
 ---
@@ -112,7 +112,7 @@ in `tcp:127.0.0.1:<port>` form, so split off the port when you need an `http://`
 URL:
 
 ```ts
-const addr = Deno.env.get("DENO_SERVE_ADDRESS"); // "tcp:127.0.0.1:54321"
+const addr = Deno.env.get("DENO_SERVE_ADDRESS")!; // "tcp:127.0.0.1:54321"
 const port = addr.split(":").pop();
 console.log("Serving on:", `http://127.0.0.1:${port}`);
 ```
@@ -124,7 +124,7 @@ from the same local HTTP server by default. Use different paths per window to
 differentiate:
 
 ```ts
-const port = Deno.env.get("DENO_SERVE_ADDRESS").split(":").pop();
+const port = Deno.env.get("DENO_SERVE_ADDRESS")!.split(":").pop();
 const settings = new Deno.BrowserWindow();
 settings.navigate(`http://127.0.0.1:${port}/settings`);
 ```


### PR DESCRIPTION
A prose pass over the new Desktop apps section surfaced three small
correctness issues. The section overview claimed in-process bindings mean
"no serialization step" between Deno and the webview, which contradicts the
Bindings and Comparison pages that both state values are still encoded as
they cross the call boundary; what bindings actually avoid is the
cross-process round-trip, so the overview now says that. Two snippets on the
HTTP serving page read DENO_SERVE_ADDRESS without a non-null assertion and
would not type-check, unlike the matching code on the Windows page. The
Notifications icon example called encodeBase64 with no import.

These are the only correctness issues found; the rest of the section reads
well. A few things I was unsure about are left for review rather than changed:
the distribution CI matrix uses a macos-15-intel runner label I could not
confirm exists, the comparison table lists the process model as
"Multi-thread" while the Bindings page describes WebView as a coordinated
process group, and the section index does not link to the deno desktop CLI
reference page.