### PR TITLE
docs: expand CSS module import documentation

### DIFF
--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-06-30
 title: "Modules"
 description: "Learn how Deno's ECMAScript module system works: importing local and third-party modules, import attributes, import maps, and supported import types such as Wasm and data URLs."
 oldUrl:
@@ -182,6 +182,44 @@ import sheet from "./styles.css" with { type: "css" };
 console.log(sheet instanceof CSSStyleSheet);
 // true
 ```
+
+Dynamic imports work the same way:
+
+```ts
+const { default: sheet } = await import("./styles.css", {
+  with: { type: "css" },
+});
+```
+
+Reading a CSS file from disk needs read permission, so run with `--allow-read`
+(or the narrower `--allow-read=./styles.css`).
+
+Deno implements the small slice of the `CSSStyleSheet` interface that browser
+module graphs rely on:
+
+- `cssRules` returns the sheet's top-level rules. Unlike the browser, this is a
+  **frozen array** of `CSSRule` (not a live `CSSRuleList`), and a fresh array is
+  created on each access.
+- `CSSRule.cssText` is the verbatim text of one top-level rule.
+- `replace(text)` and `replaceSync(text)` swap the sheet's contents. As with
+  constructed stylesheets in the browser, top-level `@import` rules are dropped.
+- The `new CSSStyleSheet()` constructor is available, but its `options` argument
+  (`media`, `disabled`, `baseURL`) is not supported.
+
+```ts
+import sheet from "./styles.css" with { type: "css" };
+
+for (const rule of sheet.cssRules) {
+  console.log(rule.cssText);
+}
+
+sheet.replaceSync("body { color: red; }");
+```
+
+Because Deno has no DOM, a sheet can't be adopted anywhere; the implementation
+is backed by the raw CSS text rather than a full CSS object model. `cssRules`
+uses a naive top-level rule split, so the live mutation methods `insertRule` and
+`deleteRule` are not implemented.
 
 :::info `css` imports
 

--- a/runtime/fundamentals/modules.md
+++ b/runtime/fundamentals/modules.md
@@ -191,8 +191,10 @@ const { default: sheet } = await import("./styles.css", {
 });
 ```
 
-Reading a CSS file from disk needs read permission, so run with `--allow-read`
-(or the narrower `--allow-read=./styles.css`).
+Static imports and dynamic imports with a statically analyzable specifier are
+loaded as part of the module graph and need no permission. Only a dynamic import
+whose specifier can't be analyzed, such as `import(base + "styles.css")`, reads
+the file at runtime and therefore requires read permission (`--allow-read`).
 
 Deno implements the small slice of the `CSSStyleSheet` interface that browser
 module graphs rely on:


### PR DESCRIPTION
Expands the `with { type: "css" }` documentation in the modules guide to
cover the details requested in #3257, which the existing short section
left out.

Adds the dynamic `import(..., { with: { type: "css" } })` form, the
read-permission requirement for loading a stylesheet from disk, and a
description of the slice of the `CSSStyleSheet` interface that Deno
actually implements: `cssRules` as a frozen array of `CSSRule` (not a
live `CSSRuleList`), `CSSRule.cssText`, `replace`/`replaceSync` dropping
top-level `@import` rules, and the `new CSSStyleSheet()` constructor
without support for its `options` argument. Also spells out the
limitations that follow from Deno having no DOM: a sheet can't be adopted
anywhere, the rule list comes from a naive top-level split, and
`insertRule`/`deleteRule` are not implemented.

I verified each of these claims against the implementation in
`ext/web/css_stylesheet.rs` before documenting them.

Closes #3257.