### PR TITLE
docs: document LD_*/DYLD_* subprocess env var restriction

### DIFF
--- a/runtime/reference/permissions.md
+++ b/runtime/reference/permissions.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-21
+last_modified: 2026-06-18
 title: "Permissions"
 description: "Reference for Deno's permission system: how the runtime sandbox works and how to grant or deny file system, network, environment, system, subprocess, FFI, and import access with the --allow and --deny flags."
 oldUrl:
@@ -419,6 +419,33 @@ has `--allow-all`, as being able to spawn a `deno` process means the script can
 spawn another `deno` process with full permissions.
 
 :::
+
+### Subprocesses with `LD_*` and `DYLD_*` environment variables
+
+Spawning a subprocess with an environment variable whose name starts with `LD_`
+(such as `LD_LIBRARY_PATH` or `LD_PRELOAD`) or `DYLD_` (such as
+`DYLD_LIBRARY_PATH` or `DYLD_INSERT_LIBRARIES`) requires the unscoped
+`--allow-run` flag. A scoped allow list like `--allow-run=curl` is _not_
+sufficient, even when the value matches the one Deno was started with:
+
+```ts
+// Fails under `--allow-run=echo`, succeeds under `--allow-run` or `--allow-all`.
+new Deno.Command("echo", {
+  args: ["hello"],
+  env: { LD_PRELOAD: "/path/to/lib.so" },
+}).outputSync();
+```
+
+```console
+NotCapable: Requires --allow-run permissions to spawn subprocess with LD_PRELOAD
+environment variable. Alternatively, spawn with the environment variable unset.
+```
+
+These variables instruct the dynamic linker to load arbitrary shared libraries
+into the child process, so they can run code in the subprocess regardless of
+which executable you allowed. Restricting them to the unscoped `--allow-run`
+keeps a scoped allow list from being silently bypassed. If you don't need them,
+the simplest fix is to spawn the subprocess with the variable unset.
 
 Definition: `--deny-run[=<PROGRAM_NAME>...]`
 


### PR DESCRIPTION
Spawning a subprocess with an environment variable named with an `LD_` or
`DYLD_` prefix (for example `LD_LIBRARY_PATH`, `LD_PRELOAD`, or
`DYLD_INSERT_LIBRARIES`) requires the unscoped `--allow-run` flag; a scoped
allow list such as `--allow-run=curl` is rejected. This trips up people who
move a working `--allow-run=...` setup into an environment that sets these
variables and hit an opaque `NotCapable` error, with no mention of the rule
anywhere in the permissions docs.

This adds a short subsection under Subprocesses in the permissions reference
explaining the restriction, why it exists (these variables let the dynamic
linker load arbitrary libraries into the child, which would otherwise bypass
the executable allow list), and how to work around it by unsetting the
variable when spawning.

Closes #1135