### PR TITLE
docs: document deno fmt .editorconfig inference

### DIFF
--- a/runtime/lint_and_format/index.md
+++ b/runtime/lint_and_format/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-17
+last_modified: 2026-06-25
 title: "Linting and formatting"
 description: "A guide to Deno's built-in code quality tools. Learn how to use deno lint and deno fmt commands, configure rules, integrate with CI/CD pipelines, and maintain consistent code style across your projects."
 oldUrl:
@@ -164,6 +164,14 @@ The formatter is configured with the `fmt` field in your
 [`deno.json`](/runtime/reference/deno_json/#formatting) file. See
 [all formatting options](/runtime/reference/deno_json/#formatting) for the full
 list of settings and their defaults.
+
+`deno fmt` also reads [`.editorconfig`](https://editorconfig.org/) files and
+uses them to fill in any option you have not set through a CLI flag or the
+`deno.json` `fmt` block. The precedence is CLI flags, then `deno.json`, then
+`.editorconfig`, then the built-in defaults, so an `.editorconfig` value only
+applies when nothing higher up has set it. See
+[Inheriting settings from .editorconfig](/runtime/reference/cli/fmt/#inheriting-settings-from-.editorconfig)
+for the property mappings.
 
 ## Using other linters and formatters
 

--- a/runtime/reference/cli/fmt.md
+++ b/runtime/reference/cli/fmt.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-24
+last_modified: 2026-06-25
 title: "deno fmt"
 oldUrl:
   - /runtime/tools/formatter/
@@ -81,6 +81,21 @@ Customize formatting options in your `deno.json`:
 
 See the [Configuration](/runtime/reference/deno_json/#formatting) page for all
 available options.
+
+## Inheriting settings from .editorconfig
+
+`deno fmt` also reads [`.editorconfig`](https://editorconfig.org/) files and
+uses them to fill in any formatting option you have not set elsewhere. The
+precedence, from highest to lowest, is:
+
+1. CLI flags (`--indent-width`, `--use-tabs`, and so on)
+2. The `fmt` block in `deno.json`
+3. `.editorconfig`
+4. Built-in defaults
+
+So `.editorconfig` only supplies values you have not already configured through
+a flag or `deno.json`. Properties such as `indent_style`, `indent_size`, and
+`max_line_length` map onto the corresponding `deno fmt` options.
 
 ## Including and excluding files
 


### PR DESCRIPTION
Deno 2.9 makes `deno fmt` read `.editorconfig` files and use them to fill in any
formatting option not already set by a CLI flag or the `deno.json` `fmt` block
(denoland/deno#34071). This documents the behavior and the precedence order on
the `deno fmt` reference page.