### PR TITLE
docs: update mysql2 tutorial to v3

### DIFF
--- a/examples/tutorials/mysql2.md
+++ b/examples/tutorials/mysql2.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-14
+last_modified: 2026-06-18
 title: "How to use MySQL2 with Deno"
 description: "Step-by-step guide to using MySQL2 with Deno. Learn how to set up database connections, execute queries, handle transactions, and build data-driven applications using MySQL's Node.js driver."
 url: /examples/mysql2_tutorial/
@@ -19,7 +19,7 @@ package and importing via `npm:mysql2`. This allows us to use its Promise
 wrapper and take advantage of top-level await.
 
 ```tsx
-import mysql from "npm:mysql2@^2.3.3/promise";
+import mysql from "npm:mysql2@^3/promise";
 ```
 
 ## Connecting to MySQL


### PR DESCRIPTION
The MySQL2 tutorial pinned `npm:mysql2@^2.3.3`, while the current release line
is v3 (latest 3.22.x). This bumps the import to `npm:mysql2@^3`.

Every API the tutorial uses (`createConnection`, `query`, `execute`, the
`[rows, fields]` tuple return, and `end`) is unchanged in v3, so no other edits
were needed.

Note: the companion sample at `denoland/examples/with-mysql2` (linked from the
tutorial) still pins `@^2.3.3` and should be bumped separately to stay in sync.

Closes #1183.