### PR TITLE
docs(desktop): move desktop APIs under Deno.desktop namespace

### DIFF
--- a/runtime/desktop/auto_update.md
+++ b/runtime/desktop/auto_update.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-10
 title: "Auto-update"
 description: "Ship binary-diff updates to deno desktop apps with Deno.desktop.autoUpdate(): bsdiff patches, manifest polling, automatic rollback on failed launch."
 ---

--- a/runtime/desktop/auto_update.md
+++ b/runtime/desktop/auto_update.md
@@ -46,16 +46,16 @@ Two pieces of configuration are required:
    ```
 
 Both are baked into the compiled binary. The version is exposed at runtime as
-[`Deno.desktop.desktopVersion`](/api/deno/~/Deno.desktop.desktopVersion):
+[`Deno.desktop.appVersion`](/api/deno/~/Deno.desktop.appVersion):
 
 ```ts
-console.log(Deno.desktop.desktopVersion); // "1.4.0", or null if no version was set
+console.log(Deno.desktop.appVersion); // "1.4.0", or null if no version was set
 ```
 
-If [`Deno.desktop.desktopVersion`](/api/deno/~/Deno.desktop.desktopVersion) is
-`null`, [`Deno.desktop.autoUpdate()`](/api/deno/~/Deno.desktop.autoUpdate) is a
-no-op: the runtime warns once and returns. This is also what happens under
-`deno run`, since a non-compiled program has no baked-in version.
+If [`Deno.desktop.appVersion`](/api/deno/~/Deno.desktop.appVersion) is `null`,
+[`Deno.desktop.autoUpdate()`](/api/deno/~/Deno.desktop.autoUpdate) is a no-op:
+the runtime warns once and returns. This is also what happens under `deno run`,
+since a non-compiled program has no baked-in version.
 [`Deno.desktop.autoUpdate()`](/api/deno/~/Deno.desktop.autoUpdate) does not
 throw there, so you can leave the call in your code and run the same entry point
 with `deno run` during development.
@@ -107,7 +107,7 @@ is an object carrying the patch filename and its **SHA-256 hash**:
 
 | Field     | Meaning                                                                                                                                                          |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version` | The latest available version. Compared with [`Deno.desktop.desktopVersion`](/api/deno/~/Deno.desktop.desktopVersion).                                            |
+| `version` | The latest available version. Compared with [`Deno.desktop.appVersion`](/api/deno/~/Deno.desktop.appVersion).                                                    |
 | `patches` | Map of from-version → `{ name, sha256 }`. `name` is the patch filename relative to the manifest's URL; `sha256` is the lowercase hex SHA-256 of the patch bytes. |
 
 The `sha256` is **required**: the runtime refuses to apply a patch whose bytes
