### PR TITLE
docs: document __tests__ directory test discovery convention

### DIFF
--- a/runtime/test/index.md
+++ b/runtime/test/index.md
@@ -99,7 +99,9 @@ subcommand.
 
 If run without a file name or directory name, this subcommand will automatically
 find and execute all tests in the current directory (recursively) that match the
-glob `{*_,*.,}test.{ts, tsx, mts, js, mjs, jsx}`.
+glob `{*_,*.,}test.{ts, tsx, mts, js, mjs, jsx}`. Additionally, any script file
+inside a directory named `__tests__` is treated as a test file, regardless of
+its file name.
 
 ```sh
 # Run all tests in the current directory and all sub-directories

--- a/runtime/test/index.md
+++ b/runtime/test/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-02
 title: "Testing"
 description: "Write and run tests with Deno's built-in test runner: assertions, test steps, hooks, filtering, and reporters, with dedicated guides for mocking, snapshots, and coverage."
 oldUrl:


### PR DESCRIPTION
Since Deno 1.45 (denoland/deno#24443), `deno test` treats every script file
inside a `__tests__` directory as a test file, in addition to files matching
the `{*_,*.,}test.{ts, tsx, mts, js, mjs, jsx}` glob. This convention was
never mentioned on the testing page, which has caused confusion when
non-test files placed in such a directory get collected and type-checked
(denoland/deno#24594). This documents it next to the existing glob
description.