### PR TITLE
feat: add character counter to docs feedback form

### DIFF
--- a/_components/Feedback.tsx
+++ b/_components/Feedback.tsx
@@ -81,9 +81,18 @@ export default function Feedback({ file }: { file: string | undefined }) {
                   class="block w-full p-2 border border-foreground-tertiary bg-white dark:bg-background-primary rounded"
                   name="feedback-comment"
                   id="feedback-comment"
+                  // Keep maxlength in sync with MAX_COMMENT_LENGTH in
+                  // middleware/functions/feedback.ts and js/feedback.ts
+                  maxLength={2000}
                   placeholder="Your feedback will be posted as an issue in the denoland/docs GitHub repo"
                 >
                 </textarea>
+                <p
+                  id="feedback-comment-count"
+                  class="text-xs text-gray-600 dark:text-gray-400 text-right mt-1"
+                >
+                  0 / 2000
+                </p>
               </div>
               <div class="space-y-1">
                 <label for="feedback-contact">

--- a/js/feedback.ts
+++ b/js/feedback.ts
@@ -2,11 +2,32 @@
 // deno-lint-ignore-file no-window
 import type { FeedbackSubmission } from "../types.ts";
 
+// Keep in sync with MAX_COMMENT_LENGTH in middleware/functions/feedback.ts
+// and the maxlength on the textarea in _components/Feedback.tsx
+const MAX_COMMENT_LENGTH = 2000;
+
 let lastFeedbackItemId: string | null = null;
 const feedbackYes = document.getElementById("feedback-yes");
 const feedbackNo = document.getElementById("feedback-no");
 const feedbackForm = document.getElementById("feedback-form");
 const feedbackSection = document.getElementById("feedback-section");
+const feedbackComment = document.getElementById(
+  "feedback-comment",
+) as HTMLTextAreaElement | null;
+const feedbackCommentCount = document.getElementById("feedback-comment-count");
+
+feedbackComment?.addEventListener("input", () => {
+  const length = feedbackComment.value.length;
+  if (feedbackCommentCount) {
+    feedbackCommentCount.textContent = `${length} / ${MAX_COMMENT_LENGTH}`;
+    // Highlight the counter once the comment reaches the limit
+    const atLimit = length >= MAX_COMMENT_LENGTH;
+    feedbackCommentCount.classList.toggle("text-red-600", atLimit);
+    feedbackCommentCount.classList.toggle("dark:text-red-400", atLimit);
+    feedbackCommentCount.classList.toggle("text-gray-600", !atLimit);
+    feedbackCommentCount.classList.toggle("dark:text-gray-400", !atLimit);
+  }
+});
 
 feedbackYes?.addEventListener("click", () => {
   sendFeedback({
@@ -20,18 +41,19 @@ feedbackNo?.addEventListener("click", () => {
   });
 });
 
-feedbackForm?.addEventListener("submit", (event) => {
+feedbackForm?.addEventListener("submit", async (event) => {
   event.preventDefault();
   const formData = new FormData(feedbackForm as HTMLFormElement);
   const form = Object.fromEntries(formData.entries());
-  sendFeedback({
+  const ok = await sendFeedback({
     sentiment: form["feedback-vote"] as "yes" | "no",
     comment: form["feedback-comment"] as string,
     contact: form["feedback-contact"] as string,
   });
   if (feedbackSection) {
-    feedbackSection.innerHTML =
-      "<p>Thank you for helping make the Deno docs awesome!</p>";
+    feedbackSection.innerHTML = ok
+      ? "<p>Thank you for helping make the Deno docs awesome!</p>"
+      : "<p>Sorry, something went wrong sending your feedback. Please try again later.</p>";
   }
 });
 
@@ -75,4 +97,6 @@ async function sendFeedback(feedback: Partial<FeedbackSubmission>) {
   if (!result.ok) {
     console.error("Failed to send feedback", responseBody);
   }
+
+  return result.ok;
 }


### PR DESCRIPTION
Adds a live character counter to the docs feedback form so people know about
the 2000 character limit before they submit, as requested in #2391.

The backend (`middleware/functions/feedback.ts`) rejects comments longer than
`MAX_COMMENT_LENGTH` (2000), but the form gave no indication of the limit. This
adds:

- A `maxlength` of 2000 on the comment textarea, so the limit can't be exceeded
  in the first place.
- A live `N / 2000` counter below the textarea that updates as you type and
  turns red once the limit is reached.

While here, it also fixes a related bug: the submit handler showed "Thank you
for helping make the Deno docs awesome!" immediately, without waiting for the
request, so a failed submission (for example an over-limit comment) still showed
the success message. The handler now awaits the result and shows an error
message if the submission fails.

The `2000` value is duplicated across the textarea, the browser script, and the
middleware (they live in separate server/browser files with no shared
constant), so each has a comment pointing at the others to keep them in sync.

Closes #2391