### PR TITLE
docs: clarify that --allow-sys=inspector is not read-only

### DIFF
--- a/runtime/reference/permissions.md
+++ b/runtime/reference/permissions.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-29
+last_modified: 2026-07-09
 title: "Permissions"
 description: "Reference for Deno's permission system: how the runtime sandbox works and how to grant or deny file system, network, environment, system, subprocess, FFI, and import access with the --allow and --deny flags."
 oldUrl:
@@ -385,7 +385,7 @@ deno run --deny-sys script.ts
 The interface names accepted by `--allow-sys` correspond to the functions in the
 `Deno` namespace that expose host information, such as `hostname`, `osRelease`,
 `osUptime`, `loadavg`, `networkInterfaces`, `systemMemoryInfo`, `uid`, `gid`,
-`username`, `cpus`, and `homedir`. See
+`username`, `cpus`, `homedir`, and `inspector`. See
 [Deno.SysPermissionDescriptor](/api/deno/~/Deno.SysPermissionDescriptor) for the
 full set of recognized names.
 
@@ -397,6 +397,24 @@ system information, such as `os.hostname()`, `os.cpus()`,
 the same interface names. For example, calling `os.cpus()` needs
 `--allow-sys=cpus`, and `os.networkInterfaces()` needs
 `--allow-sys=networkInterfaces`.
+
+:::caution `--allow-sys` is not purely read-only
+
+Unlike the other names, `inspector` does not read host information. It gates
+connecting to [`node:inspector`](/api/node/inspector/), which opens a Chrome
+DevTools Protocol (CDP) session against the current isolate. CDP is a powerful
+capability: it can evaluate expressions and set breakpoints in scopes that are
+otherwise inaccessible to user code, which can be abused to reach Deno's
+internal functions and bypass the permission model. Treat
+`--allow-sys=inspector` as a high-privilege grant, not as read-only access to
+system information.
+
+Because a bare `--allow-sys` (or `-S`) enables every interface, it includes
+`inspector`. When running untrusted code, prefer granting only the specific
+interfaces you need (for example `--allow-sys=hostname,osRelease`) and avoid
+granting `inspector` unless the program genuinely needs the debugger.
+
+:::
 
 ## Subprocesses
 


### PR DESCRIPTION
The System Information section of the permissions reference presents
`--allow-sys` as a low-risk, read-only permission that only exposes host
information like the OS release, uptime, load average, network interfaces,
and memory usage. That framing is incomplete: the same flag also accepts an
`inspector` interface name, and `--allow-sys=inspector` gates connecting to
`node:inspector`.

`node:inspector` is not read-only. It opens a Chrome DevTools Protocol
session against the current isolate, which can evaluate expressions and set
breakpoints in scopes that are otherwise inaccessible to user code. That is a
meaningfully higher-privilege capability than reading system information, so
treating a bare `--allow-sys` (which enables every interface, including
`inspector`) as harmless is misleading.

This adds `inspector` to the documented list of recognized interface names and
adds a caution admonition explaining that `--allow-sys=inspector` should be
treated as a high-privilege grant. It recommends granting only the specific
interfaces a program needs when running untrusted code, rather than a blanket
`--allow-sys`.