### PR TITLE
reference: fix the orphaned assert/strict node nav link

### DIFF
--- a/reference_gen/node-rewrite-map.json
+++ b/reference_gen/node-rewrite-map.json
@@ -1,6 +1,5 @@
 {
   "assert": "./types/node/node__assert.d.ts",
-  "assert/strict": "./types/node/node__assert--strict.d.ts",
   "async_hooks": "./types/node/node__async_hooks.d.ts",
   "buffer": "./types/node/node__buffer.d.ts",
   "child_process": "./types/node/node__child_process.d.ts",


### PR DESCRIPTION
The node counterpart of the Temporal fix (#3323), and the last known
broken link from the reference rearchitecture.

The node reference sidebar lists modules from `node-rewrite-map.json`.
`node:assert/strict` is in that list, but it only re-exports `node:assert`
in strict mode and declares no symbols of its own, so `deno doc` generates
no page for it (zero entries in the generated `node.json`). The sidebar
still linked to `/api/node/assert/strict/` - a 404 on every node
reference page.

Removing it from the rewrite map drops the broken link with no effect on
generated output, since it produced nothing. Users find the same symbols
under `node:assert`, which is unchanged.

Audited: `assert/strict` is the only orphan among the 55 node modules.

Verified: reference build green (105 pages), no page links to
`/api/node/assert/strict/` anymore, and the `assert` module page and its
sidebar entry are unchanged.