### PR TITLE
docs: move JSX and React to Guides

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -62,6 +62,10 @@ export const sidebar = [
         href: "/runtime/fundamentals/web_dev/",
       },
       {
+        title: "JSX and React",
+        href: "/runtime/reference/jsx/",
+      },
+      {
         title: "HTTP Server",
         href: "/runtime/fundamentals/http_server/",
       },
@@ -276,10 +280,6 @@ export const sidebar = [
       {
         title: "Continuous integration",
         href: "/runtime/reference/continuous_integration/",
-      },
-      {
-        title: "JSX and React",
-        href: "/runtime/reference/jsx/",
       },
       {
         title: "Deno & VS Code",


### PR DESCRIPTION
Move the "JSX and React" entry in the runtime sidebar out of the
Advanced section and into Guides, placing it next to Web development.
JSX/React is a common, mainstream use case rather than an advanced
topic, so Guides is a more discoverable home for it.