### PR TITLE
docs: link how to disable a lint rule from the rules list

### DIFF
--- a/lint/index.page.tsx
+++ b/lint/index.page.tsx
@@ -67,7 +67,7 @@ export default function LintRulesIndex(
           <code>deno.json</code>, or suppress a single diagnostic in your code
           with a{" "}
           <a href="/runtime/reference/cli/lint/#ignore-directives">
-            <code>// deno-lint-ignore</code>
+            <code>{"// deno-lint-ignore"}</code>
           </a>{" "}
           comment.
         </p>

--- a/lint/index.page.tsx
+++ b/lint/index.page.tsx
@@ -58,6 +58,19 @@ export default function LintRulesIndex(
           If no tag is provided, then the <code>recommended</code>{" "}
           set of rules will be enabled by default.
         </p>
+        <p>
+          To turn a rule off, add it to{" "}
+          <a href="/runtime/reference/cli/lint/#configuring-rules-in-deno.json">
+            <code>lint.rules.exclude</code>
+          </a>{" "}
+          in{" "}
+          <code>deno.json</code>, or suppress a single diagnostic in your code
+          with a{" "}
+          <a href="/runtime/reference/cli/lint/#ignore-directives">
+            <code>// deno-lint-ignore</code>
+          </a>{" "}
+          comment.
+        </p>
         <input
           type="text"
           id="lint-rule-search"

--- a/lint/index.page.tsx
+++ b/lint/index.page.tsx
@@ -67,7 +67,7 @@ export default function LintRulesIndex(
           <code>deno.json</code>, or suppress a single diagnostic in your code
           with a{" "}
           <a href="/runtime/reference/cli/lint/#ignore-directives">
-            <code>{"// deno-lint-ignore"}</code>
+            <code>deno-lint-ignore</code>
           </a>{" "}
           comment.
         </p>


### PR DESCRIPTION
A reader on the lint rules list (/lint/) couldn't find how to turn a rule
off. The page explained enabling rule sets via tags but never pointed to
disabling, which is documented on the deno lint reference. This adds a short
sentence linking to lint.rules.exclude in deno.json and the deno-lint-ignore
directive.

Closes #2413