### PR TITLE
docs: document opening the inspector at runtime with node:inspector

### DIFF
--- a/runtime/fundamentals/debugging.md
+++ b/runtime/fundamentals/debugging.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-20
+last_modified: 2026-06-30
 title: "Debugging"
 description: "Debug Deno programs with the V8 inspector: Chrome DevTools, VS Code and JetBrains setup, network inspection, worker debugging, and the --inspect flag family."
 oldUrl:
@@ -92,6 +92,57 @@ this flag by default.
 ```sh
 deno run --inspect-brk your_script.ts
 ```
+
+## Activating the inspector at runtime
+
+The `--inspect` flags start the inspector server when the process launches. If
+you instead want to open it on demand from inside a running program, use the
+[`node:inspector`](https://nodejs.org/api/inspector.html) module. This is handy
+for long-running processes such as servers, where you only want a debugger
+listening after some condition is met rather than for the whole lifetime of the
+process.
+
+`inspector.open([port][, host][, wait])` starts the inspector server. The port
+defaults to `9229` and the host to `127.0.0.1`. Because it binds a network
+socket, the program needs the `--allow-net` permission (or run with `-A`).
+
+```ts title="server.ts"
+import inspector from "node:inspector";
+
+Deno.serve((req) => {
+  if (new URL(req.url).pathname === "/debug" && !inspector.url()) {
+    inspector.open(9229, "127.0.0.1");
+    console.log("Inspector listening on", inspector.url());
+  }
+  return new Response("hello");
+});
+```
+
+```sh
+deno run --allow-net server.ts
+```
+
+Send a request to `/debug` and the inspector server starts; open
+`chrome://inspect` in a Chromium derived browser to connect. The module exposes
+a few related functions:
+
+- `inspector.open(port, host, true)` — passing `true` as the third argument
+  blocks until a client connects, the same as `inspector.waitForDebugger()`.
+- `inspector.url()` — returns the inspector WebSocket URL, or `undefined` when
+  the inspector is not active.
+- `inspector.close()` — stops the inspector server.
+
+A `Session` is also available for issuing
+[Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
+commands programmatically without an external client.
+
+:::caution
+
+Binding the inspector to a public IP with an open port is insecure: it lets any
+host that can reach the port connect to the inspector and execute arbitrary
+code. Keep the host at `127.0.0.1` unless you fully control the network.
+
+:::
 
 ## Example with Chrome DevTools
 


### PR DESCRIPTION
The debugging guide only covered the `--inspect` flag family, so there
was no mention of opening the inspector from inside a running program.
Two feedback issues asked for exactly this, and one was additionally
confused by the `node:inspector` API reference describing the module as
mostly non-functional stubs.

Adds an "Activating the inspector at runtime" section to the debugging
page documenting `node:inspector`: `inspector.open([port][, host][,
wait])` to start the inspector server on demand (default `127.0.0.1:9229`,
needs `--allow-net`), plus `inspector.url()`, `inspector.close()`,
`inspector.waitForDebugger()`, and a note about `Session` for issuing
Chrome DevTools Protocol commands directly. Includes a server example
that opens the inspector when a `/debug` request comes in, and a security
caution about binding to a public IP.

`node:inspector` is in fact functional in Deno (`open`, `close`, `url`,
`waitForDebugger`, `Session`, `Network`, `console`), so spelling this out
on the debugging page also addresses the "does inspector.open function?"
confusion. I verified the behavior, defaults, and the net-permission
check against the implementation in `ext/node/ops/inspector.rs` and
`ext/node/polyfills/inspector.js`.

Closes #3371.
Closes #3372.