### PR TITLE
fix: enable the lockfile so deploys boot under --cached-only

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -111,6 +111,5 @@
       "ffi": true,
       "sys": true
     }
-  },
-  "lock": false
+  }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,42 +1,74 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@deno/cache-dir@0.25": "0.25.0",
+    "jsr:@deno/doc@0.187.0": "0.187.0",
+    "jsr:@deno/graph@0.100": "0.100.1",
+    "jsr:@deno/graph@0.86": "0.86.9",
     "jsr:@deno/loader@0.3.5": "0.3.5",
+    "jsr:@orama/core@^1.2.4": "1.2.14",
+    "jsr:@std/assert@^1.0.6": "1.0.19",
+    "jsr:@std/bytes@^1.0.6": "1.0.6",
     "jsr:@std/cli@1.0.22": "1.0.22",
+    "jsr:@std/cli@1.0.24": "1.0.24",
     "jsr:@std/cli@^1.0.21": "1.0.22",
+    "jsr:@std/cli@^1.0.24": "1.0.32",
+    "jsr:@std/cli@^1.0.27": "1.0.32",
     "jsr:@std/collections@^1.1.3": "1.1.3",
     "jsr:@std/crypto@1.0.5": "1.0.5",
     "jsr:@std/dotenv@~0.225.2": "0.225.5",
     "jsr:@std/encoding@1.0.10": "1.0.10",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/fmt@1.0.8": "1.0.8",
+    "jsr:@std/fmt@^1.0.10": "1.0.10",
+    "jsr:@std/fmt@^1.0.3": "1.0.10",
     "jsr:@std/fmt@^1.0.8": "1.0.8",
     "jsr:@std/front-matter@1.0.9": "1.0.9",
     "jsr:@std/fs@*": "1.0.19",
     "jsr:@std/fs@1.0.19": "1.0.19",
+    "jsr:@std/fs@1.0.20": "1.0.20",
     "jsr:@std/fs@^1.0.16": "1.0.19",
     "jsr:@std/fs@^1.0.19": "1.0.19",
+    "jsr:@std/fs@^1.0.20": "1.0.20",
+    "jsr:@std/fs@^1.0.6": "1.0.20",
+    "jsr:@std/html@^1.0.3": "1.0.5",
     "jsr:@std/html@^1.0.4": "1.0.5",
+    "jsr:@std/html@^1.0.5": "1.0.5",
     "jsr:@std/http@1.0.20": "1.0.20",
+    "jsr:@std/http@1.0.22": "1.0.22",
     "jsr:@std/internal@^1.0.10": "1.0.12",
-    "jsr:@std/internal@^1.0.9": "1.0.12",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/internal@^1.0.9": "1.0.14",
+    "jsr:@std/io@0.225": "0.225.3",
+    "jsr:@std/json@^1.0.2": "1.1.0",
     "jsr:@std/jsonc@1.0.2": "1.0.2",
     "jsr:@std/media-types@^1.0.3": "1.1.0",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.4": "1.0.6",
+    "jsr:@std/net@^1.0.6": "1.0.6",
     "jsr:@std/path@*": "1.1.2",
     "jsr:@std/path@1.1.2": "1.1.2",
-    "jsr:@std/path@^1.0.8": "1.1.2",
-    "jsr:@std/path@^1.1.1": "1.1.2",
+    "jsr:@std/path@1.1.3": "1.1.3",
+    "jsr:@std/path@^1.0.8": "1.1.3",
+    "jsr:@std/path@^1.1.1": "1.1.3",
+    "jsr:@std/path@^1.1.3": "1.1.3",
     "jsr:@std/semver@1.0.5": "1.0.5",
+    "jsr:@std/semver@1.0.7": "1.0.7",
     "jsr:@std/streams@^1.0.10": "1.0.14",
+    "jsr:@std/streams@^1.0.14": "1.0.14",
     "jsr:@std/toml@1.0.10": "1.0.10",
-    "jsr:@std/toml@^1.0.3": "1.0.10",
+    "jsr:@std/toml@1.0.11": "1.0.11",
+    "jsr:@std/toml@^1.0.3": "1.0.11",
     "jsr:@std/yaml@*": "1.0.9",
+    "jsr:@std/yaml@1.0.10": "1.0.10",
     "jsr:@std/yaml@1.0.9": "1.0.9",
-    "jsr:@std/yaml@^1.0.5": "1.0.9",
+    "jsr:@std/yaml@^1.0.11": "1.1.2",
+    "jsr:@std/yaml@^1.0.5": "1.1.2",
     "npm:@mdx-js/mdx@3.1.1": "3.1.1_acorn@8.15.0",
     "npm:@octokit/core@^5.2.0": "5.2.2",
+    "npm:@orama/cuid2@2.2.3": "2.2.3",
+    "npm:@orama/oramacore-events-parser@0.0.5": "0.0.5",
     "npm:@resvg/resvg-wasm@2.6.2": "2.6.2",
     "npm:@tailwindcss/node@4.1.13": "4.1.13",
     "npm:@tailwindcss/oxide@4.1.13": "4.1.13",