@@ -151,9 +151,9 @@ Deno.desktop.autoUpdate({
 
 1. **Fetch manifest.** `GET <url>/latest.json`. On a non-2xx response, the check
    silently returns and waits for the next interval.
-2. **Compare versions.** If `manifest.version === Deno.desktop.desktopVersion`,
+2. **Compare versions.** If `manifest.version === Deno.desktop.appVersion`,
    nothing to do.
-3. **Look up a patch.** `manifest.patches[Deno.desktop.desktopVersion]` →
+3. **Look up a patch.** `manifest.patches[Deno.desktop.appVersion]` →
    `{ name, sha256 }`.
 4. **Download the patch.** `GET <url>/<name>`. The whole patch is buffered into
    memory; for typical bsdiff outputs (a few MB) this is fine.

--- a/runtime/desktop/auto_update.md
+++ b/runtime/desktop/auto_update.md
@@ -1,7 +1,7 @@
 ---
 last_modified: 2026-06-25
 title: "Auto-update"
-description: "Ship binary-diff updates to deno desktop apps with Deno.autoUpdate(): bsdiff patches, manifest polling, automatic rollback on failed launch."
+description: "Ship binary-diff updates to deno desktop apps with Deno.desktop.autoUpdate(): bsdiff patches, manifest polling, automatic rollback on failed launch."
 ---
 
 :::info Available in Deno 2.9
@@ -11,11 +11,12 @@ version, [update Deno](/runtime/reference/cli/upgrade/) to use it.
 
 :::
 
-[`Deno.autoUpdate()`](/api/deno/~/Deno.autoUpdate) polls a release server for
-new versions, downloads binary-diff patches, applies them to the runtime dylib,
-and stages the result for the next launch. If the next launch fails, the runtime
-rolls back to the previous version automatically. Updates ship as small `bsdiff`
-patches instead of full binary downloads, with rollback baked into the launcher.
+[`Deno.desktop.autoUpdate()`](/api/deno/~/Deno.desktop.autoUpdate) polls a
+release server for new versions, downloads binary-diff patches, applies them to
+the runtime dylib, and stages the result for the next launch. If the next launch
+fails, the runtime rolls back to the previous version automatically. Updates
+ship as small `bsdiff` patches instead of full binary downloads, with rollback
+baked into the launcher.
 
 :::note Platform support
 
@@ -45,24 +46,24 @@ Two pieces of configuration are required:
    ```
 
 Both are baked into the compiled binary. The version is exposed at runtime as
-[`Deno.desktopVersion`](/api/deno/~/Deno.desktopVersion):
+[`Deno.desktop.desktopVersion`](/api/deno/~/Deno.desktop.desktopVersion):
 
 ```ts
-console.log(Deno.desktopVersion); // "1.4.0", or null if no version was set
+console.log(Deno.desktop.desktopVersion); // "1.4.0", or null if no version was set
 ```
 
-If [`Deno.desktopVersion`](/api/deno/~/Deno.desktopVersion) is `null`,
-[`Deno.autoUpdate()`](/api/deno/~/Deno.autoUpdate) is a no-op: the runtime warns
-once and returns. This is also what happens under `deno run`, since a
-non-compiled program has no baked-in version.
-[`Deno.autoUpdate()`](/api/deno/~/Deno.autoUpdate) does not throw there, so you
-can leave the call in your code and run the same entry point with `deno run`
-during development.
+If [`Deno.desktop.desktopVersion`](/api/deno/~/Deno.desktop.desktopVersion) is
+`null`, [`Deno.desktop.autoUpdate()`](/api/deno/~/Deno.desktop.autoUpdate) is a
+no-op: the runtime warns once and returns. This is also what happens under
+`deno run`, since a non-compiled program has no baked-in version.
+[`Deno.desktop.autoUpdate()`](/api/deno/~/Deno.desktop.autoUpdate) does not
+throw there, so you can leave the call in your code and run the same entry point
+with `deno run` during development.
 
 ## Calling `autoUpdate()`
 
 ```ts
-Deno.autoUpdate({
+Deno.desktop.autoUpdate({
   url: "https://releases.example.com/my-app",
   interval: 60 * 60 * 1000, // hourly
   onUpdateReady(version) {
@@ -77,7 +78,7 @@ Deno.autoUpdate({
 Or pass a URL string for a single one-shot check on startup:
 
 ```ts
-Deno.autoUpdate("https://releases.example.com/my-app");
+Deno.desktop.autoUpdate("https://releases.example.com/my-app");
 ```
 
 | Option          | Type                        | Notes                                                                                                         |
@@ -106,7 +107,7 @@ is an object carrying the patch filename and its **SHA-256 hash**:
 
 | Field     | Meaning                                                                                                                                                          |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `version` | The latest available version. Compared with [`Deno.desktopVersion`](/api/deno/~/Deno.desktopVersion).                                                            |
+| `version` | The latest available version. Compared with [`Deno.desktop.desktopVersion`](/api/deno/~/Deno.desktop.desktopVersion).                                            |
 | `patches` | Map of from-version → `{ name, sha256 }`. `name` is the patch filename relative to the manifest's URL; `sha256` is the lowercase hex SHA-256 of the patch bytes. |
 
 The `sha256` is **required**: the runtime refuses to apply a patch whose bytes
@@ -123,7 +124,8 @@ endpoint.
 ### Signed manifests
 
 For tamper protection beyond TLS, sign the manifest with an Ed25519 key and pass
-the public key to [`Deno.autoUpdate()`](/api/deno/~/Deno.autoUpdate). When a
+the public key to
+[`Deno.desktop.autoUpdate()`](/api/deno/~/Deno.desktop.autoUpdate). When a
 `publicKey` is configured, the manifest must be an envelope:
 
 ```json
@@ -139,7 +141,7 @@ depending on a canonical-JSON implementation, the real manifest is embedded
 verbatim as the `signed` string and only its contents are trusted.
 
 ```ts
-Deno.autoUpdate({
+Deno.desktop.autoUpdate({
   url: "https://releases.example.com/my-app",
   publicKey: "<base64-encoded 32-byte Ed25519 public key>",
 });
@@ -149,9 +151,9 @@ Deno.autoUpdate({
 
 1. **Fetch manifest.** `GET <url>/latest.json`. On a non-2xx response, the check
    silently returns and waits for the next interval.
-2. **Compare versions.** If `manifest.version === Deno.desktopVersion`, nothing
-   to do.
-3. **Look up a patch.** `manifest.patches[Deno.desktopVersion]` →
+2. **Compare versions.** If `manifest.version === Deno.desktop.desktopVersion`,
+   nothing to do.
+3. **Look up a patch.** `manifest.patches[Deno.desktop.desktopVersion]` →
    `{ name, sha256 }`.
 4. **Download the patch.** `GET <url>/<name>`. The whole patch is buffered into
    memory; for typical bsdiff outputs (a few MB) this is fine.
@@ -183,8 +185,8 @@ anything else runs, using three files next to the runtime dylib:
 - If `<dylib>.backup` exists but `<dylib>.update-ok` does not, the last update
   started but never confirmed, meaning it crashed during startup. The launcher
   restores `<dylib>.backup` over the dylib, rolling back. The next
-  [`Deno.autoUpdate()`](/api/deno/~/Deno.autoUpdate) call then fires
-  `onRollback` with the reason.
+  [`Deno.desktop.autoUpdate()`](/api/deno/~/Deno.desktop.autoUpdate) call then
+  fires `onRollback` with the reason.
 
 This makes broken updates self-healing. Users do not need to know anything
 happened beyond seeing the same version they had before.
@@ -220,7 +222,7 @@ keys and pick on the client:
 
 ```ts
 const arch = Deno.build.os + "-" + Deno.build.arch;
-Deno.autoUpdate({
+Deno.desktop.autoUpdate({
   url: "https://releases.example.com/" + arch,
   interval: 60 * 60 * 1000,
 });

--- a/runtime/desktop/bindings.md
+++ b/runtime/desktop/bindings.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-10
 title: "Bindings"
 description: "Call Deno-side functions from webview JavaScript via win.bind(): type-safe RPC over in-process channels, encoded at the boundary with no cross-process round-trip."
 ---

--- a/runtime/desktop/bindings.md
+++ b/runtime/desktop/bindings.md
@@ -145,15 +145,15 @@ Bindings are per-window. A binding registered on `winA` is not callable from
 `winB`'s webview. To share, register on each window:
 
 ```ts
-function bindShared(win: Deno.BrowserWindow) {
+function bindShared(win: Deno.desktop.BrowserWindow) {
   win.bind("now", () => Date.now());
   win.bind("readSettings", readSettings);
 }
 
-const main = new Deno.BrowserWindow(); // adopts the startup window
+const main = new Deno.desktop.BrowserWindow(); // adopts the startup window
 bindShared(main);
 
-const settings = new Deno.BrowserWindow();
+const settings = new Deno.desktop.BrowserWindow();
 bindShared(settings);
 ```
 

--- a/runtime/desktop/configuration.md
+++ b/runtime/desktop/configuration.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-30
+last_modified: 2026-07-10
 title: "Configuration"
 description: "Configure deno desktop in deno.json: app metadata, icons, deep-link URL schemes, backend selection, output paths, error reporting, and the auto-update server."
 ---

--- a/runtime/desktop/configuration.md
+++ b/runtime/desktop/configuration.md
@@ -227,8 +227,8 @@ patch flow.
 ```
 
 This is the **only** server URL the runtime polls automatically.
-[`Deno.autoUpdate()`](/api/deno/~/Deno.autoUpdate) defaults to this URL, but can
-override it per call.
+[`Deno.desktop.autoUpdate()`](/api/deno/~/Deno.desktop.autoUpdate) defaults to
+this URL, but can override it per call.
 
 ## `errorReporting`
 

--- a/runtime/desktop/devtools.md
+++ b/runtime/desktop/devtools.md
@@ -66,7 +66,7 @@ original source if the bundler emits maps.
 
 If you only want to debug one side, use the per-target endpoints in the DevTools
 target list, or use
-[`Deno.BrowserWindow.openDevtools()`](/api/deno/~/Deno.BrowserWindow.openDevtools)
+[`Deno.desktop.BrowserWindow.openDevtools()`](/api/deno/~/Deno.desktop.BrowserWindow.openDevtools)
 from your own code:
 
 ```ts

--- a/runtime/desktop/devtools.md
+++ b/runtime/desktop/devtools.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-10
 title: "DevTools"
 description: "Attach Chrome DevTools to a deno desktop app: a single session shows both the Deno runtime V8 and the renderer V8 as inspectable targets."
 ---

--- a/runtime/desktop/distribution.md
+++ b/runtime/desktop/distribution.md
@@ -261,5 +261,5 @@ in the output directory) externally for now, e.g.
 ## Distributing updates after release
 
 Once your binary is in users' hands, ship updates via
-[`Deno.autoUpdate()`](/runtime/desktop/auto_update/): `bsdiff` patches shipped
-from your own server, no app store required.
+[`Deno.desktop.autoUpdate()`](/runtime/desktop/auto_update/): `bsdiff` patches
+shipped from your own server, no app store required.

--- a/runtime/desktop/distribution.md
+++ b/runtime/desktop/distribution.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-10
 title: "Distribution"
 description: "Cross-compile a deno desktop app for macOS, Windows, and Linux from one machine, and produce per-platform output formats: .app, .dmg, .exe directory, AppImage."
 ---

--- a/runtime/desktop/error_reporting.md
+++ b/runtime/desktop/error_reporting.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-10
 title: "Error reporting"
 description: "Capture uncaught errors, unhandled rejections, and Rust panics, showing a native alert and POSTing a JSON report to your server."
 ---

--- a/runtime/desktop/error_reporting.md
+++ b/runtime/desktop/error_reporting.md
@@ -56,15 +56,15 @@ sent.
 }
 ```
 
-| Field        | Type                               | Notes                                                                                              |
-| ------------ | ---------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `version`    | `1`                                | Schema version. Check this on the server side.                                                     |
-| `message`    | `string`                           | The error's `message`.                                                                             |
-| `stack`      | `string`                           | The error's `stack`. Source-mapped where possible.                                                 |
-| `appVersion` | `string \| null`                   | [`Deno.desktop.desktopVersion`](/api/deno/~/Deno.desktop.desktopVersion) at the time of the error. |
-| `timestamp`  | ISO 8601 string                    | UTC timestamp of when the error was caught.                                                        |
-| `platform`   | `"darwin" \| "windows" \| "linux"` | [`Deno.build.os`](/api/deno/~/Deno.build.os).                                                      |
-| `arch`       | string                             | [`Deno.build.arch`](/api/deno/~/Deno.build.arch).                                                  |
+| Field        | Type                               | Notes                                                                                      |
+| ------------ | ---------------------------------- | ------------------------------------------------------------------------------------------ |
+| `version`    | `1`                                | Schema version. Check this on the server side.                                             |
+| `message`    | `string`                           | The error's `message`.                                                                     |
+| `stack`      | `string`                           | The error's `stack`. Source-mapped where possible.                                         |
+| `appVersion` | `string \| null`                   | [`Deno.desktop.appVersion`](/api/deno/~/Deno.desktop.appVersion) at the time of the error. |
+| `timestamp`  | ISO 8601 string                    | UTC timestamp of when the error was caught.                                                |
+| `platform`   | `"darwin" \| "windows" \| "linux"` | [`Deno.build.os`](/api/deno/~/Deno.build.os).                                              |
+| `arch`       | string                             | [`Deno.build.arch`](/api/deno/~/Deno.build.arch).                                          |
 
 The `Content-Type` header is `application/json`. Reports are sent as a single
 POST with no retry. If your server is down, the report is lost. For

--- a/runtime/desktop/error_reporting.md
+++ b/runtime/desktop/error_reporting.md
@@ -56,15 +56,15 @@ sent.
 }
 ```
 
-| Field        | Type                               | Notes                                                                              |
-| ------------ | ---------------------------------- | ---------------------------------------------------------------------------------- |
-| `version`    | `1`                                | Schema version. Check this on the server side.                                     |
-| `message`    | `string`                           | The error's `message`.                                                             |
-| `stack`      | `string`                           | The error's `stack`. Source-mapped where possible.                                 |
-| `appVersion` | `string \| null`                   | [`Deno.desktopVersion`](/api/deno/~/Deno.desktopVersion) at the time of the error. |
-| `timestamp`  | ISO 8601 string                    | UTC timestamp of when the error was caught.                                        |
-| `platform`   | `"darwin" \| "windows" \| "linux"` | [`Deno.build.os`](/api/deno/~/Deno.build.os).                                      |
-| `arch`       | string                             | [`Deno.build.arch`](/api/deno/~/Deno.build.arch).                                  |
+| Field        | Type                               | Notes                                                                                              |
+| ------------ | ---------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `version`    | `1`                                | Schema version. Check this on the server side.                                                     |
+| `message`    | `string`                           | The error's `message`.                                                                             |
+| `stack`      | `string`                           | The error's `stack`. Source-mapped where possible.                                                 |
+| `appVersion` | `string \| null`                   | [`Deno.desktop.desktopVersion`](/api/deno/~/Deno.desktop.desktopVersion) at the time of the error. |
+| `timestamp`  | ISO 8601 string                    | UTC timestamp of when the error was caught.                                                        |
+| `platform`   | `"darwin" \| "windows" \| "linux"` | [`Deno.build.os`](/api/deno/~/Deno.build.os).                                                      |
+| `arch`       | string                             | [`Deno.build.arch`](/api/deno/~/Deno.build.arch).                                                  |
 
 The `Content-Type` header is `application/json`. Reports are sent as a single
 POST with no retry. If your server is down, the report is lost. For

--- a/runtime/desktop/index.md
+++ b/runtime/desktop/index.md
@@ -84,8 +84,8 @@ webview navigates to, so you do not need to pass a port or hostname. See
 - [Frameworks](/runtime/desktop/frameworks/): Next.js, Astro, Fresh, Remix,
   Nuxt, SvelteKit, and others.
 - [Windows](/runtime/desktop/windows/):
-  [`Deno.BrowserWindow`](/api/deno/~/Deno.BrowserWindow) lifecycle, multiple
-  windows, events.
+  [`Deno.desktop.BrowserWindow`](/api/deno/~/Deno.desktop.BrowserWindow)
+  lifecycle, multiple windows, events.
 - [WebGPU rendering](/runtime/desktop/webgpu/): draw to a native window with
   WebGPU on the raw backend.
 - [Bindings](/runtime/desktop/bindings/): calling Deno code from the webview via
@@ -102,8 +102,8 @@ webview navigates to, so you do not need to pass a port or hostname. See
 - [DevTools](/runtime/desktop/devtools/): unified DevTools attached to both the
   Deno runtime and the webview.
 - [Auto-update](/runtime/desktop/auto_update/):
-  [`Deno.autoUpdate()`](/api/deno/~/Deno.autoUpdate), manifests, bsdiff,
-  rollback.
+  [`Deno.desktop.autoUpdate()`](/api/deno/~/Deno.desktop.autoUpdate), manifests,
+  bsdiff, rollback.
 - [Error reporting](/runtime/desktop/error_reporting/): capturing uncaught
   exceptions and panics.
 - [Distribution](/runtime/desktop/distribution/): cross-compilation, output

--- a/runtime/desktop/index.md
+++ b/runtime/desktop/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-09
+last_modified: 2026-07-10
 title: "Desktop apps"
 description: "Build self-contained desktop applications from a Deno project, with framework auto-detection, hot reload, native windowing, auto-update, and cross-platform distribution."
 ---

--- a/runtime/desktop/menus.md
+++ b/runtime/desktop/menus.md
@@ -15,7 +15,8 @@ version, [update Deno](/runtime/reference/cli/upgrade/) to use it.
 (macOS menu bar, Windows / Linux window menu) and **context menus** (right-click
 popups).
 
-Both use the same [`Deno.MenuItem`](/api/deno/~/Deno.MenuItem) type.
+Both use the same [`Deno.desktop.MenuItem`](/api/deno/~/Deno.desktop.MenuItem)
+type.
 
 ## `MenuItem` shape
 
@@ -154,9 +155,9 @@ commands so they behave natively (and so macOS wires up the standard Edit-menu
 keyboard shortcuts):
 
 ```ts
-const quit: Deno.MenuItem = { role: { role: "quit" } };
-const copy: Deno.MenuItem = { role: { role: "copy" } };
-const paste: Deno.MenuItem = { role: { role: "paste" } };
+const quit: Deno.desktop.MenuItem = { role: { role: "quit" } };
+const copy: Deno.desktop.MenuItem = { role: { role: "copy" } };
+const paste: Deno.desktop.MenuItem = { role: { role: "paste" } };
 ```
 
 Common roles include `quit`, `undo`, `redo`, `cut`, `copy`, `paste`,
@@ -178,7 +179,7 @@ natively when you include them as `role` items.
 Show a context menu at a screen position with `showContextMenu(x, y, menu)`:
 
 ```ts
-const contextMenu: Deno.MenuItem[] = [
+const contextMenu: Deno.desktop.MenuItem[] = [
   { item: { label: "Copy", id: "copy", enabled: true } },
   { item: { label: "Paste", id: "paste", enabled: true } },
   "separator",
@@ -239,7 +240,7 @@ calling on every change.
 Set `enabled: false` to gray out an item:
 
 ```ts
-const save: Deno.MenuItem = {
+const save: Deno.desktop.MenuItem = {
   item: { label: "Save", id: "save", enabled: false },
 };
 ```

--- a/runtime/desktop/menus.md
+++ b/runtime/desktop/menus.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-10
 title: "Menus"
 description: "Build native application menu bars and right-click context menus, with submenus, accelerators, separators, checkboxes, and click events."
 ---

--- a/runtime/desktop/serving.md
+++ b/runtime/desktop/serving.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-10
 title: "HTTP serving"
 description: "How Deno.serve() works inside a desktop app: automatic port binding, the DENO_SERVE_ADDRESS env var, and serving local UI to the embedded webview."
 ---

--- a/runtime/desktop/serving.md
+++ b/runtime/desktop/serving.md
@@ -123,6 +123,6 @@ differentiate:
 
 ```ts
 const port = Deno.env.get("DENO_SERVE_ADDRESS")!.split(":").pop();
-const settings = new Deno.BrowserWindow();
+const settings = new Deno.desktop.BrowserWindow();
 settings.navigate(`http://127.0.0.1:${port}/settings`);
 ```

--- a/runtime/desktop/tray_and_dock.md
+++ b/runtime/desktop/tray_and_dock.md
@@ -11,19 +11,20 @@ version, [update Deno](/runtime/reference/cli/upgrade/) to use it.
 
 :::
 
-[`Deno.Tray`](/api/deno/~/Deno.Tray) puts an icon in the system status area
-(macOS menu bar extras, Windows system tray, Linux AppIndicator).
-[`Deno.dock`](/api/deno/~/Deno.dock) is a singleton that controls the app's dock
-/ taskbar presence: badge, bounce, visibility, and a custom menu.
+[`Deno.desktop.Tray`](/api/deno/~/Deno.desktop.Tray) puts an icon in the system
+status area (macOS menu bar extras, Windows system tray, Linux AppIndicator).
+[`Deno.desktop.dock`](/api/deno/~/Deno.desktop.dock) is a singleton that
+controls the app's dock / taskbar presence: badge, bounce, visibility, and a
+custom menu.
 
-Menus on both use the [`Deno.MenuItem`](/runtime/desktop/menus/) type.
+Menus on both use the [`Deno.desktop.MenuItem`](/runtime/desktop/menus/) type.
 
-## `Deno.Tray`
+## `Deno.desktop.Tray`
 
 ```ts
 const icon = await Deno.readFile("./icons/tray.png");
 
-const tray = new Deno.Tray();
+const tray = new Deno.desktop.Tray();
 tray.setIcon(icon);
 tray.setTooltip("My App");
 
@@ -52,7 +53,7 @@ tray.destroy();
 
 ```ts
 {
-  using tray = new Deno.Tray();
+  using tray = new Deno.desktop.Tray();
   // ...
 } // automatically destroyed at scope exit
 ```
@@ -90,8 +91,8 @@ tray.setTooltip(null); // remove tooltip
 ### Context menu
 
 Right-click on the tray icon opens the menu set by `setMenu`. The items are the
-same [`Deno.MenuItem`](/runtime/desktop/menus/) shape used by application and
-context menus:
+same [`Deno.desktop.MenuItem`](/runtime/desktop/menus/) shape used by
+application and context menus:
 
 ```ts
 tray.setMenu([
@@ -152,7 +153,7 @@ For the classic menu-bar-app pattern, click the tray icon to toggle a small
 floating window anchored under it, then use `attachPanel()`:
 
 ```ts
-const tray = new Deno.Tray();
+const tray = new Deno.desktop.Tray();
 tray.setIcon(await Deno.readFile("./icons/tray.png"));
 
 const panel = tray.attachPanel({
@@ -164,11 +165,11 @@ const panel = tray.attachPanel({
 panel.window.bind("doThing", async () => {/* … */});
 ```
 
-The returned [`Deno.TrayPanel`](/api/deno/~/Deno.TrayPanel) toggles on tray
-click, is positioned under the icon, and hides when it loses focus. Pass a
-string as shorthand for `{ url }`. `TrayPanelOptions` also accepts `hideOnBlur`
-(default `true`) and a `position` callback to override placement (e.g. for a
-bottom-edge taskbar).
+The returned [`Deno.desktop.TrayPanel`](/api/deno/~/Deno.desktop.TrayPanel)
+toggles on tray click, is positioned under the icon, and hides when it loses
+focus. Pass a string as shorthand for `{ url }`. `TrayPanelOptions` also accepts
+`hideOnBlur` (default `true`) and a `position` callback to override placement
+(e.g. for a bottom-edge taskbar).
 
 ```ts
 panel.show();
@@ -210,18 +211,18 @@ If the backend cannot create a tray icon, the constructor's underlying `trayId`
 is `0` and subsequent calls are no-ops (silently). Check `tray.trayId !== 0` if
 you need to fall back gracefully.
 
-## `Deno.dock`
+## `Deno.desktop.dock`
 
-[`Deno.dock`](/api/deno/~/Deno.dock) is a singleton exposing the app's dock /
-taskbar controls. The methods are cross-platform but their effect varies:
-macOS-only operations are no-ops on Windows and Linux (they fail gracefully
-rather than throwing).
+[`Deno.desktop.dock`](/api/deno/~/Deno.desktop.dock) is a singleton exposing the
+app's dock / taskbar controls. The methods are cross-platform but their effect
+varies: macOS-only operations are no-ops on Windows and Linux (they fail
+gracefully rather than throwing).
 
 ### Badge
 
 ```ts
-Deno.dock.setBadge("3"); // short text on the dock / taskbar icon
-Deno.dock.setBadge(null); // clear (null or empty string)
+Deno.desktop.dock.setBadge("3"); // short text on the dock / taskbar icon
+Deno.desktop.dock.setBadge(null); // clear (null or empty string)
 ```
 
 Sets a text badge on the dock icon (macOS) or taskbar icon (Windows); on Linux
@@ -231,8 +232,8 @@ OS truncates long strings.
 ### Bounce
 
 ```ts
-Deno.dock.bounce(); // single bounce / flash
-Deno.dock.bounce(true); // bounce continuously until the app is focused
+Deno.desktop.dock.bounce(); // single bounce / flash
+Deno.desktop.dock.bounce(true); // bounce continuously until the app is focused
 ```
 
 Bounces the dock icon (macOS), flashes the taskbar button (Windows), or sets the
@@ -242,8 +243,8 @@ urgency hint on the focused window (Linux). The optional `critical` argument
 ### Visibility
 
 ```ts
-Deno.dock.setVisible(false); // remove the app from the dock
-Deno.dock.setVisible(true); // restore it
+Deno.desktop.dock.setVisible(false); // remove the app from the dock
+Deno.desktop.dock.setVisible(true); // restore it
 ```
 
 macOS only; controls the app's activation policy. A hidden app does not appear
@@ -254,19 +255,19 @@ via Spotlight or the tray icon. No-op on Windows and Linux.
 ### Menu
 
 ```ts
-Deno.dock.setMenu([
+Deno.desktop.dock.setMenu([
   { item: { label: "New Window", id: "new", enabled: true } },
   { item: { label: "Quit", id: "quit", enabled: true } },
 ]);
-Deno.dock.setMenu(null); // remove the menu
+Deno.desktop.dock.setMenu(null); // remove the menu
 
-Deno.dock.addEventListener("menuclick", (e) => {
+Deno.desktop.dock.addEventListener("menuclick", (e) => {
   if (e.detail.id === "quit") Deno.exit(0);
 });
 ```
 
 macOS only; a custom right-click menu on the dock icon. Clicks are delivered as
-`menuclick` events on [`Deno.dock`](/api/deno/~/Deno.dock).
+`menuclick` events on [`Deno.desktop.dock`](/api/deno/~/Deno.desktop.dock).
 
 ### Reopen event
 
@@ -275,7 +276,7 @@ On macOS, clicking the dock icon while the app has no visible windows fires a
 so you decide what to do:
 
 ```ts
-Deno.dock.addEventListener("reopen", (e) => {
+Deno.desktop.dock.addEventListener("reopen", (e) => {
   if (!e.detail.hasVisibleWindows) win.show();
 });
 ```
@@ -285,10 +286,10 @@ Deno.dock.addEventListener("reopen", (e) => {
 To run as a status-bar-only background process (no dock, no main window):
 
 ```ts
-Deno.dock.setVisible(false); // macOS: hide the app from the dock
+Deno.desktop.dock.setVisible(false); // macOS: hide the app from the dock
 win.hide(); // hide the implicit startup window
 
-const tray = new Deno.Tray();
+const tray = new Deno.desktop.Tray();
 tray.setIcon(await Deno.readFile("./icons/tray.png"));
 tray.setTooltip("My App");
 tray.setMenu([

--- a/runtime/desktop/tray_and_dock.md
+++ b/runtime/desktop/tray_and_dock.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-30
+last_modified: 2026-07-10
 title: "Tray and dock"
 description: "Add icons to the OS status area and the macOS dock: tooltips, dark-mode variants, click events, and right-click context menus."
 ---

--- a/runtime/desktop/webgpu.md
+++ b/runtime/desktop/webgpu.md
@@ -18,7 +18,7 @@ visualizations, emulators, and any app that renders its own pixels rather than a
 document.
 
 The bridge between a window and WebGPU is
-[`Deno.BrowserWindow.getNativeWindow()`](/api/deno/~/Deno.BrowserWindow.prototype.getNativeWindow),
+[`Deno.desktop.BrowserWindow.getNativeWindow()`](/api/deno/~/Deno.desktop.BrowserWindow.prototype.getNativeWindow),
 which hands back a
 [`Deno.UnsafeWindowSurface`](/api/deno/~/Deno.UnsafeWindowSurface). That surface
 exposes a WebGPU canvas context, so the same `context.configure()` /
@@ -56,7 +56,7 @@ const adapter = await navigator.gpu.requestAdapter();
 if (!adapter) throw new Error("no WebGPU adapter available");
 const device = await adapter.requestDevice();
 
-const win = new Deno.BrowserWindow({
+const win = new Deno.desktop.BrowserWindow({
   title: "WebGPU",
   width: 640,
   height: 480,
@@ -111,7 +111,7 @@ const adapter = await navigator.gpu.requestAdapter();
 if (!adapter) throw new Error("no WebGPU adapter available");
 const device = await adapter.requestDevice();
 
-const win = new Deno.BrowserWindow({
+const win = new Deno.desktop.BrowserWindow({
   title: "Triangle",
   width: 640,
   height: 480,
@@ -195,7 +195,11 @@ const adapter = await navigator.gpu.requestAdapter();
 if (!adapter) throw new Error("no WebGPU adapter available");
 const device = await adapter.requestDevice();
 
-const win = new Deno.BrowserWindow({ title: "Spin", width: 640, height: 480 });
+const win = new Deno.desktop.BrowserWindow({
+  title: "Spin",
+  width: 640,
+  height: 480,
+});
 
 const surface = win.getNativeWindow();
 const format = navigator.gpu.getPreferredCanvasFormat();
@@ -304,7 +308,7 @@ alive with nothing on screen.
 ## Key details
 
 - **Request the adapter before wrapping the window.**
-  [`getNativeWindow()`](/api/deno/~/Deno.BrowserWindow.prototype.getNativeWindow)
+  [`getNativeWindow()`](/api/deno/~/Deno.desktop.BrowserWindow.prototype.getNativeWindow)
   needs an active WebGPU context and throws if you call it before
   [`navigator.gpu.requestAdapter()`](/api/web/~/GPU.prototype.requestAdapter).
 
@@ -333,7 +337,7 @@ alive with nothing on screen.
 - [Backends](/runtime/desktop/backends/) — when to choose `raw` over `cef` /
   `webview`.
 - [Windows](/runtime/desktop/windows/) —
-  [`Deno.BrowserWindow`](/api/deno/~/Deno.BrowserWindow) lifecycle, sizing, and
-  events.
+  [`Deno.desktop.BrowserWindow`](/api/deno/~/Deno.desktop.BrowserWindow)
+  lifecycle, sizing, and events.
 - [WebGPU API](/api/web/~/GPUDevice) and the
   [WGSL specification](https://www.w3.org/TR/WGSL/).

--- a/runtime/desktop/webgpu.md
+++ b/runtime/desktop/webgpu.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-08
+last_modified: 2026-07-10
 title: "WebGPU rendering"
 description: "Draw to a native window with WebGPU on the raw backend: request an adapter, wrap the window as an UnsafeWindowSurface, configure a canvas context, and run a render loop."
 ---

--- a/runtime/desktop/windows.md
+++ b/runtime/desktop/windows.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-08
+last_modified: 2026-07-10
 title: "Windows"
 description: "Create and manage native windows with Deno.desktop.BrowserWindow: lifecycle, multiple windows, sizing, navigation, keyboard / mouse / focus events, and native window handles."
 ---

--- a/runtime/desktop/windows.md
+++ b/runtime/desktop/windows.md
@@ -1,7 +1,7 @@
 ---
 last_modified: 2026-07-08
 title: "Windows"
-description: "Create and manage native windows with Deno.BrowserWindow: lifecycle, multiple windows, sizing, navigation, keyboard / mouse / focus events, and native window handles."
+description: "Create and manage native windows with Deno.desktop.BrowserWindow: lifecycle, multiple windows, sizing, navigation, keyboard / mouse / focus events, and native window handles."
 ---
 
 :::info Available in Deno 2.9
@@ -11,25 +11,25 @@ version, [update Deno](/runtime/reference/cli/upgrade/) to use it.
 
 :::
 
-The [`Deno.BrowserWindow`](/api/deno/~/Deno.BrowserWindow) class controls native
-windows. A window opens automatically when your binary starts and is navigated
-to your local [HTTP server](/runtime/desktop/serving/). The **first**
-`new Deno.BrowserWindow()` you construct adopts that initial window; every
-construction after that opens a new one. All windows share the same Deno
-runtime: there is one async runtime per process, regardless of how many windows
-are open.
+The [`Deno.desktop.BrowserWindow`](/api/deno/~/Deno.desktop.BrowserWindow) class
+controls native windows. A window opens automatically when your binary starts
+and is navigated to your local [HTTP server](/runtime/desktop/serving/). The
+**first** `new Deno.desktop.BrowserWindow()` you construct adopts that initial
+window; every construction after that opens a new one. All windows share the
+same Deno runtime: there is one async runtime per process, regardless of how
+many windows are open.
 
 ## Creating windows
 
 ```ts
 // The first construction adopts the implicit startup window.
-const win = new Deno.BrowserWindow({ title: "My App" });
+const win = new Deno.desktop.BrowserWindow({ title: "My App" });
 
 // Subsequent constructions open additional windows.
 const base = Deno.env.get("DENO_SERVE_ADDRESS")!; // "tcp:127.0.0.1:<port>"
 const port = base.split(":").pop();
 
-const settings = new Deno.BrowserWindow({
+const settings = new Deno.desktop.BrowserWindow({
   title: "Settings",
   width: 420,
   height: 320,
@@ -51,8 +51,8 @@ The constructor accepts a `BrowserWindowOptions` object:
 | `noActivate`          | `boolean` | `false` | Floating, non-activating panel that doesn't steal focus. Creation-only. |
 | `transparentTitlebar` | `boolean` | `false` | Blend the title bar into the content. Creation-only.                    |
 
-`new Deno.BrowserWindow()` opens (or adopts) a window immediately. The window is
-alive until `close()` is called or the user closes it from the OS.
+`new Deno.desktop.BrowserWindow()` opens (or adopts) a window immediately. The
+window is alive until `close()` is called or the user closes it from the OS.
 
 `frameless`, `noActivate`, and `transparentTitlebar` can only be set at creation
 time. `frameless` + `noActivate` together are the building blocks for tray /
@@ -123,7 +123,7 @@ try {
   // First run, or no saved state yet — fall back to defaults.
 }
 
-const win = new Deno.BrowserWindow({
+const win = new Deno.desktop.BrowserWindow({
   title: "My App",
   width: saved.width ?? 800,
   height: saved.height ?? 600,
@@ -166,8 +166,9 @@ windows. For modal dialogs, prefer creating a child window over navigating away.
 
 ## Events
 
-[`Deno.BrowserWindow`](/api/deno/~/Deno.BrowserWindow) is an `EventTarget`.
-Listen with `addEventListener` or assign to the matching `on<event>` property.
+[`Deno.desktop.BrowserWindow`](/api/deno/~/Deno.desktop.BrowserWindow) is an
+`EventTarget`. Listen with `addEventListener` or assign to the matching
+`on<event>` property.
 
 ```ts
 win.addEventListener("resize", (e) => {

--- a/runtime/reference/cli/desktop.md
+++ b/runtime/reference/cli/desktop.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-27
+last_modified: 2026-07-10
 title: "deno desktop"
 openGraphLayout: "/open_graph/cli-commands.jsx"
 openGraphTitle: "deno desktop"

--- a/runtime/reference/cli/desktop.md
+++ b/runtime/reference/cli/desktop.md
@@ -30,8 +30,9 @@ current directory and builds the appropriate desktop entrypoint. See
 per-framework requirements.
 
 This page covers the command-line flags. For the full guide (backends,
-[`Deno.BrowserWindow`](/api/deno/~/Deno.BrowserWindow), bindings, auto-update,
-DevTools, and distribution) see the [Desktop apps section](/runtime/desktop/).
+[`Deno.desktop.BrowserWindow`](/api/deno/~/Deno.desktop.BrowserWindow),
+bindings, auto-update, DevTools, and distribution) see the
+[Desktop apps section](/runtime/desktop/).
 
 ## Runtime flags
 


### PR DESCRIPTION
## Summary

Updates the desktop docs to reflect the move of the desktop runtime APIs from the top-level `Deno` namespace onto a dedicated `Deno.desktop` namespace. Every name is unchanged — only the namespace prefix is added:

- `Deno.BrowserWindow` → `Deno.desktop.BrowserWindow`
- `Deno.Dock` → `Deno.desktop.Dock`
- `Deno.dock` → `Deno.desktop.dock`
- `Deno.Tray` → `Deno.desktop.Tray`
- `Deno.desktopVersion` → `Deno.desktop.desktopVersion`
- `Deno.autoUpdate` → `Deno.desktop.autoUpdate`
- type refs: `Deno.MenuItem`, `Deno.TrayPanel`, `Deno.AutoUpdateOptions`, etc.

Web-standard globals documented under `runtime/desktop/` (Notification, dialogs, permissions) are unchanged, as they remain global.

Pairs with denoland/deno#35939, which performs the implementation and typings move.

## Changes

All prose references, code samples, section headings, and `/api/deno/~/…` links across `runtime/desktop/*.md` and `runtime/reference/cli/desktop.md` updated to the `Deno.desktop.*` names. Code samples reflowed by `deno fmt` where the longer names changed line wrapping.