### PR TITLE
fix(lint): correct camelcase rule docs for destructuring and named imports

### DIFF
--- a/lint/rules/camelcase.md
+++ b/lint/rules/camelcase.md
@@ -23,7 +23,6 @@ Of note:
 let first_name = "Ichigo";
 const obj1 = { last_name: "Hoshimiya" };
 const obj2 = { first_name };
-const { last_name } = obj1;
 
 function do_something() {}
 function foo({ snake_case = "default value" }) {}
@@ -31,7 +30,6 @@ function foo({ snake_case = "default value" }) {}
 class snake_case_class {}
 class Also_Not_Valid_Class {}
 
-import { not_camelCased } from "external-module.js";
 export * as not_camelCased from "mod.ts";
 
 enum snake_case_enum {
@@ -54,6 +52,7 @@ const __myPrivateVariable = "Hoshimiya";
 const myPrivateVariable_ = "Hoshimiya";
 const obj1 = { "last_name": "Hoshimiya" }; // if an object key is wrapped in quotation mark, then it's valid
 const obj2 = { "first_name": first_name };
+const { last_name } = obj1; // valid, because one has no control over the identifier
 const { last_name: lastName } = obj;
 
 function doSomething() {} // function declarations must be camelCase but...
@@ -62,6 +61,7 @@ function foo({ snake_case: camelCase = "default value" }) {}
 
 class PascalCaseClass {}
 
+import { not_camelCased } from "external-module.js"; // valid, because one has no control over the identifier
 import { not_camelCased as camelCased } from "external-module.js";
 export * as camelCased from "mod.ts";
 


### PR DESCRIPTION
Addresses denoland/deno_lint#1324.

The `camelcase` rule docs list two snippets in the **Invalid** section that
are actually **valid**:

- `const { last_name } = obj1;` — shorthand destructuring binds a local whose
  name is fixed by the source object property; the user has no control over it.
- `import { not_camelCased } from "external-module.js";` — a named import binds
  the exported name from the external module, likewise outside the user's
  control.

This matches the rule's documented note that it applies to imported/exported
variables but not to object properties of those variables, and reflects the
behaviour change in denoland/deno_lint#1187.

Verified against deno_lint `main`:

```
$ deno lint --rule camelcase
const obj1 = { last_name: "x" };       // flagged (object literal key) — stays Invalid
const { last_name } = obj1;            // no diagnostic — Valid
import { not_camelCased } from "...";   // no diagnostic — Valid
```

Only the object-literal key on line 1 is reported, confirming the two moved
snippets belong in the Valid section.

This supersedes the stale denoland/deno_lint#1325, which targeted the old
in-repo `docs/rules/camelcase.md` that was since removed when rule docs moved
to this repo.