### PR TITLE
docs: clarify Deno.cron runtime behavior

### DIFF
--- a/deploy/reference/cron.md
+++ b/deploy/reference/cron.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-03-02
+last_modified: 2026-07-08
 title: Cron
 description: "Scheduling and managing cron jobs in Deno Deploy, including defining cron jobs in code, execution lifecycle, retries, and observability."
 ---
@@ -8,9 +8,9 @@ Cron jobs are scheduled tasks that run automatically on a defined schedule. You
 define cron jobs in your code using the `Deno.cron()` API, deploy your
 application, and the platform discovers and runs them on schedule.
 
-[`Deno.cron()`](/runtime/fundamentals/cron/) is a Deno runtime API — it ships
-with Deno itself. Deno Deploy builds on top of that runtime API: it discovers
-your `Deno.cron()` definitions at deployment time, schedules and invokes them,
+[`Deno.cron()`](/api/deno/~/Deno.cron) is a Deno runtime API — it ships with
+Deno itself. Deno Deploy builds on top of that runtime API: it discovers your
+`Deno.cron()` definitions at deployment time, schedules and invokes them,
 handles retries, and surfaces runs in the dashboard and logs, so you don't need
 to keep a long-running process up yourself.
 
@@ -19,11 +19,9 @@ to keep a long-running process up yourself.
 `Deno.cron()` takes a human-readable name, a schedule, and a handler function.
 The name identifies the cron job in the dashboard and logs, the schedule
 determines when it fires, and the handler contains the code to run on each
