### PR TITLE
docs(desktop): document deep-link URL schemes

### DIFF
--- a/api_links_test.ts
+++ b/api_links_test.ts
@@ -9,6 +9,7 @@ const DIRS_TO_CHECK = ["./runtime"];
  * Matches: `Deno.serve`  `Deno.readFile()`  `Deno.FsFile`
  * Ignores: [`Deno.serve`](/api/deno/~/Deno.serve)  (already linked)
  * Ignores: references inside fenced code blocks
+ * Ignores: section headings (linking a heading breaks anchor nav, see #3358)
  */
 function findUnlinkedDenoApis(
   content: string,
@@ -25,6 +26,10 @@ function findUnlinkedDenoApis(
       continue;
     }
     if (inCodeBlock) continue;
+
+    // Skip headings: linking a section heading to the API reference breaks the
+    // on-this-page anchor navigation (see issue #3358).
+    if (/^#{1,6}\s/.test(line)) continue;
 
     // Match `Deno.something` or `Deno.something()` NOT preceded by [
     const regex = /(?<!\[)`(Deno\.[a-zA-Z]\w+(?:\.\w+)*?)(?:\(\))?`/g;

--- a/runtime/desktop/configuration.md
+++ b/runtime/desktop/configuration.md
@@ -1,7 +1,7 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-06-30
 title: "Configuration"
-description: "Configure deno desktop in deno.json: app metadata, icons, backend selection, output paths, error reporting, and the auto-update server."
+description: "Configure deno desktop in deno.json: app metadata, icons, deep-link URL schemes, backend selection, output paths, error reporting, and the auto-update server."
 ---
 
 :::info Coming in Deno 2.9
@@ -23,6 +23,7 @@ still compiles, using sensible defaults.
 {
   "name": "my-app",
   "version": "1.4.0",
+  "exports": "./main.ts",
   "desktop": {
     "app": {
       "name": "My App",
@@ -31,7 +32,8 @@ still compiles, using sensible defaults.
         "macos": "./icons/app.icns",
         "windows": "./icons/app.ico",
         "linux": "./icons/app.png"
-      }
+      },
+      "deepLinks": ["myapp"]
     },
     "backend": "cef",
     "output": {
@@ -102,6 +104,52 @@ multi-resolution icon at build time:
 are assembled into the right container per platform.
 
 If no `icons` entry is set for a platform, the default Deno icon is used.
+
+### `app.deepLinks`
+
+Custom URL schemes (deep links) the app registers with the OS, so that opening a
+`<scheme>://...` link routes to your app. Each entry is a bare scheme name with
+no `://`.
+
+```jsonc
+"deepLinks": ["myapp"]
+```
+
+With the above, the OS treats `myapp://open/document/42` as belonging to your
+app. List several schemes if your app handles more than one:
+
+```jsonc
+"deepLinks": ["myapp", "myapp-beta"]
+```
+
+Scheme names follow the
+[RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1) grammar:
+they must start with an ASCII letter and may otherwise contain letters, digits,
+`+`, `-`, and `.`. Names are lowercased during registration. The reserved
+schemes `http`, `https`, `file`, `ftp`, `ws`, and `wss` are rejected, since
+registering them as app handlers would hijack normal browsing. An invalid or
+reserved scheme fails the build.
+
+Registration happens at bundle time, per platform:
+
+- **macOS** adds a `CFBundleURLTypes` entry (with your schemes under
+  `CFBundleURLSchemes`) to the bundle `Info.plist`. This is written before
+  code-signing so the signature stays valid.
+- **Linux** adds an `x-scheme-handler/<scheme>` MIME type to the `.desktop`
+  entry and ensures `Exec=` forwards the opened URL via the `%u` field code.
+- **Windows** has no in-bundle registration for protocol handlers, so the
+  bundler drops a `register-deep-links.bat` next to the launcher. It writes the
+  `HKCU\Software\Classes\<scheme>` keys pointing back at the launcher. An
+  installer (or the user) runs it once after install.
+
+:::info Registration only
+
+This registers the schemes with the OS so links are routed to your app. Handling
+the opened URL inside a running app (delivering the URL to your code) is coming
+in a later release; declare your schemes now so packaging and OS registration
+are in place.
+
+:::
 
 ## `backend`
 
@@ -223,5 +271,6 @@ Configuration is validated at the start of `deno desktop`:
 - Icon paths must resolve to existing files.
 - Output paths must be writable.
 - `release.baseUrl` must parse as a URL.
+- `app.deepLinks` entries must be valid, non-reserved URL schemes.
 
 Errors are reported with the offending `deno.json` location.

--- a/runtime/desktop/tray_and_dock.md
+++ b/runtime/desktop/tray_and_dock.md
@@ -18,7 +18,7 @@ version, [update Deno](/runtime/reference/cli/upgrade/) to use it.
 
 Menus on both use the [`Deno.MenuItem`](/runtime/desktop/menus/) type.
 
-## [`Deno.Tray`](/api/deno/~/Deno.Tray)
+## `Deno.Tray`
 
 ```ts
 const icon = await Deno.readFile("./icons/tray.png");
@@ -210,7 +210,7 @@ If the backend cannot create a tray icon, the constructor's underlying `trayId`
 is `0` and subsequent calls are no-ops (silently). Check `tray.trayId !== 0` if
 you need to fall back gracefully.
 
-## [`Deno.dock`](/api/deno/~/Deno.dock)
+## `Deno.dock`
 
 [`Deno.dock`](/api/deno/~/Deno.dock) is a singleton exposing the app's dock /
 taskbar controls. The methods are cross-platform but their effect varies:

--- a/runtime/desktop/tray_and_dock.md
+++ b/runtime/desktop/tray_and_dock.md
@@ -18,7 +18,7 @@ version, [update Deno](/runtime/reference/cli/upgrade/) to use it.
 
 Menus on both use the [`Deno.MenuItem`](/runtime/desktop/menus/) type.
 
-## `Deno.Tray`
+## [`Deno.Tray`](/api/deno/~/Deno.Tray)
 
 ```ts
 const icon = await Deno.readFile("./icons/tray.png");
@@ -210,7 +210,7 @@ If the backend cannot create a tray icon, the constructor's underlying `trayId`
 is `0` and subsequent calls are no-ops (silently). Check `tray.trayId !== 0` if
 you need to fall back gracefully.
 
-## `Deno.dock`
+## [`Deno.dock`](/api/deno/~/Deno.dock)
 
 [`Deno.dock`](/api/deno/~/Deno.dock) is a singleton exposing the app's dock /
 taskbar controls. The methods are cross-platform but their effect varies:

--- a/runtime/desktop/tray_and_dock.md
+++ b/runtime/desktop/tray_and_dock.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-16
+last_modified: 2026-06-30
 title: "Tray and dock"
 description: "Add icons to the OS status area and the macOS dock: tooltips, dark-mode variants, click events, and right-click context menus."
 ---
@@ -20,7 +20,7 @@ keys, and TypeScript APIs may still change before the feature is stable.
 
 Menus on both use the [`Deno.MenuItem`](/runtime/desktop/menus/) type.
 
-## [`Deno.Tray`](/api/deno/~/Deno.Tray)
+## `Deno.Tray`
 
 ```ts
 const icon = await Deno.readFile("./icons/tray.png");
@@ -212,7 +212,7 @@ If the backend cannot create a tray icon, the constructor's underlying `trayId`
 is `0` and subsequent calls are no-ops (silently). Check `tray.trayId !== 0` if
 you need to fall back gracefully.
 
-## [`Deno.dock`](/api/deno/~/Deno.dock)
+## `Deno.dock`
 
 [`Deno.dock`](/api/deno/~/Deno.dock) is a singleton exposing the app's dock /
 taskbar controls. The methods are cross-platform but their effect varies:


### PR DESCRIPTION
Documents the new `desktop.app.deepLinks` configuration field for `deno
desktop`, which registers custom URL schemes (deep links) with the OS at
bundle time. Covers the config field with single- and multi-scheme
examples, the scheme validation rules (RFC 3986 grammar, lowercasing, and
the rejected reserved schemes), and the per-platform registration
behavior on macOS, Linux, and Windows. An info callout notes that this is
OS registration only for now and that delivering an opened URL into a
running app arrives in a later release, matching the upstream PR's scope
(denoland/deno#35466).

Also folds in two reported documentation fixes on the same desktop pages.

Fixes #3359: the full configuration example carried a root `name` without
an `exports` field, so following it and running `deno desktop` produced a
repeated `"exports" field should be specified when specifying a "name".`
warning. Added `"exports": "./main.ts"` to the example.

Fixes #3358: the `Deno.Tray` and `Deno.dock` section headings in
`tray_and_dock.md` were themselves markdown links, which broke the
on-this-page anchor navigation (clicking the heading entry followed the
embedded API link instead of scrolling to the section). Changed both to
plain code headings, matching the convention on the sibling desktop
pages; the API reference links already exist in the intro prose just
above.