### PR TITLE
docs: fix broken Deno.test.each API reference links

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,26 +28,25 @@ jobs:
       - run: deno fmt --check
       - run: deno task test
 
-      # Cache reference types + generated docs (types: 86s, docs: 162s)
-      - name: Restore reference cache
-        uses: actions/cache@v4
-        id: ref-cache
-        with:
-          path: |
-            reference_gen/types
-            reference_gen/gen
-          key: reference-${{ hashFiles('reference_gen/**') }}
-          restore-keys: reference-
-
+      # The types come from `deno types`, so they depend on the Deno binary,
+      # not on any repo file. Regenerate them every run (types: 86s) and cache
+      # only the doc generation (docs: 162s), keyed on the generated types'
+      # content. A repo-only cache key kept serving reference docs generated
+      # with an older Deno, missing newly added APIs (#3389).
       - name: "Reference: install"
-        if: steps.ref-cache.outputs.cache-hit != 'true'
         working-directory: "reference_gen"
         run: deno install
 
       - name: "Reference: generate types"
-        if: steps.ref-cache.outputs.cache-hit != 'true'
         working-directory: "reference_gen"
         run: deno task types
+
+      - name: Restore reference docs cache
+        uses: actions/cache@v4
+        id: ref-cache
+        with:
+          path: reference_gen/gen
+          key: reference-${{ hashFiles('reference_gen/types/**', 'reference_gen/*.ts', 'reference_gen/*.json', 'reference_gen/*.jsonc', 'reference_gen/deno.lock', 'reference_gen/node_descriptions/**') }}
 
       - name: "Reference: generate docs"
         if: steps.ref-cache.outputs.cache-hit != 'true'

--- a/oldurls.json
+++ b/oldurls.json
@@ -37,6 +37,7 @@
   "/runtime/reference/tcp_udp_connections/": "/examples/",
   "/runtime/getting_started/": "/runtime/",
   "/api/deno/~/Deno.TlsConn.rid/": "/runtime/reference/migration_guide/#rid",
+  "/api/deno/~/Deno.test.each/": "/api/deno/~/Deno.DenoTest.each",
   "/manual@main/advanced/typescript/faqs": "/runtime/fundamentals/typescript/",
   "/runtime/tutorials/": "/examples/",
   "/runtime/manual/examples/how_to_with_npm/": "/examples/",

--- a/runtime/reference/cli/test.md
+++ b/runtime/reference/cli/test.md
@@ -152,7 +152,7 @@ per-metric configuration.
 ## Parameterized tests
 
 Run the same test body over a table of cases with
-[`Deno.test.each`](/api/deno/~/Deno.test.each), which registers one
+[`Deno.test.each`](/api/deno/~/Deno.DenoTest.each), which registers one
 independently reported test per case. See
 [Parameterized tests](/runtime/test/#parameterized-tests) for the name templates
 and case forms.

--- a/runtime/reference/cli/test.md
+++ b/runtime/reference/cli/test.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-06
 title: "deno test"
 oldUrl: /runtime/manual/tools/test/
 command: test

--- a/runtime/test/index.md
+++ b/runtime/test/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-02
+last_modified: 2026-07-06
 title: "Testing"
 description: "Write and run tests with Deno's built-in test runner: assertions, test steps, hooks, filtering, and reporters, with dedicated guides for mocking, snapshots, and coverage."
 oldUrl:

--- a/runtime/test/index.md
+++ b/runtime/test/index.md
@@ -204,8 +204,8 @@ deno test --retry=2
 
 ## Parameterized tests
 
-[`Deno.test.each`](/api/deno/~/Deno.test.each) runs the same test body over a
-table of cases. It registers one real test per case, so each case reports
+[`Deno.test.each`](/api/deno/~/Deno.DenoTest.each) runs the same test body over
+a table of cases. It registers one real test per case, so each case reports
 independently and can be filtered or run on its own.
 
 Array cases are spread as positional arguments. The name template interpolates
@@ -235,7 +235,7 @@ Deno.test.each([
 });
 ```
 
-[`Deno.test.each`](/api/deno/~/Deno.test.each) accepts the usual per-test
+[`Deno.test.each`](/api/deno/~/Deno.DenoTest.each) accepts the usual per-test
 options object, and the `only` and `ignore` shorthands compose with it as
 `.only.each` and `.ignore.each`.
 


### PR DESCRIPTION
The testing guide and the deno test CLI page linked Deno.test.each to
/api/deno/~/Deno.test.each, but the reference generator never emits a page
at that URL: each is a property of the DenoTest interface, so its page is
/api/deno/~/Deno.DenoTest.each (same pattern as the existing
Deno.DenoTest.beforeEach page). The links now point there, and oldurls.json
redirects the already-published Deno.test.each URL to the right page.

The symbol is also missing from the deployed API reference because it was
generated with a pre-2.9 Deno (the each types landed in 2.9.0). In CI the
lint workflow cached reference_gen/types keyed only on repo files, so the
types produced by `deno types` were never refreshed when the Deno binary
changed. The workflow now regenerates types on every run and caches only
the doc generation, keyed on the generated types' content. The deployed
reference will pick up the new page on the next build with Deno >= 2.9.

Fixes #3389