-invocation. The schedule can be either a standard
-[5-field cron expression](https://en.wikipedia.org/wiki/Cron#UNIX-like) or a
-structured object. All times are UTC — this avoids ambiguity around daylight
-saving transitions. See the
-[full API reference](https://docs.deno.com/api/deno/~/Deno.cron) for details.
+invocation.
+
+The schedule can be either a 5-field cron expression or a structured object.
 
 ```typescript
 Deno.cron("cleanup-old-data", "0 * * * *", () => {
@@ -32,7 +30,7 @@ Deno.cron("cleanup-old-data", "0 * * * *", () => {
 
 Deno.cron(
   "sync-data",
-  "*/15 * * * *",
+  { minute: { every: 15 } },
   {
     backoffSchedule: [1000, 5000, 10000],
   },
@@ -41,6 +39,12 @@ Deno.cron(
   },
 );
 ```
+
+:::info
+
+See the Deno.cron [runtime docs](/runtime/fundamentals/cron/) for more details.
+
+:::
 
 ### Common schedule expressions
 

--- a/runtime/fundamentals/cron.md
+++ b/runtime/fundamentals/cron.md
@@ -44,7 +44,8 @@ Deno.cron("hourly-task", { hour: { every: 1 } }, () => {
 
 :::note
 
-All times are UTC — this avoids ambiguity around daylight saving transitions.
+All times are **UTC** — this avoids ambiguity around daylight saving
+transitions.
 
 :::
 
@@ -80,18 +81,15 @@ Each field accepts an exact value, `*` (every value), a range (`1-5`), a list
 
 :::note
 
-Unlike traditional UNIX cron engines (which use `0-6` where `0` is Sunday), Deno
-maps numeric days of the week from **1** to **7** (1 = Sunday, 7 = Saturday).
+Unlike traditional UNIX cron engines (which use `0–6`, where `0` is Sunday),
+Deno maps numeric days of the week as **`1–7`** (where `1` is Sunday and `7` is
+Saturday).
 
 :::
 
 ### Advanced Features
 
 Deno's parser introduces powerful features for advanced scheduling:
-
-- **Wraparound Ranges:** Inverted ranges that cross time boundaries are
-  supported. Useful for night-time windows or end-of-month + start-of-next-month
-  logic.
 
 - **Last Day of Month:** Specifying `L` in the _Day of Month_ field triggers the
   task on the exact last day of the current month (28, 29, 30, or 31).\
@@ -103,25 +101,31 @@ Deno's parser introduces powerful features for advanced scheduling:
   `LW` or `L-<offset>W` works relative to the end of the month.
 
 - **Last Day of Week:** Specifying `<day>L` triggers on the last specific day of
-  the week in that month. Standalone `L` is equivalent to `7L`.
+  the week in that month. However, a standalone `L` is simply equivalent to `7`
+  (every Saturday).
 
 - **N-th Day of Week:** `<day>#<nth>` triggers on the n-th specific day of the
   week in a month. The `<nth>` value can be from `1` to `5`.
 
+- **Wraparound Ranges:** Inverted ranges that cross time boundaries are
+  supported. Useful for night-time windows or end-of-month + start-of-next-month
+  logic. Note: plain wraparound ranges are processed by including one value
+  prior to the start bound (e.g., `31-1` is `30,31,1`).
+
 ### Examples
 
-| Expression              | Description                                               |
-| ----------------------- | --------------------------------------------------------- |
-| `0 9 * * 2-6`           | Every weekday at 09:00                                    |
-| `5/10 8-18 * * *`       | Every 10 minutes starting at :05, between 8 AM and 6 PM   |
-| `59-0 23-0 31-1 12-1 *` | From end of December to beginning of January (wraparound) |
-| `0 0 L * *`             | Last day of every month at midnight                       |
-| `0 0 LW * *`            | Last weekday of every month at midnight                   |
-| `0 0 L-30W * *`         | Nearest weekday to (end of month - 30 days) at midnight   |
-| `0 0 1W * *`            | Nearest weekday to the 1st of the month at midnight       |
-| `0 0 * * 7L`            | Last Saturday of every month at midnight                  |
-| `0 0 * * MON#2`         | Second Monday of every month at midnight                  |
-| `*/10 20-4 * * *`       | Every 10 minutes during night hours (wraparound)          |
+| Expression              | Description                                                                                                                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0 9 * * 2-6`           | Every weekday at 09:00                                                                                                                                                        |
+| `5/10 8-18 * * *`       | Every 10 minutes starting at :05, between 8 AM and 6 PM                                                                                                                       |
+| `0 0 L * *`             | Last day of every month at midnight                                                                                                                                           |
+| `0 0 LW * *`            | Last weekday of every month at midnight                                                                                                                                       |
+| `0 0 L-30W * *`         | Nearest weekday to (end of month - 30 days) at midnight                                                                                                                       |
+| `0 0 1W * *`            | Nearest weekday to the 1st of the month at midnight                                                                                                                           |
+| `0 0 * * 7L`            | Last Saturday of every month at midnight                                                                                                                                      |
+| `0 0 * * MON#2`         | Second Monday of every month at midnight                                                                                                                                      |
+| `50-10/10 * * * *`      | Every 10 minutes in range (00:50, 01:00, 01:10)                                                                                                                               |
+| `59-0 23-0 31-1 12-1 *` | Tricky example. It is **not** _"from the end of December to the beginning of January"_. Invocations will occur at specific times, such as Nov 30 at 22:58 and Dec 1 at 00:00. |
 
 ## Retries and backoff
 

--- a/runtime/fundamentals/cron.md
+++ b/runtime/fundamentals/cron.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-18
+last_modified: 2026-07-08
 title: "Cron"
 description: "Schedule recurring tasks in Deno with the Deno.cron() runtime API, an unstable feature enabled via --unstable-cron."
 ---
@@ -27,41 +27,101 @@ reference</a>
 
 [`Deno.cron()`](/api/deno/~/Deno.cron) takes a human-readable name, a schedule,
 and a handler function. The name identifies the cron job in logs, the schedule
-determines when the handler fires, and all times are in UTC.
+determines when the handler fires, and the handler contains the code to run on
+each invocation.
+
+The schedule can be either a 5-field cron expression or a structured object.
 
 ```ts
 Deno.cron("log-a-message", "* * * * *", () => {
   console.log("This runs once a minute.");
 });
-```
 
-A 5-field cron expression has one field per time unit, separated by spaces:
-
-```sh
-┌──────────── minute (0-59)
-│ ┌────────── hour (0-23)
-│ │ ┌──────── day of month (1-31)
-│ │ │ ┌────── month (1-12 or JAN-DEC)
-│ │ │ │ ┌──── day of week (0-6 or SUN-SAT, where 0 is Sunday)
-│ │ │ │ │
-* * * * *
-```
-
-Each field accepts an exact value, `*` (every value), a range (`1-5`), a list
-(`1,3,5`), or a step (`*/15` for every fifteenth unit). For example,
-`0 9 * * MON-FRI` runs at 09:00 UTC on weekdays.
-
-The schedule can be a standard 5-field cron expression or a structured object:
-
-```ts
 Deno.cron("hourly-task", { hour: { every: 1 } }, () => {
   console.log("This runs once an hour.");
 });
 ```
 
+:::note
+
+All times are UTC — this avoids ambiguity around daylight saving transitions.
+
+:::
+
 Cron jobs must be registered at the top level of a module, before any server
 starts. Definitions nested inside request handlers, conditionals, or callbacks
 will not be picked up.
+
+## Cron Syntax and Rules
+
+Deno uses a **Saffron-compatible** parser that strictly requires a **5-field**
+format:
+
+```sh
+┌───────────── minute (0-59)
+│ ┌─────────── hour (0-23)
+│ │ ┌───────── day of month (1-31)
+│ │ │ ┌─────── month (1-12 or JAN-DEC)
+│ │ │ │ ┌───── day of week (1-7 or SUN-SAT)
+│ │ │ │ │
+* * * * *
+```
+
+Each field accepts an exact value, `*` (every value), a range (`1-5`), a list
+(`1,3,5`), or a step (`*/15` for every fifteenth unit), plus advanced macros:
+
+| Field        | Allowed Values      | Allowed Special Characters |
+| ------------ | ------------------- | -------------------------- |
+| Minute       | `0-59`              | `*` `-` `,` `/`            |
+| Hour         | `0-23`              | `*` `-` `,` `/`            |
+| Day of Month | `1-31`              | `*` `-` `,` `/` `L` `W`    |
+| Month        | `1-12` or `JAN-DEC` | `*` `-` `,` `/`            |
+| Day of Week  | `1-7` or `SUN-SAT`  | `*` `-` `,` `/` `L` `#`    |
+
+:::note
+
+Unlike traditional UNIX cron engines (which use `0-6` where `0` is Sunday), Deno
+maps numeric days of the week from **1** to **7** (1 = Sunday, 7 = Saturday).
+
+:::
+
+### Advanced Features
+
+Deno's parser introduces powerful features for advanced scheduling:
+
+- **Wraparound Ranges:** Inverted ranges that cross time boundaries are
+  supported. Useful for night-time windows or end-of-month + start-of-next-month
+  logic.
+
+- **Last Day of Month:** Specifying `L` in the _Day of Month_ field triggers the
+  task on the exact last day of the current month (28, 29, 30, or 31).\
+  Specifying `L-<offset>` triggers on the last day minus the offset (e.g., `L-1`
+  is the second-to-last day). The offset can be from `1` to `30`.
+
+- **Nearest Weekday:** Specifying `<day>W` triggers on the closest weekday
+  (Mon–Fri) to the given date.\
+  `LW` or `L-<offset>W` works relative to the end of the month.
+
+- **Last Day of Week:** Specifying `<day>L` triggers on the last specific day of
+  the week in that month. Standalone `L` is equivalent to `7L`.
+
+- **N-th Day of Week:** `<day>#<nth>` triggers on the n-th specific day of the
+  week in a month. The `<nth>` value can be from `1` to `5`.
+
+### Examples
+
+| Expression              | Description                                               |
+| ----------------------- | --------------------------------------------------------- |
+| `0 9 * * 2-6`           | Every weekday at 09:00                                    |
+| `5/10 8-18 * * *`       | Every 10 minutes starting at :05, between 8 AM and 6 PM   |
+| `59-0 23-0 31-1 12-1 *` | From end of December to beginning of January (wraparound) |
+| `0 0 L * *`             | Last day of every month at midnight                       |
+| `0 0 LW * *`            | Last weekday of every month at midnight                   |
+| `0 0 L-30W * *`         | Nearest weekday to (end of month - 30 days) at midnight   |
+| `0 0 1W * *`            | Nearest weekday to the 1st of the month at midnight       |
+| `0 0 * * 7L`            | Last Saturday of every month at midnight                  |
+| `0 0 * * MON#2`         | Second Monday of every month at midnight                  |
+| `*/10 20-4 * * *`       | Every 10 minutes during night hours (wraparound)          |
 
 ## Retries and backoff
 


### PR DESCRIPTION
### Changes

1. Runtime (`runtime/fundamentals/cron.md`)

    * Expanded Cron Syntax section with clear reference table and detailed explanation of supported fields.
    * Added Advanced Features and Examples sections based on `cron.rs` analysis and test cases.

2. Deploy (`deploy/reference/cron.md`)

    * Added reference to the Runtime Docs to avoid information duplication and maintain a single source of truth.
    * Small link fixes.

### Testing

- [x] `deno fmt --check` of both files passes

Closes denoland/deno#21555