### PR TITLE
docs: reinstate LTS channel with v2.9 release

### DIFF
--- a/runtime/fundamentals/stability_and_releases.md
+++ b/runtime/fundamentals/stability_and_releases.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-06
+last_modified: 2026-07-08
 title: "Stability and releases"
 description: "Guide to Deno's stability guarantees and release process. Covering release channels, long-term support (LTS), unstable features, versioning policy, and how Deno maintains backward compatibility."
 oldUrl:
@@ -21,46 +21,39 @@ released.
 
 ### Release channels
 
-Deno offers 3 release channels
+Deno offers 4 release channels
 
 - `stable` - a semver minor/patch release, as described above. This is **the
   default** distribution channel that is recommended for most users.
+- `lts` - long term support for a particular stable release, recommended for
+  enterprise users who prefer not to upgrade so often. See below for details.
 - `rc` - a release candidate for the upcoming semver minor release.
 - `canary` - an unstable release that changes multiple times per day, allows to
   try out latest bug fixes and new features that might end up in the `stable`
   channel.
 
-An `lts` (long term support) channel was previously offered, but it has been
-discontinued. See below for details.
+### Long Term Support (LTS)
 
-### Long Term Support (LTS) - discontinued
+Deno offers an LTS (long-term support) channel. This is a minor semver version
+that we maintain with only backwards-compatible bug fixes, so you can stay on a
+single release line without absorbing new features or breaking changes.
 
-:::warning
-
-LTS support was discontinued on April 30, 2026. There are no LTS releases or
-maintenance beyond that date. If you are still using an LTS release, upgrade to
-the latest `stable` release.
-
-:::
-
-From February 2025 to April 2026, Deno offered an LTS (long-term support)
-channel: a minor semver version maintained with only backwards-compatible bug
-fixes. The final LTS release was v2.5, which reached end of life on April 30,
-2026.
+The current LTS release is **v2.9**, maintained until December 31st, 2026.
 
 | LTS release version | LTS maintenance start | LTS maintenance end |
 | ------------------- | --------------------- | ------------------- |
 | v2.1                | Feb 1st, 2025         | Apr 30th, 2025      |
 | v2.2                | May 1st, 2025         | Oct 31st, 2025      |
 | v2.5                | Nov 1st, 2025         | Apr 30th, 2026      |
+| v2.9                | Jul 1st, 2026         | Dec 31st, 2026      |
 
-LTS backports included:
+LTS backports include:
 
 - Security patches
 - Critical bug fixes (e.g., crashes, incorrect computations)
-- **Critical** performance improvements, backported based on severity
+- **Critical** performance improvements _may_ be backported based on severity.
 
-API changes and major new features were not backported.
+**API changes and major new features will not be backported.**
 
 ## Unstable APIs
 


### PR DESCRIPTION
The previous change (#3390) marked the LTS channel as discontinued after the
v2.5 line reached end of life on April 30, 2026. That framing became a
liability: it read as Deno walking away from long-term support just as
enterprise and background-service users lean on stability guarantees.

We are instead promoting the v2.9 line to LTS, maintained until December 31,
2026. This restores the `lts` release channel to the channel list, returns
the LTS section to describing an active offering, adds the v2.9 row to the
maintenance table alongside the historical releases, and puts the backport
policy back in present tense.