### PR TITLE
docs: fix typos in the deno install reference

### DIFF
--- a/runtime/reference/cli/install.md
+++ b/runtime/reference/cli/install.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-20
+last_modified: 2026-06-18
 title: "deno install"
 oldUrl:
   - /runtime/manual/tools/script_installer/
@@ -117,7 +117,7 @@ Download npm:express
 
 :::tip
 
-If you want to set up local `node_modules` directory, you can pass
+If you want to set up a local `node_modules` directory, you can pass the
 `--node-modules-dir=auto` flag.
 
 Some dependencies might not work correctly without a local `node_modules`
@@ -127,8 +127,8 @@ directory.
 
 ### deno install --global [PACKAGE_OR_URL]
 
-Use this command to install provide package or script as a globally available
-binary on your system.
+Use this command to install the provided package or script as a globally
+available binary on your system.
 
 This command creates a thin, executable shell script which invokes `deno` using
 the specified CLI flags and main module. It is placed in the installation root.


### PR DESCRIPTION
Two small wording fixes on the `deno install` reference page:

- "install provide package or script" becomes "install the provided
  package or script" in the `--global` section.
- "set up local `node_modules` directory" becomes "set up a local
  `node_modules` directory" in the install-from-entrypoint tip.

These were reported in #1377. The remaining items in that issue concern the
auto-generated option tables (descriptions for `--node-modules-dir`,
`--dev`, `--reload`, `--check`), which come from the Deno CLI help output
rather than this page; those are filed upstream in denoland/deno#35322.