### PR TITLE
docs: fix typos across 9 files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ deno task prod
 Which will start a Deno server on [localhost:8000](http://localhost:8000) used
 in production, which handles redirects.
 
-the above commands will defauilt to performing as complete build of the site
+the above commands will default to performing as complete build of the site
 including all of the more expensive operations. You can also perform a lighter
 build by running:
 
@@ -41,7 +41,7 @@ deno task build:light
 
 This will build the site without generating the Open Graph images and other more
 time-consuming operations which might be desirable to skip during local
-developement work.
+development work.
 
 ## Developing styles and components
 
@@ -52,8 +52,8 @@ components and is generated during the build process.
 You can browse to it in the site at `/styleguide/`
 
 To avoid longer build times of the entire site and all of its content while
-developing UI elements and components, a styleguide-only build is avaiable which
-performs the initial global configureation for the site, but then only generates
+developing UI elements and components, a styleguide-only build is available which
+performs the initial global configuration for the site, but then only generates
 and watches for changes in the `/styleguide` folder of the repo.
 
 To work on just the components and UI elements and review them within

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ components and is generated during the build process.
 You can browse to it in the site at `/styleguide/`
 
 To avoid longer build times of the entire site and all of its content while
-developing UI elements and components, a styleguide-only build is available which
-performs the initial global configuration for the site, but then only generates
-and watches for changes in the `/styleguide` folder of the repo.
+developing UI elements and components, a styleguide-only build is available
+which performs the initial global configuration for the site, but then only
+generates and watches for changes in the `/styleguide` folder of the repo.
 
 To work on just the components and UI elements and review them within
 styleguide, run:

--- a/deploy/classic/api/runtime-broadcast-channel.md
+++ b/deploy/classic/api/runtime-broadcast-channel.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-19
+last_modified: 2026-06-20
 title: "BroadcastChannel"
 oldUrl:
   - /deploy/docs/runtime-broadcast-channel/

--- a/deploy/classic/api/runtime-broadcast-channel.md
+++ b/deploy/classic/api/runtime-broadcast-channel.md
@@ -65,7 +65,7 @@ instance of `BroadcastChannel`.
 One use case for a message bus like the one enabled by `BroadcastChannel` is
 updating an in-memory cache of data between isolates running in different data
 centers across the network. In the example below, we show how you can configure
-a simple server that uses `BroadcastChannel` to synchornize state across all
+a simple server that uses `BroadcastChannel` to synchronize state across all
 running instances of the server.
 
 ```ts

--- a/deploy/classic/api/runtime-request.md
+++ b/deploy/classic/api/runtime-request.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-19
+last_modified: 2026-06-20
 title: "HTTP Request"
 oldUrl:
   - /deploy/docs/runtime-request/
@@ -49,7 +49,7 @@ The return type is a `Request` instance.
 | [`body`][body]               | `Blob`, `BufferSource`, `FormData`, `URLSearchParams`, `USVString`, or `ReadableStream` | none           | The body of the request.                                   |
 | [`cache`][cache]             | `string`                                                                                | none           | The cache mode of the request.                             |
 | [`credentials`][credentials] | `string`                                                                                | `same-origin`  | The credentials mode of the request.                       |
-| [`integrity`][integrity]     | `string`                                                                                | none           | The cryptographic hash of the request's body.             |
+| [`integrity`][integrity]     | `string`                                                                                | none           | The cryptographic hash of the request's body.              |
 | [`mode`][mode]               | `string`                                                                                | `cors`         | The request mode you want to use.                          |
 | [`redirect`][redirect]       | `string`                                                                                | `follow`       | The mode of how redirects are handled.                     |
 | [`referrer`][referrer]       | `string`                                                                                | `about:client` | A `USVString` specifying `no-referrer`, `client` or a URL. |
@@ -65,7 +65,7 @@ The return type is a `Request` instance.
 | [`bodyUsed`][bodyused]             | `boolean`                                  | Indicates whether the body content is read.                                                                                  |
 | [`url`][url]                       | `USVString`                                | The URL of the request.                                                                                                      |
 | [`headers`][headers]               | [`Headers`](runtime-headers)               | The headers associated with the request.                                                                                     |
-| [`integrity`][integrity]           | `string`                                   | The cryptographic hash of the request's body.                                                                               |
+| [`integrity`][integrity]           | `string`                                   | The cryptographic hash of the request's body.                                                                                |
 | [`method`][method]                 | `string`                                   | The request's method (`POST`, `GET`, etc).                                                                                   |
 | [`mode`][mode]                     | `string`                                   | Indicates the mode of the request (e.g. `cors` ).                                                                            |
 | [`redirect`][redirect]             | `string`                                   | The mode of how redirects are handled.                                                                                       |

--- a/deploy/classic/api/runtime-request.md
+++ b/deploy/classic/api/runtime-request.md
@@ -49,7 +49,7 @@ The return type is a `Request` instance.
 | [`body`][body]               | `Blob`, `BufferSource`, `FormData`, `URLSearchParams`, `USVString`, or `ReadableStream` | none           | The body of the request.                                   |
 | [`cache`][cache]             | `string`                                                                                | none           | The cache mode of the request.                             |
 | [`credentials`][credentials] | `string`                                                                                | `same-origin`  | The credentials mode of the request.                       |
-| [`integrity`][integrity]     | `string`                                                                                | none           | The crypotographic hash of the request's body.             |
+| [`integrity`][integrity]     | `string`                                                                                | none           | The cryptographic hash of the request's body.             |
 | [`mode`][mode]               | `string`                                                                                | `cors`         | The request mode you want to use.                          |
 | [`redirect`][redirect]       | `string`                                                                                | `follow`       | The mode of how redirects are handled.                     |
 | [`referrer`][referrer]       | `string`                                                                                | `about:client` | A `USVString` specifying `no-referrer`, `client` or a URL. |
@@ -65,7 +65,7 @@ The return type is a `Request` instance.
 | [`bodyUsed`][bodyused]             | `boolean`                                  | Indicates whether the body content is read.                                                                                  |
 | [`url`][url]                       | `USVString`                                | The URL of the request.                                                                                                      |
 | [`headers`][headers]               | [`Headers`](runtime-headers)               | The headers associated with the request.                                                                                     |
-| [`integrity`][integrity]           | `string`                                   | The crypotographic hash of the request's body.                                                                               |
+| [`integrity`][integrity]           | `string`                                   | The cryptographic hash of the request's body.                                                                               |
 | [`method`][method]                 | `string`                                   | The request's method (`POST`, `GET`, etc).                                                                                   |
 | [`mode`][mode]                     | `string`                                   | Indicates the mode of the request (e.g. `cors` ).                                                                            |
 | [`redirect`][redirect]             | `string`                                   | The mode of how redirects are handled.                                                                                       |

--- a/deploy/classic/deployctl.md
+++ b/deploy/classic/deployctl.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-19
+last_modified: 2026-06-20
 title: "Using deployctl on the command line"
 ---
 

--- a/deploy/classic/deployctl.md
+++ b/deploy/classic/deployctl.md
@@ -128,7 +128,7 @@ the deployment being created and are not added to the list of
 ### Production Deployments
 
 Each deployment you create have a unique URL. In addition, a project has a
-"production URL" and custom domains routing trafffic to its "production"
+"production URL" and custom domains routing traffic to its "production"
 deployment. Deployments can be promoted to production at any time, or created
 directly as production using the `--prod` flag:
 

--- a/examples/tutorials/drizzle.md
+++ b/examples/tutorials/drizzle.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-03-10
+last_modified: 2026-06-20
 title: "Build a Database App with Drizzle ORM and Deno"
 description: "Step-by-step guide to building database applications with Drizzle ORM and Deno. Learn about schema management, type-safe queries, PostgreSQL integration, migrations, and how to implement CRUD operations."
 url: /examples/drizzle_tutorial/

--- a/examples/tutorials/drizzle.md
+++ b/examples/tutorials/drizzle.md
@@ -115,7 +115,7 @@ Let's say our current database already has the following table schemas:
 
 ![Diagram of table schema in postgres](./images/how-to/drizzle/table-diagram.png)
 
-We'll run the following command to instrospect the database and populate several
+We'll run the following command to introspect the database and populate several
 files under a `./drizzle` directory:
 
 <figure>

--- a/examples/tutorials/snapshots.md
+++ b/examples/tutorials/snapshots.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-02-24
+last_modified: 2026-06-20
 title: "Deno Sandbox Snapshots Tutorial"
 description: "Use read only images to create isolated and reproducible environments."
 url: "/examples/snapshots_tutorial/"

--- a/examples/tutorials/snapshots.md
+++ b/examples/tutorials/snapshots.md
@@ -16,7 +16,7 @@ inherit the same environment without running installers again.
 
 We will:
 
-1. Start a shapshot
+1. Start a snapshot
 2. Install Node.js and some global tooling exactly once.
 3. Snapshot the prepared volume into `my-toolchain-snapshot`.
 4. Boot new sandboxes from that snapshot and verify the tools are ready the

--- a/examples/tutorials/sveltekit.md
+++ b/examples/tutorials/sveltekit.md
@@ -179,7 +179,7 @@ With this setup we have our "database"! Next to access it on a page.
 ### Loading data to be rendered
 
 We now need to create a `+page.server.ts` file which will be at the root of our
-routes directory. There should already be a `+page.svlete` there.
+routes directory. There should already be a `+page.svelte` there.
 
 ```
 src/routes/+page.server.ts

--- a/examples/tutorials/sveltekit.md
+++ b/examples/tutorials/sveltekit.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-02-10
+last_modified: 2026-06-20
 title: "Building a SvelteKit app with sv and Deno"
 url: /examples/sveltekit_tutorial/
 ---

--- a/examples/tutorials/web_testing.md
+++ b/examples/tutorials/web_testing.md
@@ -16,7 +16,7 @@ using Deno.
 
 ## Testing UI components and DOM manipulation
 
-Let's say you have a website that shows a uers's profile, you can set up a test
+Let's say you have a website that shows a user's profile, you can set up a test
 function to verify that the DOM element creation works correctly. This code sets
 up a basic card element then tests whether the created DOM structure matches
 what was expected.

--- a/examples/tutorials/web_testing.md
+++ b/examples/tutorials/web_testing.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-04-03
+last_modified: 2026-06-20
 title: "Testing web apps"
 description: "A comprehensive guide to testing web applications with Deno"
 url: "/examples/web_testing_tutorial/"

--- a/lint/rules/no-this-alias.md
+++ b/lint/rules/no-this-alias.md
@@ -14,7 +14,7 @@ Let's take a look at a concrete example:
 const obj = {
   count: 0,
   doSomethingLater() {
-    setTimeout(function () { // this function executes on the global scope; `this` evalutes to `globalThis`
+    setTimeout(function () { // this function executes on the global scope; `this` evaluates to `globalThis`
       this.count++;
       console.log(this.count);
     }, 300);


### PR DESCRIPTION
Closes #3328

## Summary

- `trafffic` -> `traffic`
- `crypotographic` -> `cryptographic`
- `synchornize` -> `synchronize`
- `evalutes` -> `evaluates`
- `uers's` -> `user's`
- `+page.svlete` -> `+page.svelte`
- `shapshot` -> `snapshot`
- `instrospect` -> `introspect`
- `defauilt`, `developement`, `avaiable`, `configureation` in README.md

Found via `npx cspell`. Did not touch intentional misspellings in lint rule examples.