### PR TITLE
docs: add /go/minimum-dependency-age go link

### DIFF
--- a/go.json
+++ b/go.json
@@ -28,6 +28,7 @@
   "lint-ignore": "/runtime/reference/cli/lint/#ignore-directives",
   "lint": "/runtime/reference/cli/lint/",
   "lsp": "/runtime/reference/cli/lsp/",
+  "minimum-dependency-age": "/runtime/packages/supply_chain/#minimum-dependency-age",
   "peer-deps": "/runtime/packages/peer_dependencies/",
   "permission-broker": "/runtime/fundamentals/security/#permission-broker",
   "permission-sets": "/runtime/fundamentals/configuration/#permissions",


### PR DESCRIPTION
Adds a `go.json` entry so that `/go/minimum-dependency-age/` redirects to the
Minimum dependency age section of the supply chain security guide
(`/runtime/packages/supply_chain/#minimum-dependency-age`).

This gives a short, stable link to point people at when explaining the
`--minimum-dependency-age` flag and the `minimumDependencyAge` config option.