### PR TITLE
Adding `deno.desktop` as a documented library

### DIFF
--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -167,6 +167,7 @@ The built-in libraries that are of interest to users:
 - `"dom.asynciterable"` - TypeScript currently does not include the DOM async
   iterables that Deno implements (plus several browsers), so we have implemented
   it ourselves until it becomes available in TypeScript.
+- `"deno.desktop"` - This is the library used when checking apps created with `deno desktop`. Check out [Desktop apps](/runtime/desktop/).
 
 These are common libraries that are not enabled by default, but are useful when
 writing code that is intended to also work in another runtime:

--- a/runtime/reference/ts_config_migration.md
+++ b/runtime/reference/ts_config_migration.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-19
+last_modified: 2026-06-25
 title: "Configuring TypeScript"
 description: "A guide to TypeScript configuration in Deno. Learn about compiler options, type checking JavaScript, JSDoc support, type declarations, and configuring TypeScript for cross-platform compatibility."
 oldUrl:
@@ -167,7 +167,8 @@ The built-in libraries that are of interest to users:
 - `"dom.asynciterable"` - TypeScript currently does not include the DOM async
   iterables that Deno implements (plus several browsers), so we have implemented
   it ourselves until it becomes available in TypeScript.
-- `"deno.desktop"` - This is the library used when checking apps created with `deno desktop`. Check out [Desktop apps](/runtime/desktop/).
+- `"deno.desktop"` - This is the library used when checking apps created with
+  `deno desktop`. Check out [Desktop apps](/runtime/desktop/).
 
 These are common libraries that are not enabled by default, but are useful when
 writing code that is intended to also work in another runtime:


### PR DESCRIPTION
This PR is just to bring attention to the community. So `deno desktop` autocompletions such as `new Deno.BrowserWindow` get properly typechecked and are supported on LSP.

Probably missing a section for using it as:

```js
/// <reference lib="deno.desktop" />
```

Which I think could be very nice on the initial single file examples.