@@ -45,6 +77,7 @@
     "npm:ico-endec@0.1.6": "0.1.6",
     "npm:leo-profanity@^1.7.0": "1.8.0",
     "npm:lightningcss-wasm@1.30.1": "1.30.1",
+    "npm:lightningcss-wasm@1.30.2": "1.30.2",
     "npm:markdown-it-anchor@9": "9.2.0_@types+markdown-it@14.1.2_markdown-it@14.1.0",
     "npm:markdown-it-attrs@4.3.1": "4.3.1_markdown-it@14.1.0",
     "npm:markdown-it-deflist@3.0.0": "3.0.0",
@@ -56,14 +89,70 @@
     "npm:satori@0.18.2": "0.18.2",
     "npm:sharp@0.34.3": "0.34.3",
     "npm:tailwindcss@4.1.13": "4.1.13",
-    "npm:tailwindcss@^4.1.11": "4.1.17"
+    "npm:tailwindcss@^4.1.11": "4.1.13",
+    "npm:zod-to-json-schema@3.24.5": "3.24.5_zod@3.24.3",
+    "npm:zod@3.24.3": "3.24.3"
   },
   "jsr": {
+    "@deno/cache-dir@0.25.0": {
+      "integrity": "e9c3e901f87961a813a197b076668007699953dcbeb3af51971d90fdb0d29723",
+      "dependencies": [
+        "jsr:@deno/graph@0.86",
+        "jsr:@std/fmt@^1.0.3",
+        "jsr:@std/fs@^1.0.6",
+        "jsr:@std/io",
+        "jsr:@std/path@^1.0.8"
+      ]
+    },
+    "@deno/doc@0.187.0": {
+      "integrity": "f25464b03ab66f14a2d3be562a1f81337f3f40ebb5befa614c5ca8ab51b3d842",
+      "dependencies": [
+        "jsr:@deno/cache-dir",
+        "jsr:@deno/graph@0.100"
+      ]
+    },
+    "@deno/graph@0.86.9": {
+      "integrity": "c4f353a695bcc5246c099602977dabc6534eacea9999a35a8cb24e807192e6a1"
+    },
+    "@deno/graph@0.100.1": {
+      "integrity": "91ae087c95fe3d97f35f84b3ea38ea21163d12df28c6ec70bb89f253fd99870e"
+    },
     "@deno/loader@0.3.5": {
       "integrity": "72f6ce9c6e7242c6e070705dbd8a838884dd236d5dd0bd907d08bece92db5722"
     },
+    "@orama/core@1.2.14": {
+      "integrity": "bbcce5dff3385f88e8806beccbd52c3fdf263dcfcc5dadc97892dc7aa3a89f2c",
+      "dependencies": [
+        "npm:@orama/cuid2",
+        "npm:@orama/oramacore-events-parser",
+        "npm:zod",
+        "npm:zod-to-json-schema"
+      ]
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/bytes@1.0.6": {
+      "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
+    },
     "@std/cli@1.0.22": {
       "integrity": "50d1e4f87887cb8a8afa29b88505ab5081188f5cad3985460c3b471fa49ff21a"
+    },
+    "@std/cli@1.0.24": {
+      "integrity": "b655a5beb26aa94f98add6bc8889f5fb9bc3ee2cc3fc954e151201f4c4200a5e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/cli@1.0.32": {
+      "integrity": "188b3a100d6202d64e3f5bd3d799c7fa4f6d77f92cc65eb7f641c1fa0aa92a66",
+      "dependencies": [
+        "jsr:@std/fmt@^1.0.10",
+        "jsr:@std/internal@^1.0.14"
+      ]
     },
     "@std/collections@1.1.3": {
       "integrity": "bf8b0818886df6a32b64c7d3b037a425111f28278d69fd0995aeb62777c986b0"
@@ -80,6 +169,9 @@
     "@std/fmt@1.0.8": {
       "integrity": "71e1fc498787e4434d213647a6e43e794af4fd393ef8f52062246e06f7e372b7"
     },
+    "@std/fmt@1.0.10": {
+      "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
+    },
     "@std/front-matter@1.0.9": {
       "integrity": "ee6201d06674cbef137dda2252f62477450b48249e7d8d9ab57a30f85ff6f051",
       "dependencies": [
@@ -94,6 +186,13 @@
         "jsr:@std/path@^1.1.1"
       ]
     },
+    "@std/fs@1.0.20": {
+      "integrity": "e953206aae48d46ee65e8783ded459f23bec7dd1f3879512911c35e5484ea187",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12",
+        "jsr:@std/path@^1.1.3"
+      ]
+    },
     "@std/html@1.0.5": {
       "integrity": "4e2d693f474cae8c16a920fa5e15a3b72267b94b84667f11a50c6dd1cb18d35e"
     },
@@ -104,18 +203,47 @@
         "jsr:@std/encoding@^1.0.10",
         "jsr:@std/fmt@^1.0.8",
         "jsr:@std/fs@^1.0.19",
-        "jsr:@std/html",
+        "jsr:@std/html@^1.0.4",
         "jsr:@std/media-types@^1.1.0",
-        "jsr:@std/net",
+        "jsr:@std/net@^1.0.4",
         "jsr:@std/path@^1.1.1",
-        "jsr:@std/streams"
+        "jsr:@std/streams@^1.0.10"
+      ]
+    },
+    "@std/http@1.0.22": {
+      "integrity": "53f0bb70e23a2eec3e17c4240a85bb23d185b2e20635adb37ce0f03cc4ca012a",
+      "dependencies": [
+        "jsr:@std/cli@^1.0.24",
+        "jsr:@std/encoding@^1.0.10",
+        "jsr:@std/fmt@^1.0.8",
+        "jsr:@std/fs@^1.0.20",
+        "jsr:@std/html@^1.0.5",
+        "jsr:@std/media-types@^1.1.0",
+        "jsr:@std/net@^1.0.6",
+        "jsr:@std/path@^1.1.3",
+        "jsr:@std/streams@^1.0.14"
       ]
     },
     "@std/internal@1.0.12": {
       "integrity": "972a634fd5bc34b242024402972cd5143eac68d8dffaca5eaa4dba30ce17b027"
     },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/io@0.225.3": {
