### PR TITLE
Upgrade checkout action from v4 to v6

### DIFF
--- a/.github/workflows/freshness.yml
+++ b/.github/workflows/freshness.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Fixes job [warning](https://github.com/denoland/docs/actions/runs/27807551013/job/82290461538) about using deprecated Node 20