### PR TITLE
docs: add deno watch reference page

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -467,6 +467,10 @@ export const sidebar = [
             href: "/runtime/reference/cli/unstable_flags/",
           },
           {
+            title: "deno watch",
+            href: "/runtime/reference/cli/watch/",
+          },
+          {
             title: "deno why",
             href: "/runtime/reference/cli/why/",
           },

--- a/runtime/reference/cli/_commands_reference.json
+++ b/runtime/reference/cli/_commands_reference.json
@@ -8435,6 +8435,13 @@
       "usage": "\u001b[37mUsage:\u001b[0m \u001b[32mdeno vendor\u001b[0m \u001b[32m[OPTIONS]\u001b[0m"
     },
     {
+      "name": "watch",
+      "about": "Run a program in watch mode with hot module replacement. Shorthand for deno run --watch-hmr.\n  deno watch main.ts",
+      "args": {},
+      "subcommands": [],
+      "usage": "Usage: deno watch [OPTIONS] <SCRIPT_ARG>..."
+    },
+    {
       "name": "why",
       "about": "Show why a package is installed, displaying the dependency chain from your project's direct dependencies to the specified package.\n  \u001b[38;5;245mdeno why express\u001b[39m\n\nShow why a specific version is installed\n  \u001b[38;5;245mdeno why express@4.18.2\u001b[39m",
       "args": [

--- a/runtime/reference/cli/watch.md
+++ b/runtime/reference/cli/watch.md
@@ -1,0 +1,38 @@
+---
+last_modified: 2026-06-25
+title: "deno watch"
+command: watch
+openGraphLayout: "/open_graph/cli-commands.jsx"
+openGraphTitle: "deno watch"
+description: "Run a program in watch mode with hot module replacement"
+---
+
+The `deno watch` command runs a program and reloads it when its source files
+change. It is a shorthand for
+[`deno run --watch-hmr`](/runtime/reference/cli/run/): the program runs with hot
+module replacement enabled, so on a change Deno swaps the updated modules in
+place where it can instead of doing a full restart.
+
+## Usage
+
+```sh
+deno watch main.ts
+```
+
+This is equivalent to:
+
+```sh
+deno run --watch-hmr main.ts
+```
+
+Because `deno watch` reuses `deno run`, every `deno run` flag works, including
+the watch options:
+
+- `--watch-hmr=<paths>` adds extra paths to watch.
+- `--watch-exclude=<paths>` excludes paths from triggering a reload.
+- `--no-clear-screen` keeps previous output instead of clearing the screen on
+  each reload.
+
+```sh
+deno watch --watch-exclude=dist/ -RN main.ts
+```

--- a/runtime/run/watch_mode.md
+++ b/runtime/run/watch_mode.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-15
+last_modified: 2026-06-25
 title: "Watch mode and HMR"
 description: "Deno's built-in file watcher: re-run code on change with --watch, control what gets watched, and hot-replace modules with --watch-hmr."
 ---
@@ -56,6 +56,14 @@ back to a full restart.
 
 ```shell
 deno run --watch-hmr main.ts
+```
+
+Because this is such a common development workflow,
+[`deno watch`](/runtime/reference/cli/watch/) is a shorthand for
+`deno run --watch-hmr`:
+
+```shell
+deno watch main.ts
 ```
 
 ### Editors with atomic save


### PR DESCRIPTION
Deno 2.9 adds a `deno watch` subcommand (denoland/deno#35301), a shorthand for
`deno run --watch-hmr` that makes the watch-with-hot-module-replacement workflow
short to type and discoverable from `deno --help`. This adds its reference page
and wires it into the CLI sidebar and command reference.