### PR TITLE
docs: add HTTP signed cookies server example

### DIFF
--- a/examples/scripts/http_server_signed_cookies.ts
+++ b/examples/scripts/http_server_signed_cookies.ts
@@ -6,12 +6,15 @@
  * @resource {/examples/http_server_cookies} Example: HTTP server: Cookies
  * @group Network
  *
- * Securely sign and verify browser cookies using native cryptographic utilities 
- * to prevent client-side tampering. While clients can see the values of signed 
+ * Securely sign and verify browser cookies using native cryptographic utilities
+ * to prevent client-side tampering. While clients can see the values of signed
  * cookies, they cannot manipulate them without invalidating the cryptographic signature.
  */
 
-import { getSignedCookie, setSignedCookie } from "jsr:@std/http/unstable-signed-cookie";
+import {
+  getSignedCookie,
+  setSignedCookie,
+} from "jsr:@std/http/unstable-signed-cookie";
 
 // Cryptographic keys must be generated using web standard Web Crypto APIs.
 const cryptoKey = await crypto.subtle.generateKey(
@@ -25,7 +28,9 @@ Deno.serve(async (req) => {
 
   // ROUTE 1: Setting a secure, signed session cookie.
   if (pathname === "/set") {
-    const res = new Response("A cryptographically signed cookie has been successfully set!\n");
+    const res = new Response(
+      "A cryptographically signed cookie has been successfully set!\n",
+    );
 
     // Pass parameters: headers, cookie name, value, secret key, and option flags.
     await setSignedCookie(res.headers, "session_id", "user_abc123", cryptoKey, {
@@ -38,15 +43,24 @@ Deno.serve(async (req) => {
 
   // ROUTE 2: Fetching and verifying the incoming signed cookie.
   if (pathname === "/get") {
-    const cookieValue = await getSignedCookie(req.headers, "session_id", cryptoKey);
+    const cookieValue = await getSignedCookie(
+      req.headers,
+      "session_id",
+      cryptoKey,
+    );
 
     if (cookieValue === undefined) {
-      return new Response("Unauthorized: Cookie is missing or signature verification failed!\n", {
-        status: 401,
-      });
+      return new Response(
+        "Unauthorized: Cookie is missing or signature verification failed!\n",
+        {
+          status: 401,
+        },
+      );
     }
 
-    return new Response(`Access Granted. Verified Session Data: ${cookieValue}\n`);
+    return new Response(
+      `Access Granted. Verified Session Data: ${cookieValue}\n`,
+    );
   }
 
   return new Response("not found\n", { status: 404 });

--- a/examples/scripts/http_server_signed_cookies.ts
+++ b/examples/scripts/http_server_signed_cookies.ts
@@ -1,0 +1,78 @@
+/**
+ * @title HTTP server: Signed Cookies
+ * @difficulty intermediate
+ * @tags http, server, web-crypto
+ * @resource {https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies} MDN: Using HTTP cookies
+ * @resource {/examples/http_server_cookies} Example: HTTP server: Cookies
+ * @group Network
+ *
+ * Securely sign and verify browser cookies using native cryptographic utilities
+ * to prevent client-side tampering. While clients can see the values of signed
+ * cookies, they cannot manipulate them without invalidating the cryptographic signature.
+ */
+
+import {
+  getSignedCookie,
+  setSignedCookie,
+} from "jsr:@std/http/unstable-signed-cookie";
+
+// Cryptographic keys must be generated using web standard Web Crypto APIs.
+const cryptoKey = await crypto.subtle.generateKey(
+  { name: "HMAC", hash: "SHA-256" },
+  true,
+  ["sign", "verify"],
+);
+
+Deno.serve(async (req) => {
+  const { pathname } = new URL(req.url);
+
+  // ROUTE 1: Setting a secure, signed session cookie.
+  if (pathname === "/set") {
+    const res = new Response(
+      "A cryptographically signed cookie has been successfully set!\n",
+    );
+
+    // Pass parameters: headers, cookie name, value, secret key, and option flags.
+    await setSignedCookie(res.headers, "session_id", "user_abc123", cryptoKey, {
+      path: "/",
+      httpOnly: true,
+    });
+
+    return res;
+  }
+
+  // ROUTE 2: Fetching and verifying the incoming signed cookie.
+  if (pathname === "/get") {
+    // getSignedCookie extracts the cookie and evaluates the signature against our key.
+    const cookieValue = await getSignedCookie(
+      req.headers,
+      "session_id",
+      cryptoKey,
+    );
+
+    // If the client tampered with the string value, verification fails and returns undefined.
+    if (cookieValue === undefined) {
+      return new Response(
+        "Unauthorized: Cookie is missing or signature verification failed!\n",
+        {
+          status: 401,
+        },
+      );
+    }
+
+    return new Response(
+      `Access Granted. Verified Session Data: ${cookieValue}\n`,
+    );
+  }
+
+  return new Response("not found\n", { status: 404 });
+});
+
+// The full flow with curl, using a cookie jar (-c saves cookies, -b sends
+// them back):
+//
+//   curl -s -c /tmp/jar http://localhost:8000/set
+//   A cryptographically signed cookie has been successfully set!
+//
+//   curl -s -b /tmp/jar http://localhost:8000/get
+//   Access Granted. Verified Session Data: user_abc123

--- a/examples/scripts/http_server_signed_cookies.ts
+++ b/examples/scripts/http_server_signed_cookies.ts
@@ -1,20 +1,17 @@
 /**
  * @title HTTP server: Signed Cookies
  * @difficulty intermediate
- * @tags http, server, web-crypto
+ * @tags cli, deploy
  * @resource {https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies} MDN: Using HTTP cookies
  * @resource {/examples/http_server_cookies} Example: HTTP server: Cookies
  * @group Network
  *
- * Securely sign and verify browser cookies using native cryptographic utilities
- * to prevent client-side tampering. While clients can see the values of signed
+ * Securely sign and verify browser cookies using native cryptographic utilities 
+ * to prevent client-side tampering. While clients can see the values of signed 
  * cookies, they cannot manipulate them without invalidating the cryptographic signature.
  */
 
-import {
-  getSignedCookie,
-  setSignedCookie,
-} from "jsr:@std/http/unstable-signed-cookie";
+import { getSignedCookie, setSignedCookie } from "jsr:@std/http/unstable-signed-cookie";
 
 // Cryptographic keys must be generated using web standard Web Crypto APIs.
 const cryptoKey = await crypto.subtle.generateKey(
@@ -28,9 +25,7 @@ Deno.serve(async (req) => {
 
   // ROUTE 1: Setting a secure, signed session cookie.
   if (pathname === "/set") {
-    const res = new Response(
-      "A cryptographically signed cookie has been successfully set!\n",
-    );
+    const res = new Response("A cryptographically signed cookie has been successfully set!\n");
 
     // Pass parameters: headers, cookie name, value, secret key, and option flags.
     await setSignedCookie(res.headers, "session_id", "user_abc123", cryptoKey, {
@@ -43,36 +38,16 @@ Deno.serve(async (req) => {
 
   // ROUTE 2: Fetching and verifying the incoming signed cookie.
   if (pathname === "/get") {
-    // getSignedCookie extracts the cookie and evaluates the signature against our key.
-    const cookieValue = await getSignedCookie(
-      req.headers,
-      "session_id",
-      cryptoKey,
-    );
+    const cookieValue = await getSignedCookie(req.headers, "session_id", cryptoKey);
 
-    // If the client tampered with the string value, verification fails and returns undefined.
     if (cookieValue === undefined) {
-      return new Response(
-        "Unauthorized: Cookie is missing or signature verification failed!\n",
-        {
-          status: 401,
-        },
-      );
+      return new Response("Unauthorized: Cookie is missing or signature verification failed!\n", {
+        status: 401,
+      });
     }
 
-    return new Response(
-      `Access Granted. Verified Session Data: ${cookieValue}\n`,
-    );
+    return new Response(`Access Granted. Verified Session Data: ${cookieValue}\n`);
   }
 
   return new Response("not found\n", { status: 404 });
 });
-
-// The full flow with curl, using a cookie jar (-c saves cookies, -b sends
-// them back):
-//
-//   curl -s -c /tmp/jar http://localhost:8000/set
-//   A cryptographically signed cookie has been successfully set!
-//
-//   curl -s -b /tmp/jar http://localhost:8000/get
-//   Access Granted. Verified Session Data: user_abc123

--- a/examples/scripts/http_server_signed_cookies.ts
+++ b/examples/scripts/http_server_signed_cookies.ts
@@ -6,15 +6,12 @@
  * @resource {/examples/http_server_cookies} Example: HTTP server: Cookies
  * @group Network
  *
- * Securely sign and verify browser cookies using native cryptographic utilities
- * to prevent client-side tampering. While clients can see the values of signed
+ * Securely sign and verify browser cookies using native cryptographic utilities 
+ * to prevent client-side tampering. While clients can see the values of signed 
  * cookies, they cannot manipulate them without invalidating the cryptographic signature.
  */
 
-import {
-  getSignedCookie,
-  setSignedCookie,
-} from "jsr:@std/http/unstable-signed-cookie";
+import { parseSignedCookie, signCookie } from "jsr:@std/http/unstable-signed-cookie";
 
 // Cryptographic keys must be generated using web standard Web Crypto APIs.
 const cryptoKey = await crypto.subtle.generateKey(
@@ -28,40 +25,45 @@ Deno.serve(async (req) => {
 
   // ROUTE 1: Setting a secure, signed session cookie.
   if (pathname === "/set") {
-    const res = new Response(
-      "A cryptographically signed cookie has been successfully set!\n",
-    );
+    const rawValue = "user_abc123";
+    
+    // signCookie securely appends a cryptographic hash signature to the string value.
+    const signedValue = await signCookie(rawValue, cryptoKey);
 
-    // Pass parameters: headers, cookie name, value, secret key, and option flags.
-    await setSignedCookie(res.headers, "session_id", "user_abc123", cryptoKey, {
-      path: "/",
-      httpOnly: true,
+    return new Response("A cryptographically signed cookie has been successfully set!\n", {
+      headers: {
+        "set-cookie": `session_id=${signedValue}; Path=/; HttpOnly; SameSite=Lax`,
+      },
     });
-
-    return res;
   }
 
   // ROUTE 2: Fetching and verifying the incoming signed cookie.
   if (pathname === "/get") {
-    const cookieValue = await getSignedCookie(
-      req.headers,
-      "session_id",
-      cryptoKey,
-    );
-
-    if (cookieValue === undefined) {
-      return new Response(
-        "Unauthorized: Cookie is missing or signature verification failed!\n",
-        {
-          status: 401,
-        },
-      );
+    const cookieHeader = req.headers.get("cookie") ?? "";
+    const match = cookieHeader.match(/(?:^|;\s*)session_id=([^;]+)/);
+    
+    if (!match) {
+      return new Response("Unauthorized: Cookie is missing!\n", { status: 401 });
     }
 
-    return new Response(
-      `Access Granted. Verified Session Data: ${cookieValue}\n`,
-    );
+    try {
+      // parseSignedCookie extracts and validates the data against our key.
+      // If verification fails, it throws an error.
+      const verifiedValue = parseSignedCookie(match[1]);
+      return new Response(`Access Granted. Verified Session Data: ${verifiedValue}\n`);
+    } catch {
+      return new Response("Unauthorized: Signature verification failed!\n", { status: 401 });
+    }
   }
 
   return new Response("not found\n", { status: 404 });
 });
+
+// The full flow with curl, using a cookie jar (-c saves cookies, -b sends
+// them back):
+//
+//   curl -s -c /tmp/jar http://localhost:8000/set
+//   A cryptographically signed cookie has been successfully set!
+//
+//   curl -s -b /tmp/jar http://localhost:8000/get
+//   Access Granted. Verified Session Data: user_abc123

--- a/examples/scripts/http_server_signed_cookies.ts
+++ b/examples/scripts/http_server_signed_cookies.ts
@@ -6,12 +6,15 @@
  * @resource {/examples/http_server_cookies} Example: HTTP server: Cookies
  * @group Network
  *
- * Securely sign and verify browser cookies using native cryptographic utilities 
- * to prevent client-side tampering. While clients can see the values of signed 
+ * Securely sign and verify browser cookies using native cryptographic utilities
+ * to prevent client-side tampering. While clients can see the values of signed
  * cookies, they cannot manipulate them without invalidating the cryptographic signature.
  */
 
-import { parseSignedCookie, signCookie } from "jsr:@std/http/unstable-signed-cookie";
+import {
+  parseSignedCookie,
+  signCookie,
+} from "jsr:@std/http/unstable-signed-cookie";
 
 // Cryptographic keys must be generated using web standard Web Crypto APIs.
 const cryptoKey = await crypto.subtle.generateKey(
@@ -26,33 +29,43 @@ Deno.serve(async (req) => {
   // ROUTE 1: Setting a secure, signed session cookie.
   if (pathname === "/set") {
     const rawValue = "user_abc123";
-    
+
     // signCookie securely appends a cryptographic hash signature to the string value.
     const signedValue = await signCookie(rawValue, cryptoKey);
 
-    return new Response("A cryptographically signed cookie has been successfully set!\n", {
-      headers: {
-        "set-cookie": `session_id=${signedValue}; Path=/; HttpOnly; SameSite=Lax`,
+    return new Response(
+      "A cryptographically signed cookie has been successfully set!\n",
+      {
+        headers: {
+          "set-cookie":
+            `session_id=${signedValue}; Path=/; HttpOnly; SameSite=Lax`,
+        },
       },
-    });
+    );
   }
 
   // ROUTE 2: Fetching and verifying the incoming signed cookie.
   if (pathname === "/get") {
     const cookieHeader = req.headers.get("cookie") ?? "";
     const match = cookieHeader.match(/(?:^|;\s*)session_id=([^;]+)/);
-    
+
     if (!match) {
-      return new Response("Unauthorized: Cookie is missing!\n", { status: 401 });
+      return new Response("Unauthorized: Cookie is missing!\n", {
+        status: 401,
+      });
     }
 
     try {
       // parseSignedCookie extracts and validates the data against our key.
       // If verification fails, it throws an error.
       const verifiedValue = parseSignedCookie(match[1]);
-      return new Response(`Access Granted. Verified Session Data: ${verifiedValue}\n`);
+      return new Response(
+        `Access Granted. Verified Session Data: ${verifiedValue}\n`,
+      );
     } catch {
-      return new Response("Unauthorized: Signature verification failed!\n", { status: 401 });
+      return new Response("Unauthorized: Signature verification failed!\n", {
+        status: 401,
+      });
     }
   }
 


### PR DESCRIPTION
Add an interactive documentation script showing how to use setSignedCookie and getSignedCookie with Web Crypto APIs.

Closes denoland/std#4913