### PR TITLE
docs: clarify that custom spans nest under request traces

### DIFF
--- a/deploy/reference/observability.md
+++ b/deploy/reference/observability.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-09-29
+last_modified: 2026-06-18
 title: Observability
 description: "Comprehensive overview of monitoring features in Deno Deploy, including logs, traces, metrics, and filtering options."
 ---
@@ -45,6 +45,11 @@ Traces in Deno Deploy are captured in three ways:
 
 Traces are organized by application. The search bar lets you filter based on
 various attributes and span names.
+
+The Traces list shows top-level request traces. Custom spans you create through
+manual instrumentation appear as child spans nested within the request trace
+they run under, not as separate entries in the list. To find them, open the
+relevant request trace rather than looking for a standalone trace.
 
 Clicking a trace opens the trace overlay drawer, showing all spans within that
 trace in a waterfall view. This visualization displays the start time, end time,


### PR DESCRIPTION
On the [Observability](https://docs.deno.com/deploy/reference/observability/)
page, the Traces section explains the parent/child waterfall view but
never states that the Traces list itself only shows top-level request
traces. Users who add custom spans via manual instrumentation expect to
see them as standalone entries and get confused when they don't appear.

This adds a short clarification that custom spans show up as children
nested within the request trace they run under, and that you find them by
opening the relevant request trace. This matches the behavior a
maintainer confirmed in #2492.

Refs #2492. The remaining items in that issue (surfacing span events in
the dashboard, and traces for non-request contexts) are Deno Deploy
product behaviors rather than documentation changes.