### PR TITLE
docs(cf-workers): document type-checking setup for the Wrangler tutorial

### DIFF
--- a/examples/tutorials/cloudflare_workers_wrangler.md
+++ b/examples/tutorials/cloudflare_workers_wrangler.md
@@ -63,6 +63,46 @@ definition file, `worker-configuration.d.ts`.
 deno task cf-typegen
 ```
 
+## Configure type checking
+
+The generated `worker-configuration.d.ts` provides the `Env` interface and the
+Cloudflare Workers runtime types (`ExportedHandler`, `Request`, `Response`, and
+the rest of the [workerd](https://github.com/cloudflare/workerd) global scope).
+Because Deno ships its own Web API globals by default, you need to tell Deno to
+use the Workers runtime types as the single source of truth. Otherwise type
+checking either can't find `Env`/`ExportedHandler`, or reports many conflicting
+global declarations.
+
+Add a `compilerOptions` block to your `deno.json`:
+
+```json
+{
+  "compilerOptions": {
+    "lib": ["esnext"],
+    "types": ["./worker-configuration.d.ts"],
+    "skipLibCheck": true
+  },
+  "tasks": {
+    "deploy": "deno --allow-env --allow-run npm:wrangler deploy",
+    "dev": "deno npm:wrangler dev",
+    "start": "deno npm:wrangler dev",
+    "cf-typegen": "deno npm:wrangler types"
+  }
+}
+```
+
+- `"lib": ["esnext"]` removes Deno's default Web/DOM globals so the workerd
+  types from `worker-configuration.d.ts` are used instead of clashing with them.
+  If your project also uses Deno runtime APIs (`Deno.*`), use
+  `["esnext", "deno.ns"]`.
+- `"types": ["./worker-configuration.d.ts"]` loads the generated Workers types
+  project-wide, so `Env` and `ExportedHandler` resolve in your worker.
+- `"skipLibCheck": true` skips type checking inside declaration files, which the
+  generated file relies on.
+
+With this in place, `deno check` and your editor type-check the worker against
+the Cloudflare Workers runtime types.
+
 ## Create your function
 
 Now, create your worker script in `src/mod.ts`. It needs to export an object

--- a/examples/tutorials/cloudflare_workers_wrangler.md
+++ b/examples/tutorials/cloudflare_workers_wrangler.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-04-18
+last_modified: 2026-07-01
 title: "Deploying Deno to Cloudflare Workers with Wrangler"
 description: "Learn how to build and deploy a Deno application to Cloudflare Workers using Wrangler"
 url: /examples/cloudflare_workers_wrangler_tutorial/


### PR DESCRIPTION
The Wrangler tutorial generates `worker-configuration.d.ts` via `cf-typegen` and the example worker uses `satisfies ExportedHandler<Env>`, but the tutorial never configures `deno.json` to consume those generated types. Following it as written, `deno check` (and the editor) fails: with nothing wiring the file in, `Env` and `ExportedHandler` are not found; and once the file is wired in, Deno reports many conflicting global declarations, because Deno ships its own Web API globals (`Request`, `Response`, `EventTarget`, and the rest) alongside the workerd types declared in the generated file.

This adds a short Configure type checking section after the `cf-typegen` step that sets a `compilerOptions` block in `deno.json`:

- `lib: ["esnext"]` drops Deno\x27s default Web/DOM globals so the workerd types from `worker-configuration.d.ts` are the single source of truth (this mirrors the `tsconfig` Cloudflare generates for Workers). For projects that also use `Deno.*`, `["esnext", "deno.ns"]` works too.
- `types: ["./worker-configuration.d.ts"]` loads the generated Workers types project-wide so `Env` and `ExportedHandler` resolve.
- `skipLibCheck: true` skips checking inside the generated declaration file.

Verified on Deno 2.9.0 + Wrangler 4.105.0: with the block, `deno check` goes from erroring to clean while real type checking stays active (e.g. a wrong handler signature is still flagged, and `req` is correctly typed as the workerd `Request`). Relates to denoland/deno#31487.