### PR TITLE
docs: document typing dynamic imports with a type assertion

### DIFF
--- a/runtime/fundamentals/typescript.md
+++ b/runtime/fundamentals/typescript.md
@@ -370,6 +370,20 @@ Without a local `node_modules` (Deno's default global-cache mode), this
 automatic resolution does not apply; use the per-import `@ts-types` annotation
 shown above instead.
 
+### Typing dynamic imports
+
+The `@ts-types` directive only applies to static `import` statements, not to
+dynamic `import()`. To type a dynamic import of a module that ships without
+declarations, use a type assertion that points at the corresponding `@types`
+package:
+
+```ts title="main.ts"
+const { markedTerminal } =
+  await import("npm:marked-terminal@7") as typeof import(
+    "npm:@types/marked-terminal@6"
+  );
+```
+
 ### Providing types for HTTP modules
 
 Servers hosting JavaScript modules can advertise a declaration file in an

--- a/runtime/fundamentals/typescript.md
+++ b/runtime/fundamentals/typescript.md
@@ -378,10 +378,9 @@ declarations, use a type assertion that points at the corresponding `@types`
 package:
 
 ```ts title="main.ts"
-const { markedTerminal } =
-  await import("npm:marked-terminal@7") as typeof import(
-    "npm:@types/marked-terminal@6"
-  );
+const { markedTerminal } = await import(
+  "npm:marked-terminal@7"
+) as typeof import("npm:@types/marked-terminal@6");
 ```
 
 ### Providing types for HTTP modules


### PR DESCRIPTION
The `@ts-types` (formerly `@deno-types`) directive only applies to static
`import` statements, not to dynamic `import()`, so dynamically importing an
untyped module leaves it as `any`. The workaround is a type assertion pointing
at the corresponding `@types` package.

This adds a short "Typing dynamic imports" subsection to the TypeScript
fundamentals page showing that pattern.

Closes #495.