### PR TITLE
fix(examples): make the per-example "run locally" command actually runnable

### DIFF
--- a/examples/_components/ExamplePage.tsx
+++ b/examples/_components/ExamplePage.tsx
@@ -9,7 +9,7 @@ export default function ExamplePage({ example }: Props) {
     file.snippets.map((snippet) => snippet.code).join("\n")
   ).join("\n");
   const url =
-    `https://github.com/denoland/deno-docs/blob/main/examples/scripts/${example.name}${
+    `https://github.com/denoland/docs/blob/main/examples/scripts/${example.name}${
       example.parsed.files.length > 1 ? "/main" : ""
     }`;
   const rawUrl = `https://docs.deno.com/examples/scripts/${example.name}${
@@ -81,8 +81,12 @@ export default function ExamplePage({ example }: Props) {
             >
               <pre className="highlight">
                 <code>
-                {example.parsed.run.startsWith("deno")
-                    ? example.parsed.run.replace("<url>", url)
+                {example.parsed.run.startsWith("deno test")
+                    ? `# deno test runs local files, so download the example first:\ncurl -O ${rawUrl}\n${
+                      example.parsed.run.replace("<url>", example.name)
+                    }`
+                    : example.parsed.run.startsWith("deno")
+                    ? example.parsed.run.replace("<url>", rawUrl)
                     : "deno run " +
                     example.parsed.run.replace("<url>", rawUrl)}
                 </code>


### PR DESCRIPTION
The "Run this example locally" command on every example page substituted
`<url>` with a github.com `/blob/` URL, which serves an HTML page rather
than the script. As a result the rendered command never worked:

```
$ deno run https://github.com/denoland/deno-docs/blob/main/examples/scripts/hello_world.ts
error: SyntaxError: Expected ';', '}' or <eof>
7 | <!DOCTYPE html>
```

This switches the run command to the raw `docs.deno.com` URL the component
already computes, which serves the script and runs:

```
$ deno run https://docs.deno.com/examples/scripts/hello_world.ts
Hello, World!
```

It also corrects the repo name in the GitHub source links (`deno-docs`
was relying on a redirect to `docs`).

Separately, `deno test` cannot run a remote URL at all, even the working
raw one:

```
$ deno test -R -W https://docs.deno.com/examples/scripts/writing_tests.ts
error: No test modules found
```

So for `deno test` examples the page now renders a download-then-run
command that works (verified end to end against the three test examples):

```
# deno test runs local files, so download the example first:
curl -O https://docs.deno.com/examples/scripts/writing_tests.ts
deno test -R -W writing_tests.ts
```

Closes #1827.