### PR TITLE
docs: add agent skills for tutorial maintenance

### DIFF
--- a/_config.ts
+++ b/_config.ts
@@ -251,6 +251,10 @@ if (PROFILE) {
 // ignore some folders that have their own build tasks
 // site.ignore("styleguide");
 
+// Agent skills are instructions for humans and coding agents working on the
+// repo, not published pages.
+site.ignore("skills");
+
 site.copy("static", ".");
 site.copy("timeUtils.ts");
 site.copy("subhosting/api/images");

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,50 @@
+# Agent skills
+
+Reusable
+[Agent Skills](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview)
+for recurring maintenance on this docs site. Each subdirectory is one skill: a
+`SKILL.md` with a `name` and a `description` of when to use it, plus any helper
+files that skill needs.
+
+These are instructions for whoever is doing the work, human or coding agent.
+They capture how we keep [docs.deno.com](https://docs.deno.com) tutorials
+correct and current, so the knowledge is not re-derived each time. Lume ignores
+this directory (`site.ignore("skills")` in `_config.ts`), so nothing here is
+published.
+
+## Skills
+
+| Skill                                                 | Use it when                                                                                                          |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| [`modernize-tutorial`](./modernize-tutorial/SKILL.md) | A tutorial uses a deprecated API, an outdated scaffolder, or version-pinned doc links and needs bringing up to date. |
+| [`verify-tutorial`](./verify-tutorial/SKILL.md)       | You want to confirm a tutorial actually works when followed, using Deno-native tooling.                              |
+| [`audit-tutorials`](./audit-tutorials/SKILL.md)       | You want a ranked worklist of stale or broken tutorials, without editing anything.                                   |
+| [`new-tutorial`](./new-tutorial/SKILL.md)             | You are adding a new tutorial and want it to follow this repo's conventions with verified code.                      |
+| [`open-docs-pr`](./open-docs-pr/SKILL.md)             | You have a change ready and want to run the required checks and open a PR in the house style.                        |
+
+## Using these with Claude Code
+
+Claude Code auto-discovers skills from `.claude/skills/`, not from this
+top-level directory. To make these live as project skills without duplicating
+them, symlink the directory:
+
+```console
+mkdir -p .claude && ln -s ../skills .claude/skills
+```
+
+(`.claude/` is gitignored, so the symlink stays local to each checkout.) Other
+agent tooling can point at `skills/` directly.
+
+## Conventions every skill assumes
+
+From [`AGENTS.md`](../AGENTS.md); skills restate the parts they depend on so
+they work standalone.
+
+- Tutorials live in `examples/tutorials/`. Bump `last_modified: YYYY-MM-DD` on
+  every content page you change; CI enforces it.
+- Before a PR: `deno fmt`, `deno lint`, `deno task test`, and
+  `deno task build:light`.
+- Prefer plain sentences and colons over em-dash joins. Frontmatter titles have
+  no backticks.
+- This is a Deno site: tutorial code must run under Deno-native tooling
+  (`deno run`, `deno install`, `deno task`), never `npm`/`npx`/`node`.

--- a/skills/audit-tutorials/SKILL.md
+++ b/skills/audit-tutorials/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: audit-tutorials
+description: Scan examples/tutorials for staleness and report a ranked worklist without editing. Use to find deprecated APIs, version-pinned doc links, old last_modified dates, and snippet bugs across the tutorials.
+---
+
+# Audit tutorials for staleness
+
+Scan the tutorials under `examples/tutorials/` (or a narrower target if the
+author names one) and report a ranked worklist. Do not edit anything and do not
+open a PR: this skill only produces the report that feeds `modernize-tutorial`.
+
+For each tutorial, check for:
+
+1. Version-pinned documentation links. Grep the code and prose for URLs that pin
+   an old major, for example `tanstack.com/.../v1/`, `.../v4/`, or any `/vN/`
+   segment that is behind the library's current major. Flag each with the file
+   and line.
+
+2. Stale `last_modified`. Sort pages by their frontmatter date and surface the
+   oldest. Treat anything older than about a year as worth a review, and call
+   out any page missing the field (CI requires it).
+
+3. Deprecated or renamed APIs in code blocks. Look for patterns you know have
+   moved (for example `new RootRoute()` / `new Route()` for TanStack Router) and
+   anything the framework's current docs mark as deprecated. When unsure, say so
+   rather than guessing.
+
+4. Snippet bugs a reader would hit: identifiers used but never imported, files
+   referenced by a name that no earlier step created, and install or scaffold
+   commands that are not Deno-native (`npm install`, `npx`, `node`).
+
+5. Non-Deno-native setup. Flag tutorials that reach for the Node toolchain where
+   a `deno` equivalent exists.
+
+Output a single ranked table: file, issue, severity (high = wrong or broken
+code, medium = deprecated but working, low = stale link or old date), and the
+suggested fix. Order by severity, then by how many readers the page likely gets
+(getting-started and framework tutorials rank higher). End with the two or three
+pages you would fix first and the exact `modernize-tutorial` runs to do it.

--- a/skills/modernize-tutorial/SKILL.md
+++ b/skills/modernize-tutorial/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: modernize-tutorial
+description: Update an existing docs tutorial to a framework's current API and tooling, verifying the new code runs under Deno before editing. Use when a tutorial references a deprecated API, an outdated scaffolder, or version-pinned documentation links.
+---
+
+# Modernize a tutorial
+
+Bring the named tutorial under `examples/tutorials/` up to date so a reader
+following it today uses the current, supported API and tooling, and every code
+block actually runs under Deno.
+
+Work in this order:
+
+1. Read the tutorial. List every external-facing thing that can rot: package
+   APIs used in code blocks, scaffolding commands, install commands,
+   version-pinned documentation links (for example `/v1/` or `/v4/` in a
+   tanstack.com URL), and any snippet that imports or references something it
+   never defines.
+
+2. Establish what "current" is. Check the framework's official docs for the
+   supported API and the recommended Deno-native setup. Do not trust memory for
+   version-specific details. Note deprecations explicitly (for example TanStack
+   Router's `new RootRoute()` / `new Route()` became `createRootRoute()` /
+   `createRoute()`).
+
+3. Verify before you rewrite. Reproduce the relevant part of the tutorial in a
+   throwaway directory using only Deno-native tooling (`deno run`,
+   `deno install`, `deno task`; never `npm`/`npx`/`node`). Get the updated code
+   to pass a real build (for a Vite app, `deno task build` runs `tsc` plus
+   `vite build`) and to serve from the dev server. If it will not run, fix the
+   code until it does. The version you paste into the tutorial is the version
+   you ran.
+
+4. Apply the edits: replace deprecated API usage, refresh scaffold and install
+   commands to the Deno-native path, fix version-pinned links to `latest` (or
+   the correct current major), and correct any snippet bugs you found (missing
+   imports, stale filenames). Keep the tutorial's app and narrative intact
+   unless asked otherwise. Modernize, do not rewrite.
+
+5. Housekeeping: bump `last_modified` to today. Replace em-dash joins with
+   colons or shorter sentences. Keep frontmatter titles backtick-free. Run
+   `deno fmt` on the file.
+
+6. Show the `git diff` and a short note on what you verified: the exact command
+   that built or ran, and its result. Then hand off to the `open-docs-pr` skill.
+   Do not push until the author confirms.

--- a/skills/new-tutorial/SKILL.md
+++ b/skills/new-tutorial/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: new-tutorial
+description: Author a new docs tutorial that follows this repo's conventions, with code verified under Deno. Use when adding a tutorial for a framework, tool, or workflow that no existing page covers.
+---
+
+# Write a new tutorial
+
+Write a new tutorial for the requested topic, following this repo's conventions,
+with code you have actually run under Deno.
+
+First check for overlap: search `examples/tutorials/` for an existing page on
+this topic. If one exists, stop and recommend the `modernize-tutorial` skill
+instead of a second page. A topic's depth should live in exactly one place.
+
+Then:
+
+1. Decide the smallest real app that teaches the concept, and confirm it runs.
+   Build it in a throwaway directory (a scratch location, not this repo) using
+   only Deno-native tooling (`deno run`, `deno install`, `deno task`,
+   `deno serve`; never `npm`/`npx`/`node`). Get it to build and serve for real
+   before writing any prose. Every code block must come from code you ran.
+
+2. Create `examples/tutorials/<snake_case_name>.md` with frontmatter matching
+   the existing tutorials:
+   - `last_modified: <today>`
+   - `title:` a plain string, no backticks
+   - `description:` one or two sentences for search and previews
+   - `url: /examples/<snake_case_name>_tutorial/`
+
+3. Write the body as a teaching guide: introduce at most one or two concepts at
+   a time, show each file with a `// path` comment header, and explain the why,
+   not just the code. Link out to the framework's official docs and to related
+   Deno tutorials rather than repeating detail. Prefer plain sentences and
+   colons over em-dash joins.
+
+4. Register it in navigation if the section requires it: check
+   `examples/_data.ts` (or the section's `_data.ts`) and add the page where the
+   sibling tutorials are listed. Keep any sidebar label within the section's
+   length limit (the sidebar test enforces this).
+
+5. Run `deno fmt` on the new file, then `deno lint`, `deno task test`, and
+   `deno task build:light`, and fix anything they flag.
+
+6. Show the new file and a note on what you verified (the exact build or run
+   command and result). Then hand off to the `open-docs-pr` skill. Do not push
+   until the author confirms.

--- a/skills/open-docs-pr/SKILL.md
+++ b/skills/open-docs-pr/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: open-docs-pr
+description: Run this repo's required checks and open a PR in the project's house style. Use when a docs change is ready to propose against main.
+---
+
+# Open a docs PR
+
+Open a pull request for the current branch's changes against `main`, but only
+after this repo's required checks pass.
+
+1. Sanity-check the branch. If you are on `main`, stop and create a topic branch
+   off `origin/main` first. Run `git status` and
+   `git diff origin/main...HEAD --stat` and confirm the diff is only what you
+   intend. If running the checks below touched unrelated files (for example
+   `deno.lock`), revert those so the PR stays focused.
+
+2. Confirm freshness. Every changed content page must have `last_modified` set
+   to today. Run `deno task check:freshness` and fix any page it flags.
+
+3. Run the required gate and make it green. Paste the results; do not open the
+   PR while any of these fail:
+   - `deno fmt` (then re-stage any files it reformats)
+   - `deno lint`
+   - `deno task test` (frontmatter, sidebar, and API link tests)
+   - `deno task build:light` (must build with no broken links or invalid MDX)
+
+4. Push the branch to `origin` with `-u` under its own name. Never push to
+   `main`.
+
+5. Open the PR against `main` with a house-style description:
+   - Prose only. No `## Summary`, `## Test plan`, or any section headers.
+   - Hard-wrap every body line at 80 columns.
+   - Lead with why the change exists and what it does at a high level; let the
+     diff show the mechanics. One short paragraph is usually enough.
+   - Title under 70 characters, using the repo's `docs:` prefix convention
+     (check recent `git log origin/main --oneline`).
+
+6. Return the PR URL.

--- a/skills/verify-tutorial/SKILL.md
+++ b/skills/verify-tutorial/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: verify-tutorial
+description: Reproduce a docs tutorial's code with Deno-native tooling and confirm it builds and runs, without editing the tutorial. Use for a QA pass on a tutorial before trusting or shipping it.
+---
+
+# Verify a tutorial runs
+
+Confirm the named tutorial under `examples/tutorials/` actually works when
+followed exactly, using only Deno-native tooling. This is a QA pass: do not edit
+the tutorial. Produce a pass/fail report backed by real command output.
+
+1. Read the tutorial and extract the concrete steps a reader would run: the
+   scaffold command, install command(s), every file they create with its
+   contents, and the run and build commands.
+
+2. Work in a throwaway directory (a scratch location, not this repo). Follow the
+   steps literally and in order, using only `deno` (`deno run`, `deno install`,
+   `deno task`, `deno serve`). If the tutorial tells the reader to run
+   `npm`/`npx`/`node`, that itself is a finding: record it and use the
+   Deno-native equivalent to continue.
+
+3. Prove it works, do not assert it:
+   - Dev server: start it in the background, then `curl` the root and the main
+     entry module and record the HTTP status.
+   - Build: run the production build and capture the result (module count and
+     exit code).
+   - If the tutorial has a backend, stand it up and `curl` an endpoint.
+
+4. Report:
+   - Verdict: passes as written, passes with deviations, or broken.
+   - Each deviation you had to make (wrong command, missing import, deprecated
+     API, stale version) with the exact error and what fixed it.
+   - The commands you ran and their output as evidence.
+
+5. If you found problems, recommend the `modernize-tutorial` skill to fix them.
+   This skill does not edit or open a PR.


### PR DESCRIPTION
Keeping the tutorials correct and current is recurring work: the same steps
come up every time a framework ships a new API or a page goes stale. This adds
a top-level skills/ directory that captures that knowledge as reusable
instructions for whoever does the work, human or coding agent, so it does not
have to be re-derived each time.

Each subdirectory is one Agent Skill (a SKILL.md with a name and a description
of when to use it): modernize-tutorial, verify-tutorial, audit-tutorials,
new-tutorial, and open-docs-pr. They encode the conventions already in
AGENTS.md, notably that tutorial code must run under Deno-native tooling and
must be verified before it ships, and that the required checks and house PR
style gate every change. Lume ignores the directory via site.ignore("skills")
so nothing here is published, and the tutorial and sidebar tests already scope
themselves to the content sections, so the suite is unaffected. The README
explains how to symlink the directory into .claude/skills so Claude Code picks
the skills up locally.