### PR TITLE
docs: link the denidian example app from the desktop docs

### DIFF
--- a/runtime/desktop/index.md
+++ b/runtime/desktop/index.md
@@ -74,6 +74,16 @@ The compiled binary opens a window pointed at a local HTTP server bound to your
 webview navigates to, so you do not need to pass a port or hostname. See
 [HTTP serving](/runtime/desktop/serving/) for details.
 
+## A complete example
+
+For a complete, real-world app built with `deno desktop`, see
+[denidian](https://github.com/bartlomieju/denidian): an Obsidian-style
+note-taking app with Markdown notes, `[[wikilink]]` crosslinking, and a
+force-directed graph view. It is deliberately small — a single Deno HTTP server
+plus a vanilla HTML/CSS/JS frontend — and covers window management via
+[`Deno.BrowserWindow`](/api/deno/~/Deno.BrowserWindow), application menus,
+`--hmr` development, and packaging for distribution.
+
 ## What's in this section
 
 - [Configuration](/runtime/desktop/configuration/): the `desktop` block in

--- a/runtime/desktop/index.md
+++ b/runtime/desktop/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-09
+last_modified: 2026-07-27
 title: "Desktop apps"
 description: "Build self-contained desktop applications from a Deno project, with framework auto-detection, hot reload, native windowing, auto-update, and cross-platform distribution."
 ---

--- a/runtime/desktop/windows.md
+++ b/runtime/desktop/windows.md
@@ -19,6 +19,9 @@ construction after that opens a new one. All windows share the same Deno
 runtime: there is one async runtime per process, regardless of how many windows
 are open.
 
+For a complete app that manages a window, application menus, and packaging, see
+the [denidian example](https://github.com/bartlomieju/denidian).
+
 ## Creating windows
 
 ```ts

--- a/runtime/desktop/windows.md
+++ b/runtime/desktop/windows.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-08
+last_modified: 2026-07-27
 title: "Windows"
 description: "Create and manage native windows with Deno.BrowserWindow: lifecycle, multiple windows, sizing, navigation, keyboard / mouse / focus events, and native window handles."
 ---


### PR DESCRIPTION
The `deno desktop` section had no pointer to a complete working application —
the denidian example (an Obsidian-style note-taking app covering
Deno.BrowserWindow, menus, --hmr development, and packaging) was only linked
from the 2.9 release blog post. Users reading the docs saw only isolated
snippets, which came up as a complaint in denoland/deno#36118.

This links denidian from the desktop section index and from the Windows page,
where window lifecycle and events are documented.