### PR TITLE
docs: clarify deno bundle is not a Vite/webpack replacement

### DIFF
--- a/runtime/reference/cli/bundle.md
+++ b/runtime/reference/cli/bundle.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-17
+last_modified: 2026-06-18
 title: "deno bundle"
 oldUrl: /runtime/manual/cli/bundler/
 command: bundle

--- a/runtime/reference/cli/bundle.md
+++ b/runtime/reference/cli/bundle.md
@@ -9,7 +9,11 @@ info: "`deno bundle` is currently an experimental subcommand and is subject to c
 ---
 
 `deno bundle` combines your module and all of its dependencies into a single
-JavaScript file, using [esbuild](https://esbuild.github.io/) under the hood.
+JavaScript file, using [esbuild](https://esbuild.github.io/) under the hood. It
+is useful for deploying or distributing a project as a single optimized file,
+but it is not currently intended as a replacement for complex or interactive
+build tools such as [Vite](https://vite.dev/) or
+[webpack](https://webpack.js.org/).
 
 ## Basic usage
 


### PR DESCRIPTION
The deno bundle reference describes the command as combining a module and
its dependencies into a single file, but it does not say what the command
is not for. Users have read it as a general-purpose build tool and expected
it to stand in for something like Vite or webpack, which it is not meant to
do.

This adds half a sentence to the intro setting that expectation: deno bundle
is useful for shipping a project as a single optimized file, but is not
currently intended as a replacement for complex or interactive build tools.

Closes #2441