### PR TITLE
docs: group debugging, profiling, and OpenTelemetry into a Diagnostics sidebar section

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -101,17 +101,6 @@ export const sidebar = [
         href: "/runtime/lint_and_format/",
       },
       {
-        title: "Debugging",
-        href: "/runtime/fundamentals/debugging/",
-        disclosure: true,
-        items: [
-          {
-            title: "CPU profiling",
-            href: "/runtime/fundamentals/cpu_profiling/",
-          },
-        ],
-      },
-      {
         title: "Migrating from Node",
         href: "/runtime/migrate/",
         disclosure: true,
@@ -204,6 +193,23 @@ export const sidebar = [
     ],
   },
   {
+    title: "Debugging & observability",
+    items: [
+      {
+        title: "Debugging",
+        href: "/runtime/fundamentals/debugging/",
+      },
+      {
+        title: "CPU profiling",
+        href: "/runtime/fundamentals/cpu_profiling/",
+      },
+      {
+        title: "OpenTelemetry",
+        href: "/runtime/fundamentals/open_telemetry/",
+      },
+    ],
+  },
+  {
     title: "Concepts",
     items: [
       {
@@ -250,10 +256,6 @@ export const sidebar = [
       {
         title: "Cron",
         href: "/runtime/fundamentals/cron/",
-      },
-      {
-        title: "OpenTelemetry",
-        href: "/runtime/fundamentals/open_telemetry/",
       },
       {
         title: "Loader hooks",

--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -193,23 +193,6 @@ export const sidebar = [
     ],
   },
   {
-    title: "Debugging & observability",
-    items: [
-      {
-        title: "Debugging",
-        href: "/runtime/fundamentals/debugging/",
-      },
-      {
-        title: "CPU profiling",
-        href: "/runtime/fundamentals/cpu_profiling/",
-      },
-      {
-        title: "OpenTelemetry",
-        href: "/runtime/fundamentals/open_telemetry/",
-      },
-    ],
-  },
-  {
     title: "Concepts",
     items: [
       {
@@ -239,6 +222,23 @@ export const sidebar = [
       {
         title: "Stability and releases",
         href: "/runtime/fundamentals/stability_and_releases/",
+      },
+    ],
+  },
+  {
+    title: "Debugging & observability",
+    items: [
+      {
+        title: "Debugging",
+        href: "/runtime/fundamentals/debugging/",
+      },
+      {
+        title: "CPU profiling",
+        href: "/runtime/fundamentals/cpu_profiling/",
+      },
+      {
+        title: "OpenTelemetry",
+        href: "/runtime/fundamentals/open_telemetry/",
       },
     ],
   },

--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -226,7 +226,7 @@ export const sidebar = [
     ],
   },
   {
-    title: "Debugging & observability",
+    title: "Diagnostics",
     items: [
       {
         title: "Debugging",


### PR DESCRIPTION
Observability and diagnostics topics in the Runtime sidebar were scattered:
Debugging sat under Guides, OpenTelemetry under the Advanced grab-bag, and CPU
profiling was buried as a sub-item of Debugging. They all serve the same user
intent of "my program is running, how do I observe and diagnose it?", so
splitting them across unrelated sections hurt discoverability.

This pulls them into a dedicated "Debugging & observability" section in
runtime/_data.ts containing Debugging, CPU profiling, and OpenTelemetry as
peers. Coverage stays under Testing since it is genuinely test tooling. Only
the sidebar grouping changes; page URLs are untouched.

Closes #3204