+      "integrity": "27b07b591384d12d7b568f39e61dff966b8230559122df1e9fd11cc068f7ddd1",
+      "dependencies": [
+        "jsr:@std/bytes"
+      ]
+    },
+    "@std/json@1.1.0": {
+      "integrity": "93330d3ed4054d6b1ffe54b075432c80a5f671be77277b978931e018014cb1cc"
+    },
     "@std/jsonc@1.0.2": {
-      "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7"
+      "integrity": "909605dae3af22bd75b1cbda8d64a32cf1fd2cf6efa3f9e224aba6d22c0f44c7",
+      "dependencies": [
+        "jsr:@std/json"
+      ]
     },
     "@std/media-types@1.1.0": {
       "integrity": "c9d093f0c05c3512932b330e3cc1fe1d627b301db33a4c2c2185c02471d6eaa4"
@@ -129,8 +257,17 @@
         "jsr:@std/internal@^1.0.10"
       ]
     },
+    "@std/path@1.1.3": {
+      "integrity": "b015962d82a5e6daea980c32b82d2c40142149639968549c649031a230b1afb3",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
     "@std/semver@1.0.5": {
       "integrity": "529f79e83705714c105ad0ba55bec0f9da0f24d2f726b6cc1c15e505cc2c0624"
+    },
+    "@std/semver@1.0.7": {
+      "integrity": "7d5f65391762dc4358abde80fc3354086ddb40101f140295e60f290c138887d0"
     },
     "@std/streams@1.0.14": {
       "integrity": "c0df6cdd73bd4bbcbe4baa89e323b88418c90ceb2d926f95aa99bdcdbfca2411"
@@ -141,8 +278,20 @@
         "jsr:@std/collections"
       ]
     },
+    "@std/toml@1.0.11": {
+      "integrity": "e084988b872ca4bad6aedfb7350f6eeed0e8ba88e9ee5e1590621c5b5bb8f715",
+      "dependencies": [
+        "jsr:@std/collections"
+      ]
+    },
     "@std/yaml@1.0.9": {
       "integrity": "6bad3dc766dd85b4b37eabcba81b6aa4eac7a392792ae29abcfb0f90602d55bb"
+    },
+    "@std/yaml@1.0.10": {
+      "integrity": "245706ea3511cc50c8c6d00339c23ea2ffa27bd2c7ea5445338f8feff31fa58e"
+    },
+    "@std/yaml@1.1.2": {
+      "integrity": "de612653c036749ba2044165e316f52412b0f0698afffb7ee80b5331d6d2abae"
     }
   },
   "npm": {
@@ -354,6 +503,9 @@
         "vfile"
       ]
     },
+    "@noble/hashes@1.8.0": {
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
+    },
     "@octokit/auth-token@4.0.0": {
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA=="
     },
@@ -410,6 +562,15 @@
         "@octokit/openapi-types"
       ]
     },
+    "@orama/cuid2@2.2.3": {
+      "integrity": "sha512-Lcak3chblMejdlSHgYU2lS2cdOhDpU6vkfIJH4m+YKvqQyLqs1bB8+w6NT1MG5bO12NUK2GFc34Mn2xshMIQ1g==",
+      "dependencies": [
+        "@noble/hashes"
+      ]
+    },
+    "@orama/oramacore-events-parser@0.0.5": {
+      "integrity": "sha512-yAuSwog+HQBAXgZ60TNKEwu04y81/09mpbYBCmz1RCxnr4ObNY2JnPZI7HmALbjAhLJ8t5p+wc2JHRK93ubO4w=="
+    },
     "@resvg/resvg-wasm@2.6.2": {
       "integrity": "sha512-FqALmHI8D4o6lk/LRWDnhw95z5eO+eAa6ORjVg09YRR7BkcM6oPHU9uyC0gtQG5vpFLvgpeU4+zEAz2H8APHNw=="
     },
