### PR TITLE
docs: address runtime feedback (testing, permissions, deno x, fetch, versions)

### DIFF
--- a/examples/tutorials/fetch_data.md
+++ b/examples/tutorials/fetch_data.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-08-11
+last_modified: 2026-06-18
 title: "Fetch and stream data"
 description: "A tutorial on working with network requests in Deno. Learn how to use the fetch API for HTTP requests, handle responses, implement data streaming, and manage file uploads and downloads."
 url: /examples/fetch_data_tutorial/
@@ -53,6 +53,17 @@ deno run --allow-net fetch.js
 
 You should see the JSON data, HTML data as text, and an error message in the
 console.
+
+### HTTP/2
+
+You don't need to do anything special to use HTTP/2. When you `fetch()` an
+`https://` URL, Deno negotiates the protocol with the server over TLS (via ALPN)
+and uses HTTP/2 automatically when the server supports it, falling back to
+HTTP/1.1 otherwise. The `fetch` API is the same either way, so the same code
+talks to HTTP/1.1 and HTTP/2 servers without changes.
+
+On the server side, [`Deno.serve()`](/api/deno/~/Deno.serve) also speaks HTTP/2
+automatically when serving over TLS.
 
 ## Streaming data
 

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-14
+last_modified: 2026-06-18
 title: "Modules"
 description: "Learn how Deno's ECMAScript module system works: importing local and third-party modules, import attributes, import maps, and supported import types such as Wasm and data URLs."
 oldUrl:

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -327,6 +327,25 @@ without the trailing `/`:
 }
 ```
 
+## Updating versions from the command line
+
+You don't have to edit version numbers in `deno.json` by hand. To move
+dependencies to newer versions, run
+[`deno outdated`](/runtime/reference/cli/outdated/) to see what's behind, then
+`deno outdated --update` to bump them:
+
+```sh
+deno outdated            # list dependencies with newer versions available
+deno outdated --update   # update them in deno.json
+```
+
+To increment your own package's `version` field between releases, use
+[`deno bump-version`](/runtime/reference/cli/bump_version/):
+
+```sh
+deno bump-version patch  # 1.4.6 -> 1.4.7 (also: minor, major, or a prerelease)
+```
+
 ## Managing dependencies
 
 Now that you understand how Deno resolves and imports modules, see the

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -327,6 +327,15 @@ without the trailing `/`:
 }
 ```
 
+## Managing dependencies
+
+Now that you understand how Deno resolves and imports modules, see the
+[Dependency management guide](/runtime/packages/) for the day-to-day tasks:
+adding and removing packages with `deno add` / `deno
+remove`, pinning versions,
+overriding and vendoring dependencies, lockfiles and integrity checking, supply
+chain management, publishing your own modules, and using private registries.
+
 ## Updating versions from the command line
 
 You don't have to edit version numbers in `deno.json` by hand. To move
@@ -345,12 +354,3 @@ To increment your own package's `version` field between releases, use
 ```sh
 deno bump-version patch  # 1.4.6 -> 1.4.7 (also: minor, major, or a prerelease)
 ```
-
-## Managing dependencies
-
-Now that you understand how Deno resolves and imports modules, see the
-[Dependency management guide](/runtime/packages/) for the day-to-day tasks:
-adding and removing packages with `deno add` / `deno
-remove`, pinning versions,
-overriding and vendoring dependencies, lockfiles and integrity checking, supply
-chain management, publishing your own modules, and using private registries.

--- a/runtime/reference/cli/x.md
+++ b/runtime/reference/cli/x.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-20
+last_modified: 2026-06-18
 title: "deno x"
 command: x
 openGraphLayout: "/open_graph/cli-commands.jsx"
@@ -68,6 +68,28 @@ The previous form `deno x typescript/tsc` still works.
 resolves the package's binary entry point, and executes it. The package is not
 added to your project's [`deno.json`](/runtime/fundamentals/configuration/) or
 `package.json`.
+
+## Authoring a package that runs with `deno x`
+
+How `deno x` finds something to execute depends on the registry:
+
+- **npm packages** expose runnable binaries through the `bin` field in
+  `package.json`. `deno x npm:<package>` runs the package's default binary, and
+  `deno x -p <package> <binary>` (or `deno x npm:<package>/<binary>`) selects a
+  specific one when the package ships several. To make your own npm package
+  runnable, publish it with a `bin` entry as you would for `npx`.
+- **JSR packages** are run by pointing `deno x` at an export that executes when
+  imported, for example `deno x jsr:@std/http/file-server`. To make your own JSR
+  package runnable, expose the entry point as a module export (guard top-level
+  side effects with `import.meta.main` so the module can still be imported as a
+  library), then document the subpath users should run, such as
+  `deno x jsr:@you/tool/cli`.
+
+If you want the tool available as a permanent command rather than run on demand,
+install it with [`deno install`](/runtime/reference/cli/install/) or compile it
+to a standalone executable. See [Build CLI apps](/runtime/cli_apps/) for the
+full workflow, and [Publishing modules](/runtime/packages/publishing/) for
+publishing to JSR.
 
 ## Permissions
 

