### PR TITLE
docs: add deno list reference page

### DIFF
--- a/runtime/_data.ts
+++ b/runtime/_data.ts
@@ -395,6 +395,10 @@ export const sidebar = [
             href: "/runtime/reference/cli/lint/",
           },
           {
+            title: "deno list",
+            href: "/runtime/reference/cli/list/",
+          },
+          {
             title: "deno outdated",
             href: "/runtime/reference/cli/outdated/",
           },

--- a/runtime/reference/cli/_commands_reference.json
+++ b/runtime/reference/cli/_commands_reference.json
@@ -6224,6 +6224,13 @@
       "usage": "\u001b[37mUsage:\u001b[0m \u001b[32mdeno lint\u001b[0m \u001b[32m[OPTIONS]\u001b[0m \u001b[32m[files]...\u001b[0m"
     },
     {
+      "name": "list",
+      "about": "List the dependencies declared in deno.json and package.json.\n  deno list\n\nShow the dependency tree two levels deep\n  deno list --depth 2",
+      "args": {},
+      "subcommands": [],
+      "usage": "Usage: deno list [OPTIONS] [filters]..."
+    },
+    {
       "name": "publish",
       "about": "Publish the current working directory's package or workspace to JSR",
       "args": [

--- a/runtime/reference/cli/list.md
+++ b/runtime/reference/cli/list.md
@@ -1,0 +1,60 @@
+---
+last_modified: 2026-06-25
+title: "deno list"
+command: list
+openGraphLayout: "/open_graph/cli-commands.jsx"
+openGraphTitle: "deno list"
+description: "List the dependencies declared in your project"
+---
+
+The `deno list` command prints the packages your project declares as
+dependencies. It reads them from the `imports` in your
+[`deno.json`](/runtime/fundamentals/configuration/) and from the `dependencies`
+and `devDependencies` in your `package.json`, resolves each to the version
+currently in use, and prints them grouped by package, similar to `npm ls` or
+`pnpm list`.
+
+It answers a different question than
+[`deno info`](/runtime/reference/cli/info/): `deno info` walks the module graph
+from an entrypoint and reports every file it reaches, while `deno list` reports
+what the project depends on straight from the manifest, without an entrypoint.
+
+## Usage
+
+```sh
+deno list [OPTIONS] [filters...]
+```
+
+By default `deno list` prints a flat table of your direct dependencies. Optional
+positional `filters` narrow the output by package name and support wildcards and
+`!` negation, the same matcher
+[`deno outdated`](/runtime/reference/cli/outdated/) uses.
+
+## Options
+
+| Option        | Description                                                                                                |
+| ------------- | ---------------------------------------------------------------------------------------------------------- |
+| `--depth <N>` | Render the resolved dependency tree N levels deep, for both npm and JSR packages (read from the lockfile). |
+| `--prod`      | Show only production dependencies.                                                                         |
+| `--dev`       | Show only development dependencies.                                                                        |
+| `--recursive` | Include the dependencies of every workspace member.                                                        |
+
+## Examples
+
+List direct dependencies:
+
+```sh
+deno list
+```
+
+Show the dependency tree two levels deep:
+
+```sh
+deno list --depth 2
+```
+
+List only production dependencies whose name starts with `@std/`:
+
+```sh
+deno list --prod "@std/*"
+```


### PR DESCRIPTION
Deno 2.9 adds a `deno list` subcommand (denoland/deno#34972), the equivalent of
`npm ls` / `pnpm list` for inspecting a project's declared dependencies straight
from the manifest, grouped by package and version. This adds its reference page
and wires it into the CLI sidebar and command reference.