### PR TITLE
docs: loader hooks don't resolve jsr:/npm:/https: specifiers

### DIFF
--- a/runtime/reference/loader_hooks.md
+++ b/runtime/reference/loader_hooks.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-05-20
+last_modified: 2026-07-09
 title: "Loader hooks"
 description: "Customize module resolution and loading in Deno using the Node.js-compatible module.registerHooks() API. Create virtual modules, transpile custom formats, and intercept imports."
 oldUrl: /runtime/reference/module_hooks/

--- a/runtime/reference/loader_hooks.md
+++ b/runtime/reference/loader_hooks.md
@@ -125,35 +125,6 @@ registerHooks({
 });
 ```
 
-:::info
-
-<strong>`jsr:`, `npm:`, and `https:` specifiers in hook-emitted source are not
-resolved automatically.</strong> Deno discovers and installs external
-dependencies by statically analyzing your module graph <em>before</em>
-execution. Source produced by a `load` hook is generated at load time, after
-that analysis has completed, so any bare `jsr:`, `npm:`, or `https:` import that
-only appears in the emitted source is invisible to dependency resolution. You
-will see errors such as
-`Could not find constraint 'lodash-es@latest' in the list of packages.`
-
-To use an external dependency from hook-generated code, declare it up front so
-it is part of the resolved package set. For example, add it to the `imports` map
-in your `deno.json`:
-
-```json title="deno.json"
-{
-  "imports": {
-    "lodash-es": "npm:lodash-es@latest"
-  }
-}
-```
-
-and import it by its mapped name from the transformed source. This is working as
-designed: dependency resolution is deterministic and lockfile-driven, which
-requires the dependency set to be known ahead of execution.
-
-:::
-
 ### Module aliasing
 
 Redirect imports to different modules:
@@ -232,6 +203,40 @@ const hooks = registerHooks({
 
 hooks.deregister(); // Clean up after tests
 ```
+
+## External dependencies in hook-generated source
+
+:::info
+
+<strong>`jsr:`, `npm:`, and `https:` specifiers are not resolved automatically
+when they appear only in source produced by a hook.</strong> This applies to any
+`load` hook that returns source Deno did not read from disk itself — custom
+transpilation, virtual modules, mocks, and so on.
+
+Deno discovers and installs external dependencies by statically analyzing your
+module graph <em>before</em> execution. Source returned from a `load` hook is
+generated at load time, after that analysis has completed, so any bare `jsr:`,
+`npm:`, or `https:` import that only appears in the emitted source is invisible
+to dependency resolution. You will see errors such as
+`Could not find constraint 'lodash-es@latest' in the list of packages.`
+
+To use an external dependency from hook-generated code, declare it up front so
+it is part of the resolved package set. For example, add it to the `imports` map
+in your `deno.json`:
+
+```json title="deno.json"
+{
+  "imports": {
+    "lodash-es": "npm:lodash-es@latest"
+  }
+}
+```
+
+and import it by its mapped name from the generated source. This is working as
+designed: dependency resolution is deterministic and lockfile-driven, which
+requires the dependency set to be known ahead of execution.
+
+:::
 
 ## The `resolve` hook
 

--- a/runtime/reference/loader_hooks.md
+++ b/runtime/reference/loader_hooks.md
@@ -125,6 +125,35 @@ registerHooks({
 });
 ```
 
+:::info
+
+<strong>`jsr:`, `npm:`, and `https:` specifiers in hook-emitted source are not
+resolved automatically.</strong> Deno discovers and installs external
+dependencies by statically analyzing your module graph <em>before</em>
+execution. Source produced by a `load` hook is generated at load time, after
+that analysis has completed, so any bare `jsr:`, `npm:`, or `https:` import that
+only appears in the emitted source is invisible to dependency resolution. You
+will see errors such as
+`Could not find constraint 'lodash-es@latest' in the list of packages.`
+
+To use an external dependency from hook-generated code, declare it up front so
+it is part of the resolved package set. For example, add it to the `imports` map
+in your `deno.json`:
+
+```json title="deno.json"
+{
+  "imports": {
+    "lodash-es": "npm:lodash-es@latest"
+  }
+}
+```
+
+and import it by its mapped name from the transformed source. This is working as
+designed: dependency resolution is deterministic and lockfile-driven, which
+requires the dependency set to be known ahead of execution.
+
+:::
+
 ### Module aliasing
 
 Redirect imports to different modules:


### PR DESCRIPTION
The Loader hooks reference didn't mention that external specifiers introduced
by hook-emitted source aren't resolved automatically. This trips people up when
they use a `load` hook to transpile a custom format (e.g. Civet, CoffeeScript)
whose output imports an npm or jsr package.

The reason is that Deno discovers and installs dependencies by statically
analyzing the module graph before execution, whereas hook-generated source is
produced at load time, after that analysis has finished. A bare `jsr:`, `npm:`,
or `https:` import that only appears in the emitted source is therefore invisible
to dependency resolution and fails with an error like
`Could not find constraint 'lodash-es@latest' in the list of packages.`

This adds an info box to the Custom transpilation use case documenting the
limitation, explaining why it happens, and showing the workaround of declaring
the dependency in `deno.json` up front. This is working as designed, so the docs
should set the expectation.

Refs denoland/deno#35896