--- a/runtime/reference/permissions.md
+++ b/runtime/reference/permissions.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-21
+last_modified: 2026-06-18
 title: "Permissions"
 description: "Reference for Deno's permission system: how the runtime sandbox works and how to grant or deny file system, network, environment, system, subprocess, FFI, and import access with the --allow and --deny flags."
 oldUrl:

--- a/runtime/reference/permissions.md
+++ b/runtime/reference/permissions.md
@@ -382,6 +382,22 @@ deno run --allow-sys --deny-sys="networkInterfaces" script.ts
 deno run --deny-sys script.ts
 ```
 
+The interface names accepted by `--allow-sys` correspond to the functions in the
+`Deno` namespace that expose host information, such as `hostname`, `osRelease`,
+`osUptime`, `loadavg`, `networkInterfaces`, `systemMemoryInfo`, `uid`, `gid`,
+`username`, `cpus`, and `homedir`. See
+[Deno.SysPermissionDescriptor](/api/deno/~/Deno.SysPermissionDescriptor) for the
+full set of recognized names.
+
+The same flag gates the equivalent Node-compatibility APIs. Functions in
+[`node:os`](/api/node/os/) and [`node:process`](/api/node/process/) that read
+system information, such as `os.hostname()`, `os.cpus()`,
+`os.networkInterfaces()`, `os.freemem()`, `os.totalmem()`, `os.uptime()`,
+`process.getuid()`, and `process.getgid()`, require `--allow-sys` and map onto
+the same interface names. For example, calling `os.cpus()` needs
+`--allow-sys=cpus`, and `os.networkInterfaces()` needs
+`--allow-sys=networkInterfaces`.
+
 ## Subprocesses
 
 Code executing inside of a Deno runtime can not spawn subprocesses by default,

--- a/runtime/test/index.md
+++ b/runtime/test/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-20
+last_modified: 2026-06-18
 title: "Testing"
 description: "Write and run tests with Deno's built-in test runner: assertions, test steps, hooks, filtering, and reporters, with dedicated guides for mocking, snapshots, and coverage."
 oldUrl:
@@ -20,6 +20,29 @@ In addition to the built-in test runner, you can also use other test runners
 from the JS ecosystem, such as Jest, Mocha, or AVA, with Deno. Moving an
 existing Jest suite over? See
 [Migrating from Jest](/runtime/test/migrate_from_jest/).
+
+## `Deno.test` vs `node:test`
+
+Deno can run tests written for [Node's built-in test runner](/api/node/test/)
+(`import { test } from "node:test"`) as well as its own `Deno.test`. Which one
+to reach for depends on where the code needs to run:
+
+- **Use `Deno.test`** for Deno-first projects. It needs no imports for the
+  runner itself, type-checks TypeScript with no extra setup, and is wired into
+  the rest of Deno's tooling: per-test [permissions](#tests-and-permissions),
+  [coverage](/runtime/test/coverage/), [snapshots](/runtime/test/snapshots/),
+  [sanitizers](/runtime/test/sanitizers/), and
+  [documentation tests](/runtime/test/doc_tests/). Output, filtering, and
+  reporters are all driven by the `deno test` command.
+- **Use `node:test`** when a suite has to run unchanged on both Node and Deno,
+  or when you are porting a Node project and don't want to rewrite its tests
+  yet. It runs under `deno test`, but it does not hook into the Deno-specific
+  features above (for example, the `permissions` option and the op/resource
+  sanitizers are `Deno.test` concepts).
+
+Both runners can coexist in the same project, and `deno test` discovers and runs
+files using either one. For new Deno code, prefer `Deno.test`; keep `node:test`
+where cross-runtime portability is the priority.
 
 ## Writing Tests
 

--- a/runtime/test/index.md
+++ b/runtime/test/index.md
@@ -21,9 +21,10 @@ from the JS ecosystem, such as Jest, Mocha, or AVA, with Deno. Moving an
 existing Jest suite over? See
 [Migrating from Jest](/runtime/test/migrate_from_jest/).
 
-## `Deno.test` vs `node:test`
+## [`Deno.test`](/api/deno/~/Deno.test) vs [`node:test`](/api/node/test/)
 
-Deno supports two test APIs equally: its own `Deno.test` and Node's built-in
+Deno supports two test APIs equally: its own
+[`Deno.test`](/api/deno/~/Deno.test) and Node's built-in
 [`node:test`](/api/node/test/) module. Both are first-class. `deno test`
 discovers, runs, and reports tests written with either one, core features like
 [coverage](/runtime/test/coverage/) and name filtering work the same regardless
@@ -32,15 +33,16 @@ supported than the other.
 
 The difference is the API, not the level of support:
 
-- `Deno.test` needs no import and exposes Deno-specific options, such as
-  per-test [permissions](#tests-and-permissions) and the op/resource
-  [sanitizer](/runtime/test/sanitizers/) toggles.
+- [`Deno.test`](/api/deno/~/Deno.test) needs no import and exposes Deno-specific
+  options, such as per-test [permissions](#tests-and-permissions) and the
+  op/resource [sanitizer](/runtime/test/sanitizers/) toggles.
 - `node:test` (`import { test } from "node:test"`) uses the Node testing API, so
   a suite written with it also runs unchanged on Node.js.
 
 Reach for `node:test` when you want a suite that is portable across Deno and
-Node, or when you're migrating a Node project; reach for `Deno.test` when you
-want the Deno-native ergonomics and options.
+Node, or when you're migrating a Node project; reach for
+[`Deno.test`](/api/deno/~/Deno.test) when you want the Deno-native ergonomics
+and options.
 
 ## Writing Tests
 

--- a/runtime/test/index.md
+++ b/runtime/test/index.md
@@ -23,26 +23,24 @@ existing Jest suite over? See
 
 ## `Deno.test` vs `node:test`
 
-Deno can run tests written for [Node's built-in test runner](/api/node/test/)
-(`import { test } from "node:test"`) as well as its own `Deno.test`. Which one
-to reach for depends on where the code needs to run:
+Deno supports two test APIs equally: its own `Deno.test` and Node's built-in
+[`node:test`](/api/node/test/) module. Both are first-class. `deno test`
+discovers, runs, and reports tests written with either one, core features like
+[coverage](/runtime/test/coverage/) and name filtering work the same regardless
+of which you use, and you can mix both in the same project. Neither is more
+supported than the other.
 
-- **Use `Deno.test`** for Deno-first projects. It needs no imports for the
-  runner itself, type-checks TypeScript with no extra setup, and is wired into
-  the rest of Deno's tooling: per-test [permissions](#tests-and-permissions),
-  [coverage](/runtime/test/coverage/), [snapshots](/runtime/test/snapshots/),
-  [sanitizers](/runtime/test/sanitizers/), and
-  [documentation tests](/runtime/test/doc_tests/). Output, filtering, and
-  reporters are all driven by the `deno test` command.
-- **Use `node:test`** when a suite has to run unchanged on both Node and Deno,
-  or when you are porting a Node project and don't want to rewrite its tests
-  yet. It runs under `deno test`, but it does not hook into the Deno-specific
-  features above (for example, the `permissions` option and the op/resource
-  sanitizers are `Deno.test` concepts).
+The difference is the API, not the level of support:
 
-Both runners can coexist in the same project, and `deno test` discovers and runs
-files using either one. For new Deno code, prefer `Deno.test`; keep `node:test`
-where cross-runtime portability is the priority.
+- `Deno.test` needs no import and exposes Deno-specific options, such as
+  per-test [permissions](#tests-and-permissions) and the op/resource
+  [sanitizer](/runtime/test/sanitizers/) toggles.
+- `node:test` (`import { test } from "node:test"`) uses the Node testing API, so
+  a suite written with it also runs unchanged on Node.js.
+
+Reach for `node:test` when you want a suite that is portable across Deno and
+Node, or when you're migrating a Node project; reach for `Deno.test` when you
+want the Deno-native ergonomics and options.
 
 ## Writing Tests
 


### PR DESCRIPTION
This bundles fixes for five "needs improvement" feedback issues that each
pointed at a concrete gap on a different runtime page.

The testing guide now explains when to reach for Deno.test versus node:test,
since Deno runs both and the page only mentioned third-party runners (#2910).
The permissions reference spells out that --allow-sys also gates the
node:os and node:process system-information APIs (os.cpus(),
os.networkInterfaces(), process.getuid(), and so on) and maps them to the
same interface names, which the reader asking about node:os coverage was
missing (#2708). The deno x reference gains a section on authoring a package
that runs with deno x, covering the npm bin field and the JSR
runnable-export pattern (#2845). The fetch tutorial notes that fetch (and
Deno.serve) negotiate HTTP/2 automatically over TLS, answering a reader who
went looking for HTTP/2 support and found nothing (#2737). The modules guide
shows deno outdated --update and deno bump-version for changing versions
from the command line instead of hand-editing deno.json (#2726).

Closes #2910
Closes #2708
Closes #2845
Closes #2737
Closes #2726