### PR TITLE
reference: fix the orphaned Temporal category nav link

### DIFF
--- a/reference_gen/web-categories.json
+++ b/reference_gen/web-categories.json
@@ -14,7 +14,6 @@
   "Platform": "A set of essential interfaces and functions to interact with the browser environment. Eg handling user interactions, getting browser and device information, scheduling and canceling periodic or one-time tasks.\n\n{@linkcode prompt}, {@linkcode console}",
   "Storage": "Store data locally within the browser. Manage session storage and local storage.\n\n{@linkcode sessionStorage}, {@linkcode localStorage}",
   "Streams": "Manage data streams, queuing strategies, and transformations. Handle data in chunks, process large datasets, and optimize memory usage.\n\nEg {@linkcode ReadableStream}, {@linkcode WritableStream}, {@linkcode TransformStream}",
-  "Temporal": "Date and time handling. Includes long-lived Workflows, calendar systems, time zones, and precise duration calculations.\n\nEg {@linkcode Temporal.Now}, {@linkcode Temporal.PlainDate}",
   "URL": "Manipulate URLs, extract data from URLs and manage query parameters.\n\nEg {@linkcode URL}",
   "Wasm": "Efficiently execute computationally intensive tasks. Wasm module compilation, instantiation, memory management, and interaction with imports and exports.\n\nEg {@linkcode WebAssembly.instantiate}, {@linkcode WebAssembly.Module}, {@linkcode WebAssembly.Instance}",
   "WebSockets": "Enable real-time communication between clients and servers using WebSockets. Tools to create interactive and dynamic applications.\n\nEg {@linkcode WebSocket}",


### PR DESCRIPTION
First polish follow-up after the reference flip (#3321).

The reference sidebar builds its web category list from
`web-categories.json`, but the actual category pages are generated from
the `@category` tags in the type definitions. Temporal carries no
`@category` tag - verified: zero occurrences of `@category Temporal` in
the generated `web.d.ts` - so no `/api/web/temporal/` page is built, yet
the sidebar still linked to it. The result was a 404 on every web
reference page's sidebar.

This removes the orphaned entry so the broken link is gone. The Temporal
symbols are not lost: they remain reachable under "Other APIs"
(uncategorized), in the all-symbols index, and via search.

Auditing confirmed Temporal is the only such orphan (Deno has none), so a
targeted fix is appropriate rather than a broader sidebar refactor.

Giving Temporal its own proper category would need `@category Temporal`
tags in the upstream Deno web type definitions (`web.d.ts` is generated
by the types pipeline, not authored in this repo), which is a separate,
larger change worth doing if Temporal's prominence warrants it.

Verified: reference build green (105 pages), no page links to
`/api/web/temporal` anymore, and `Temporal.PlainDate` and friends still
render on the uncategorized page.