@@ -430,7 +591,7 @@
         "lightningcss",
         "magic-string",
         "source-map-js",
-        "tailwindcss@4.1.13"
+        "tailwindcss"
       ]
     },
     "@tailwindcss/oxide-android-arm64@4.1.13": {
@@ -567,7 +728,8 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
     },
     "@ungap/structured-clone@1.3.0": {
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "deprecated": true
     },
     "acorn-jsx@5.3.2_acorn@8.15.0": {
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
@@ -1098,6 +1260,9 @@
     },
     "lightningcss-wasm@1.30.1": {
       "integrity": "sha512-KJTnKEn0REV6DoJzxG0m5EKVEFA1CVE1isDYpXjsuqWXwLKFPJtA9Z9BSzPZJwAZFN2KaUzy+IWGP59p5bm2sA=="
+    },
+    "lightningcss-wasm@1.30.2": {
+      "integrity": "sha512-3QB24h07oFTwiXI/wItgEv5De1prsmrZFWluuTyLO7/CFk4kEC5zgG7V6qQNGLBB5+QhSnGMixUALWHXj+J3Ug=="
     },
     "lightningcss-win32-arm64-msvc@1.30.1": {
       "integrity": "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==",
@@ -1990,9 +2155,6 @@
     "tailwindcss@4.1.13": {
       "integrity": "sha512-i+zidfmTqtwquj4hMEwdjshYYgMbOrPzb9a0M3ZgNa0JMoZeFC6bxZvO8yr8ozS6ix2SDz0+mvryPeBs2TFE+w=="
     },
-    "tailwindcss@4.1.17": {
-      "integrity": "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q=="
-    },
     "tapable@2.3.0": {
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="
     },
@@ -2004,7 +2166,8 @@
         "minipass",
         "minizlib",
         "yallist"
-      ]
+      ],
+      "deprecated": true
     },
     "tiny-inflate@1.0.3": {
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
@@ -2090,6 +2253,7 @@
     },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": true,
       "bin": true
     },
     "vfile-message@4.0.3": {
@@ -2125,11 +2289,152 @@
     "yoga-layout@3.2.1": {
       "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="
     },
+    "zod-to-json-schema@3.24.5_zod@3.24.3": {
+      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "dependencies": [
+        "zod"
+      ]
+    },
+    "zod@3.24.3": {
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg=="
+    },
     "zwitch@2.0.4": {
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   },
   "remote": {
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/build/deno-wasm/deno-wasm-dynamic.js": "fd05e83a855aa68b09396dc47a7638ef526c39917971715ac37e0fc3227db886",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/build/deno-wasm/deno-wasm.js": "ccde5219e42040b8f7a8b653acc6c8cca197c29f98d6b75f74c48111e34bcbea",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/build/deno-wasm/deno-wasm_bg-wasm.js": "52c57905a74047d1574f0b96e301ef1d5974cd962705615555b5e46b5ac420e4",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/build/deno-wasm/deno-wasm_bg.wasm": "b5fbd7ede316f7c13e4a7b927a053a35b475a9acce7c7cae864e91d9b8dd24c7",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/build/deno-wasm/env.js": "17da784c11b192c591dbf7df21ec6f65f63f45ca9a713e4ca100f3c886b4023f",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/build/deno-wasm/wbg.js": "b5b6de12bc010fa23438c8a8276067b9044a405da516d0bbe4ae61b7c6d61a22",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/deno-dom-wasm.ts": "34f0654b452568fbd95b8d1b2a493de19710ac9ceeb6b82f541d09c29613572d",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/api.ts": "0ff5790f0a3eeecb4e00b7d8fbfa319b165962cf6d0182a65ba90f158d74f7d7",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/constructor-lock.ts": "0e7b297e8b9cf921a3b0d3a692ec5fb462c5afc47ec554292e20090b9e16b40a",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/deserialize.ts": "514953418b7ae558ed7361ad9be21013f46cba2f58bd7f4acc90cf1e89f9c8cf",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/document-fragment.ts": "0b915d094830d43b330dc2fb8012b990f2c815773c6cdcd4a9fdff99fe47412e",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/document.ts": "ad584ac4ce6dce03f0ff6ef4b7db86fd598f9c7824da1387f7f2acd7d6948e4a",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/dom-parser.ts": "ab5e8382700bc3936ac67e8d11b7bb9c6999a994ac8b070b7cae94e2d2ecee5a",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/element.ts": "9726ebf139b97ae96671d38da720988cfd6481ff9068ba13f3b0d00e72f0c8c0",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/elements/html-template-element.ts": "1707dfb4cbb145f3bcb94426d7cdedbaa336620d0afed30e99f50fe87ba24a98",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/html-collection.ts": "dcf328e883877f7748d3e20fb6319e739f297a6e24f4b00ec5b1a2f390cfa3c6",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/node-list.ts": "be9793475d82539da8b97a17b6b5538cc723538c10cc5820a23e5e4b2248845d",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/node.ts": "53ada9e4b2ae21f10f5941ff257ed4585920ae392020544648f349c05d15d30c",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/selectors/custom-api.ts": "852696bd58e534bc41bd3be9e2250b60b67cd95fd28ed16b1deff1d548531a71",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/selectors/nwsapi-types.ts": "c43b36c36acc5d32caabaa54fda8c9d239b2b0fcbce9a28efb93c84aa1021698",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/selectors/nwsapi.js": "985d7d8fc1eabbb88946b47a1c44c1b2d4aa79ff23c21424219f1528fa27a2ff",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/selectors/selectors.ts": "83eab57be2290fb48e3130533448c93c6c61239f2a2f3b85f1917f80ca0fdc75",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/selectors/sizzle-types.ts": "78149e2502409989ce861ed636b813b059e16bc267bb543e7c2b26ef43e4798b",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/selectors/sizzle.js": "c3aed60c1045a106d8e546ac2f85cc82e65f62d9af2f8f515210b9212286682a",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/string-cache.ts": "8e935804f7bac244cc70cec90a28c9f6d30fea14c61c2c4ea48fca274376d786",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/utils-types.ts": "96db30e3e4a75b194201bb9fa30988215da7f91b380fca6a5143e51ece2a8436",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/dom/utils.ts": "bc429635e9204051ba1ecc1b212031b5ee7c6bcd95120c91bef696804aa67e74",
+    "https://cdn.jsdelivr.net/gh/b-fuze/deno-dom@0.1.56/src/parser.ts": "e06b2300d693e6ae7564e53dfa5c9a9e97fdb8c044c39c52c8b93b5d60860be3",
+    "https://cdn.jsdelivr.net/gh/esbuild/deno-esbuild@0.27.0/wasm.js": "7fb1dab47d63864f635f9b032fdc747529e3e78a3413eacd2bff118a8b3b3f79",
+    "https://cdn.jsdelivr.net/gh/lumeland/bar@0.1.13/types.ts": "38f3714e1432c174009495333972f85fb306eb6313112ac8830fda9f1f47e87f",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/cli/create.ts": "db576c8cd3aa5a27685c6283573983be59de0be7ec404a9f815b24d4ea61c639",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/cli/utils.ts": "71e1ee512aa630cf4b2b3ddd646f1ef5f20b43b538d396ad4e27128f7a8439c3",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/cache.ts": "bec945853a7111babf1fb465090d84dbf4176af0ad465b63b51031134ad6ea2a",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/components.ts": "e5b0d2aca8e630735534a4cb781802fe9c194c3be4e1010c0abe73617c607d84",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/data_loader.ts": "8698a9e9b1aac27147dc835ba89a0e30828c81338eceae86630607d78f146215",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/debugbar.ts": "77d23362c29e69a8f42b8fc13d6129e62ac6ecf339bc0ac4739082c800b44f58",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/events.ts": "e4fd1786eb7dd4a041d7d922779b9edf1ee89e51fd17ba5e756f380879ccb557",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/file.ts": "5836010f28967a83fb02d721e78cfea1f2d125b4349204a8a3d04ac62070c127",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/formats.ts": "e65130e5c5f2e49435619479710c812199b480a9e145fdc6b2bac11cfe6ea08e",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/fs.ts": "ad0b1eb43361f76f36674505ef6b8870176ef386c43ee962e6c750506b40a071",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/loaders/binary.ts": "bb1e1cf3faac49f6007dc6814168dc0f633da17356db18e68862e4b2a87a3f33",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/loaders/json.ts": "ae28e711196215ca2772e9e31f2646ff4c3cf3f66ae75bf8cbcab94de5dbd24f",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/loaders/module.ts": "abcb210fa6724b83407407cd0f7ef90462b35a2017bc135a3d124dd7f38843f6",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/loaders/text.ts": "42860fc3482651fa6cfba18a734bb548d6e6e1163bf1015c2abc447ab150acbd",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/loaders/toml.ts": "72ddfef2deea62815c28e27faa2c5356e09b3109e9547e47a6defea3d3332452",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/loaders/yaml.ts": "241dc41fbe51b92e38dc748eda614c35d80fb8c63a6d40253453c6bb78c9c47e",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/processors.ts": "047a87b0c9a0377ef15daaf1b671a29d541e4bb744c152f02a5c4f0a80fbbb64",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/renderer.ts": "8c69046aa0fdc51fddbbd36c02aeb9b2226a5853f4ae8aeb549c17c43af13e88",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/scopes.ts": "dbdf93d7a9cead84833779e974f190b1379356ec7c0ccd34aa92f917c2cdd2f9",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/scripts.ts": "286969b120d2290ba57a7fdd9b37e587aacf4e4162d92f51f1f1e9e18c864f30",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/searcher.ts": "580fd9a81c67ae33df416f80525a3dacbf49790ea7990a721f76719e15fa4878",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/server.ts": "def3dc6fb32fcc6b059e96b9be4935e3916ef903e057c1a7c1f844bf22068505",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/site.ts": "23aa4ebc11b0705608ed82a7743e3eb5102e4d00af6ee35c7a464b2b2aff813f",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/source.ts": "d4dbe91058369ffaf23778da7e8d8287234f3901eed378accb7933e76529a216",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/cdn.ts": "5f7abfbff8b8a4d61b8eb520bfd77294066937ace2df5fc27451c09104190be4",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/cli_options.ts": "c1fd59592064e76ce71c4d65d7c0de6cafee836fbd8eb42717cc68f56ed36b8a",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/concurrent.ts": "cb0775b3d95f3faa356aa3a3e489dccef8807ed93cc4f84fcf5bc81e87c29504",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/date.ts": "3eb0b0e2ea15a95cdfe737be70cd4f48cbe49401928cb04c25a230f411ab2478",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/digest.ts": "fcd15e7666fb28989b7d5b23c111044cfa71456fa39e26090ee88ac517ee4336",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/dom.ts": "fffb0c0c3ae613282e0447c3e4c122a62f44c776771d525a0ca09759883b4b9e",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/env.ts": "9d0d859303e8cb799d122088f077c54b85258763f2541313be3bf66b58ce33a3",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/format.ts": "bad71315eefd5ad0413841bbe5e8406d636d58d3ed3ef48674655b3a21a0aab0",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/generator.ts": "1e664e9fd4c469e38a0acf5c94fd49dac4f38cb6334563ea4b7fc498b5958877",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/log.ts": "9652d9b7a78fa61d667b6749a35ea02a00927b541d6d4d72e7f3de1881101bde",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/lume_config.ts": "3fa08358cdd2ee4f8279347c4c74e2f457d0aa31ccc2201f85f455d31b620f2b",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/merge_data.ts": "8433920c7e66f27ae558777ed9add637f8c2f67adf9ca2c9ca60d566b9b3583f",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/net.ts": "d0d58c95668effc13669015c219295532f67e4a02396286308c772871b615a9b",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/object.ts": "9b2d1c20503137b612fcbb311b42d1f5500ae170b68f1dca43cc6b057423bc6e",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/page_content.ts": "bbadb588f9d9fcf1a2af156ce4b68974dfad39b65c3c8d42a6f1895b194c7eec",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/page_date.ts": "2a3d9c203df298ca61f568fdf509945f127f990769623c3edfd753d39807b757",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/page_url.ts": "e292cba024f66d35b1b622f9ac13e0910b0ed5ce12c368bd8014e03c1bb0b063",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/path.ts": "7a1d199113928cc35782aa3262cbe6f7a4894bc262d7d300de9385b3da45602f",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/read.ts": "9a0c87095be118bb599eeebba78613d5b3b1cf6c51c3b4c8016af45675bc7303",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/utils/tokens.ts": "201777343e716403bfb1dbbc1a988a85b8d3f12699daaacbe8bbdc3c352a57ff",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/watcher.ts": "9bdb33b2dac840b65545a894c6faecfd31064cc37852dc175081a2048548a89d",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/core/writer.ts": "e8952538d57c0b587a3e9344b9b10d1b71274aca234b927b05a09c88ac3f4304",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/cli.ts": "fcea058cee81b393f64bea58b2ce2f08db4244cd505961b446422829578bc756",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/colors.ts": "01c038ca4f8ad503ae0c81338223e3e9e1cbcaf0a14cc12bb6cd6c12f249df98",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/crypto.ts": "0939b1e974472d1db1d611b4160a5a51d796da1368289277d2e26803243959d5",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/debugbar.ts": "4eadd99ef215d181cd68e141e95716a5172c23dd8bb958605c0df4a164dfa0db",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/dom.ts": "08bdf42363093cae0e0a3f6efb3c500cfc8a7a6ab09d73fa69d212a6c907d547",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/esbuild.ts": "6c2bf654e6085267c35d38fe2bdd5e729de94f91bc2438a3e3fe745c64cd5f9f",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/front_matter.ts": "f5e5780d4a0502d50cde1f42a4aa7830756dc9bd0251ba7448cecd1eaa60878f",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/fs.ts": "7822d6d2692842fff18d19bcec6543e3c9a52216d10f32d6d949a956299490ec",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/hex.ts": "828718f24a780ff3ade8d0a8a5b57497cb31c257560ef12af99b6eb1a31e3bbd",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/http.ts": "fa15ee0e4827c6c643bf715ebd9144535d753ed003e17bb699a7abb2d9639d54",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/jsonc.ts": "79f0eddc3c9e593310eb8e5918eb1506b1c7d7816e4ecb96894f634ecbe626ff",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/lightningcss.ts": "9ae4e32c6b6854d5a2b955970a0f2143853511a329b275102423044b67c9c514",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/markdown_it.ts": "24c1c0fd18c99b9067d9ff5d051f934cb7c3446e6afbad934f6268af8d1ceb4d",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/path.ts": "4f0c817d8570664560aa77e6e38184c95dc66b18fac9c2a83c6b719ef28f85ee",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/semver.ts": "2002761250eb5e2ed7989c5a0e3ad637bb1bbb90adcfac9feae1c3aaa0c1eaf2",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/toml.ts": "151769d4382d8a4245e6d2e0ed5341a18216cdfc2b98c43fccaf5af957b47534",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/vento.ts": "40838402d72e8d2353ae75673cc76830b3593506d6cf2cce2edd209fe35c6896",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/deps/yaml.ts": "ee79a110ac7f97ac7821792246ff29a9a4831d35ecc96f3dd543dc7a4ffd70c9",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/middlewares/expires.ts": "998d3a1b6791fe0da589a8193be00f4aaa6988ca19407bd12731e5a32fbf9705",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/middlewares/not_found.ts": "0f92cd91239444247a1c3dce1bed4e978445687ca76f544a0ccd483a352f761a",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/mod.ts": "349b3b7fe199bc6703b1e1fb77f3ab92699fce966da2261d3419a951b1ef2c5d",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/plugins/json.ts": "5c49499e56b919ec848d4118ec97dd4fe0a323a6cc4c648dc45ab55297614c12",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/plugins/markdown.ts": "7e82d897c1e35bf119dcd18b6aec7a6ba5aa06848897b34ff9cd161ec7c8757e",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/plugins/modules.ts": "4e177c0ffe972b9deef10db2bf0ae52b405418af4dbac03db9e7ffbd6a3ec6ae",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/plugins/paginate.ts": "6a1a9a24d0fabed2f722a6a6f29d98559219c69475685034181816e82d367f2e",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/plugins/search.ts": "5acb5be828bbbd012fb9226cb97ec3e370d43d05aa44d16e7e7d50bab368b442",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/plugins/toml.ts": "e5bf35ed4915587acd453f002b00ae9b88c1782cadc25c703d7642a390af43ea",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/plugins/url.ts": "15f2e80b6fcbf86f8795a3676b8d533bab003ac016ff127e58165a6ac3bffc1a",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/plugins/vento.ts": "fd60ee80435994bcf88b2cda9c51eaed0ba49a2363f42920675f2d5a0a4a6ab2",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/plugins/yaml.ts": "d0ebf37c38648172c6b95c502753a3edf60278ab4f6a063f3ca00f31e0dd90cc",
+    "https://cdn.jsdelivr.net/gh/lumeland/lume@3.1.2/types.ts": "5f580502f366b9b25106eb72d49b30d9af7715c8a304fe6e21f382d3c2a4cc38",
+    "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.14/css.ts": "591f596af15a1e16d0eb81e99b4587b1244c2811a509209de01a1066e223719a",
+    "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.14/html.ts": "c0b93e7486db5fd32e2454bf546afcf5aa6e8c2b58df357ca2d501c12f7740b1",
+    "https://cdn.jsdelivr.net/gh/oscarotero/ssx@0.1.14/jsx-runtime.ts": "3ae5db3a19a935404b2ecef7937d1aa7c7d001469ad56d1fd5f446fac6c46111",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/core/environment.ts": "140076e560d4d6e3ab8ecfee28fd10909d9c0f680138129a908a61076b52f768",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/core/errors.ts": "8606b682b465d598a394feea135dd2f84033b5ef2a61a23d116ccb782a0a547a",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/core/js.ts": "83084240150d7e8b83e43ec8fcf78564a8ba8599c3d517976efbb11b208903b2",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/core/reserved.ts": "e3ccafb4e5524b9c51fa14fa0e4bf17fd9bdd791848f17afa2aeb97835c486d1",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/core/tokenizer.ts": "460faa3de0e561e5046c46528c8bcbfc46b9de576af7ec8c4a8954a61a80ec76",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/loaders/file.ts": "83f579ac39838642bb45c6ddf48c05c08134cdd95fa7364d004fb443e972196a",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/mod.ts": "26081287509a87d81c51917795ff94ea80056c43599af8140bb5f666f0aaa767",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/auto_trim.ts": "716fab2949f083752722eade3cf4f84dbfafd2b671b85709013771d68b637ea4",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/echo.ts": "26109b7d47d33621dd764136be665052a48b3e68aeda2bd961504702f14c829f",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/escape.ts": "1db6eb7b22f88bbf94d21636c9b156ec4868e10bbcfa7dc5eae7113c36ef7b8a",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/export.ts": "c1f25c8e1e35027cc21e780f8fb3961febec4771463eb262959fbf035b8b8a63",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/for.ts": "a893a3de2c5cab43d5018cb80718ea46377c172d550e7a8ead076f00c58d59bf",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/function.ts": "472bdbe0bffb7d38c59003b02510cf85a78a35927219bc6a02ac2d4fde8b6597",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/if.ts": "db13776a5b9e7988f65c27943c344bec7463c5f3162a06cc4da1a313d7109195",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/import.ts": "b6fb6cc922c0897d15918d10766bbbd51069336780acdc8bbf23922ed870a1b3",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/include.ts": "0f473f75064be27d3c53329f2769bf0cc8bd520f04432ef94d99ebeae2e51ad1",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/js.ts": "f5a7fd8cc48cb1b1dc0b396e3d1fee4664cf28932dc5f5f301e38243e0e987dc",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/layout.ts": "09e4b29614c66847b4d9fac4f5eb3edae9159a9a85e2d22058b722ac84f367ea",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/mod.ts": "017d5bb3e3c80b7f67271cdf8779686f55916070c5d168a143e6a37c35bcd731",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/set.ts": "cbe42b771a04203b6fc1c178e655fa2536ab90ae67e52c083cf7c71f37c62711",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/trim.ts": "8d33271327b09ffd8f569ebde85125b1324fa9538a54d6072ac97a9fb5d24264",
+    "https://cdn.jsdelivr.net/gh/ventojs/vento@2.2.0/plugins/unescape.ts": "1c56f0310c7757880df7684fc6b7bf9efd27fdb6b929b89626802f5a99cb93ee",
     "https://deno.land/std@0.120.0/async/deadline.ts": "1d6ac7aeaee22f75eb86e4e105d6161118aad7b41ae2dd14f4cfd3bf97472b93",
     "https://deno.land/std@0.120.0/async/debounce.ts": "b2f693e4baa16b62793fd618de6c003b63228db50ecfe3bd51fc5f6dc0bc264b",
     "https://deno.land/std@0.120.0/async/deferred.ts": "ab60d46ba561abb3b13c0c8085d05797a384b9f182935f051dc67136817acdee",
@@ -2514,12 +2819,14 @@
       "jsr:@deno/doc@0.187.0",
       "jsr:@orama/core@^1.2.4",
       "jsr:@std/assert@^1.0.6",
+      "jsr:@std/cli@^1.0.27",
       "jsr:@std/dotenv@~0.225.2",
       "jsr:@std/front-matter@1.0.9",
       "jsr:@std/fs@^1.0.16",
       "jsr:@std/html@^1.0.3",
       "jsr:@std/media-types@^1.0.3",
       "jsr:@std/path@^1.0.8",
+      "jsr:@std/yaml@^1.0.11",
       "npm:@octokit/core@^5.2.0",
       "npm:googleapis@144",
       "npm:leo-profanity@^1.7.0",


### PR DESCRIPTION
## Summary

Removes `"lock": false` from `deno.json` and refreshes the committed `deno.lock`, so Deno Deploy builds of this repo produce artifacts that boot reliably.

Since 2026-07-02, deploys of this site have been failing warmup with:

```
JSR package version manifest for '@std/encoding@1.0.11' failed to load:
Specifier not found in cache: "https://jsr.io/@std/encoding/1.0.11_meta.json", --cached-only is specified.
```

Root cause (upstream: denoland/deno#35879): without a lockfile, `deno cache` and `deno run --cached-only` can resolve the same JSR semver range to **different versions**. In this repo, Lume pins `jsr:@std/encoding@1.0.10` on a type-only import path while `jsr:@std/http@1.0.22/etag.ts` requires `^1.0.10`; the build's cache step unifies the range onto `1.0.10`, but the deployed runtime (which Deno Deploy starts with `--cached-only`) re-resolves `^1.0.10` to `1.0.11` — a version the artifact never contained. The moment `@std/encoding@1.0.11` was published, every lockfile-less build became unbootable, with no change to this repo.

A lockfile pins build and runtime to the same resolution, which removes the divergence structurally. The `deno.lock` in this repo has been committed all along but was **ignored** because of `"lock": false` (it had gone stale since #2798); this PR re-enables it and refreshes it.

`"lock": false` was originally carried along with Lume upgrades (#2793/#2798) rather than deliberately chosen, so this should be safe to remove; if lockfile churn on future Lume upgrades becomes annoying again, prefer regenerating the lockfile in the upgrade PR over disabling it — deploys depend on it now.

## Testing

- Regenerated `deno.lock` via `deno install --allow-scripts` + `deno cache --allow-import server.ts`; the lockfile now records `"jsr:@std/encoding@^1.0.10": "1.0.10"`.
- Reproduced the incident path locally with a fresh `DENO_DIR`: before this change, `deno cache server.ts` followed by `deno run -A --cached-only --unstable-npm-lazy-caching server.ts` (the flags Deno Deploy uses) fails with the error above; with this change it boots (`Listening on http://localhost:8000`).
