### PR TITLE
docs: add agents.md, an entrypoint for coding agents

### DIFF
--- a/ai/index.md
+++ b/ai/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-02-19
+last_modified: 2026-07-29
 title: "AI entrypoint"
 description: "Overview and key resources for LLMs and AI agents using the Deno docs"
 url: /ai/
@@ -7,6 +7,11 @@ url: /ai/
 
 This page is a short entrypoint for LLMs and AI agents consuming the Deno
 documentation.
+
+If you are a coding agent working in a user's project, read
+[deno.com/agents.md](https://deno.com/agents.md) instead. It orients you and
+points you at [Deno's agent skills](https://github.com/denoland/skills), which
+carry the full reference material and are kept current with the runtime.
 
 ## Deno overview
 
@@ -150,6 +155,8 @@ deno init --serve
 
 ## Key resources
 
+- [agents.md](https://deno.com/agents.md): entrypoint for coding agents working
+  in a project — orientation, then how to install Deno's agent skills
 - [llms.txt](/llms.txt): curated section index with key documentation links
 - [llms-full-guide.txt](/llms-full-guide.txt): agent-oriented quick reference
   with CLI commands, code examples, and usage patterns

--- a/runtime/index.md
+++ b/runtime/index.md
@@ -40,8 +40,15 @@ few minutes.
 
 ## Using an AI coding agent?
 
-Hand it [deno.com/agents.md](https://deno.com/agents.md). It is a single page
-written for coding agents: what Deno is, the assumptions to unlearn if it knows
+Paste this into Claude Code, Codex, Gemini CLI, OpenCode, Cursor, Pi, or
+whichever agent you use:
+
+```plaintext
+Read deno.com/agents.md and set up Deno in this project
+```
+
+[deno.com/agents.md](https://deno.com/agents.md) is a single page written for
+coding agents: what Deno is, the assumptions to unlearn if it already knows
 Node, and how to install
 [Deno's agent skills](https://github.com/denoland/skills) so it keeps that
 context in every session. If you are asking an agent to bring an existing Node

--- a/runtime/index.md
+++ b/runtime/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-09
+last_modified: 2026-07-29
 title: "Get started with Deno"
 description: "Install Deno and build your first project: why Deno, install, create, run, test, add a dependency, and use the built-in toolchain. No build step, no config."
 pagination_next: /runtime/getting_started/installation/
@@ -37,6 +37,15 @@ few minutes.
   [formatter](/runtime/lint_and_format/), [linter](/runtime/lint_and_format/),
   [test runner](/runtime/test/), benchmarking, and
   [a lot more](/runtime/reference/cli/). No `devDependencies` to wire up.
+
+## Using an AI coding agent?
+
+Hand it [deno.com/agents.md](https://deno.com/agents.md). It is a single page
+written for coding agents: what Deno is, the assumptions to unlearn if it knows
+Node, and how to install
+[Deno's agent skills](https://github.com/denoland/skills) so it keeps that
+context in every session. If you are asking an agent to bring an existing Node
+project across, it covers that too.
 
 ## Install Deno
 

--- a/runtime/migrate/index.md
+++ b/runtime/migrate/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-29
 title: "Migrate from Node.js"
 description: "How to move a Node.js project to Deno: use Deno as a drop-in package manager, run your existing project and package.json scripts, understand how CommonJS and ES modules are resolved, and map your Node commands to Deno."
 oldUrl:
@@ -18,6 +18,14 @@ You can also adopt Deno incrementally: use it purely as a faster, drop-in
 package manager for an app you still run with Node, run your existing
 `package.json` scripts with `deno task`, or switch to Deno as the runtime and
 pick up its built-in toolchain. This guide walks through each step.
+
+:::tip Using an AI coding agent?
+
+Point it at [deno.com/agents.md](https://deno.com/agents.md). It orients the
+agent and installs Deno's `migrate-to-deno` skill, which covers each step below,
+the errors you are likely to hit, and per-tool command equivalents.
+
+:::
 
 ## Use Deno as your package manager
 

--- a/static/agents.md
+++ b/static/agents.md
@@ -1,11 +1,5 @@
 # Deno for coding agents
 
-You are an AI coding agent. This page gets you oriented and then points you at
-Deno's agent skills, which hold the actual reference material. It is short on
-purpose — read it once, install the skill, and you will not need it again.
-
-## What Deno is
-
 Deno is a JavaScript and TypeScript runtime distributed as a single binary. That
 binary is also the package manager, formatter, linter, test runner, type
 checker, and compiler. It runs TypeScript directly, so a script needs no build
@@ -19,8 +13,7 @@ reaching for `-A`.
 
 ## Assumptions to drop
 
-This is the part models most often get wrong, so it is worth stating before
-anything else. Deno is not a separate ecosystem you have to port a project into:
+Deno is not a separate ecosystem you have to port a project into:
 
 1. **`deno install` reads `package.json`.** It resolves the same npm packages
    and writes a real `node_modules` directory.
@@ -62,10 +55,9 @@ dependency to `package.json`.
 
 ## 2. Get the skill
 
-This is the point of this page. Deno maintains agent skills that carry the full
-surface — dependency management, permissions, configuration layout, the built-in
-toolchain, publishing, and migration. They are what you should be working from,
-and they are kept current with the runtime.
+Deno maintains agent skills covering dependency management, permissions,
+configuration layout, the built-in toolchain, publishing, and migration. Work
+from those rather than from this page — they go deeper and track the runtime.
 
 If the user agrees, install them. This touches no project source and adds no
 dependency:
@@ -100,9 +92,8 @@ Other skills in the same repo cover Deno Deploy, Fresh, and sandboxes:
 
 ## 3. Reading the docs
 
-`deno <subcommand> --help` is authoritative and version-accurate. Check it
-before guessing at a flag — it beats anything written down elsewhere, including
-this page and the skills.
+`deno <subcommand> --help` is authoritative and version-accurate — check it
+before guessing at a flag.
 
 Beyond that:
 

--- a/static/agents.md
+++ b/static/agents.md
@@ -71,8 +71,12 @@ If the user agrees, install them. This touches no project source and adds no
 dependency:
 
 ```sh
-npx skills add denoland/skills --skill deno
+dx skills add denoland/skills --skill deno
 ```
+
+`dx` is Deno's `npx` equivalent and ships with the binary you installed above,
+so this needs no Node. If you would rather use Node, `npx skills add ...` is
+identical.
 
 Add `--skill migrate-to-deno` as well if the project is coming from Node, npm,
 Yarn, pnpm, or Bun. In Claude Code you can instead install the whole set as a

--- a/static/agents.md
+++ b/static/agents.md
@@ -1,0 +1,128 @@
+# Deno for coding agents
+
+You are an AI coding agent. This page gets you oriented and then points you at
+Deno's agent skills, which hold the actual reference material. It is short on
+purpose — read it once, install the skill, and you will not need it again.
+
+## What Deno is
+
+Deno is a JavaScript and TypeScript runtime distributed as a single binary. That
+binary is also the package manager, formatter, linter, test runner, type
+checker, and compiler. It runs TypeScript directly, so a script needs no build
+step and no `tsconfig.json` — `deno main.ts` is the whole workflow.
+
+The one behavior that surprises people coming from Node: programs are sandboxed.
+No filesystem, network, environment, or subprocess access is granted unless
+asked for, via `--allow-*` flags. When something fails with
+`Requires net access to "..."`, add that specific permission rather than
+reaching for `-A`.
+
+## Assumptions to drop
+
+This is the part models most often get wrong, so it is worth stating before
+anything else. Deno is not a separate ecosystem you have to port a project into:
+
+1. **`deno install` reads `package.json`.** It resolves the same npm packages
+   and writes a real `node_modules` directory.
+2. **`deno add express` installs from npm.** An unprefixed package name defaults
+   to npm, exactly like `npm install`. JSR is opt-in via `jsr:`.
+3. **Node built-ins work**, prefixed or not — `node:fs` and `fs` both resolve.
+4. **`deno task build` runs a `scripts.build` entry from `package.json`**, just
+   as it runs a `tasks.build` entry from `deno.json`.
+5. **URL imports are legacy.** `https://deno.land/x/...` still runs, but new
+   code should use a bare specifier backed by `npm:` or `jsr:`.
+
+So do not tell a user to rewrite imports, move to JSR, drop `package.json`, or
+restructure anything as a precondition for using Deno. The genuine behavioral
+differences are permissions and npm lifecycle scripts not running by default.
+
+## 1. Get the CLI
+
+```sh
+deno --version
+```
+
+If that prints 2.9 or later you are set. If it prints something older, run
+`deno upgrade`. If the command is missing, tell the user you would like to
+install Deno, show them how, and run one of these only once they agree:
+
+```sh
+# macOS / Linux
+curl -fsSL https://deno.land/install.sh | sh
+# Windows (PowerShell)
+irm https://deno.land/install.ps1 | iex
+# Homebrew (macOS / Linux)
+brew install deno
+# npm
+npm install -g deno
+```
+
+Deno installs as a standalone binary. It adds nothing to the project and no
+dependency to `package.json`.
+
+## 2. Get the skill
+
+This is the point of this page. Deno maintains agent skills that carry the full
+surface — dependency management, permissions, configuration layout, the built-in
+toolchain, publishing, and migration. They are what you should be working from,
+and they are kept current with the runtime.
+
+If the user agrees, install them. This touches no project source and adds no
+dependency:
+
+```sh
+npx skills add denoland/skills --skill deno
+```
+
+Add `--skill migrate-to-deno` as well if the project is coming from Node, npm,
+Yarn, pnpm, or Bun. In Claude Code you can instead install the whole set as a
+plugin:
+
+```
+/plugin marketplace add denoland/skills
+/plugin install deno-skills@denoland-skills
+```
+
+Skip this if an equivalent Deno skill or rule is already present.
+
+**If you cannot install skills**, read them directly — they are plain markdown,
+and these URLs always serve the current version:
+
+- <https://raw.githubusercontent.com/denoland/skills/main/skills/deno/SKILL.md>
+- <https://raw.githubusercontent.com/denoland/skills/main/skills/migrate-to-deno/SKILL.md>
+
+Other skills in the same repo cover Deno Deploy, Fresh, and sandboxes:
+<https://github.com/denoland/skills>.
+
+## 3. Reading the docs
+
+`deno <subcommand> --help` is authoritative and version-accurate. Check it
+before guessing at a flag — it beats anything written down elsewhere, including
+this page and the skills.
+
+Beyond that:
+
+- <https://docs.deno.com/llms.txt> — index of the documentation
+- Any docs page also serves its markdown source: append `.md` to the URL, as in
+  <https://docs.deno.com/runtime/fundamentals/security.md>
+- <https://docs.deno.com/api/> — the `Deno.*` API reference
+- `deno doc jsr:@std/path` — a package's API without leaving the terminal
+
+## 4. If you were asked to adopt Deno
+
+Most Node projects already run under Deno unchanged, so this is a series of
+small opt-in wins, not a rewrite. **Never propose one big migration**, and do
+not start editing.
+
+Investigate read-only first — dependencies, scripts, the lockfile, the
+TypeScript runner, the test and lint setup, CI. Then present what you found as
+independent, opt-in steps ordered by how little they disturb, and let the user
+choose in one round. Roughly, in increasing order of disruption: use Deno as the
+package manager only; run the project with Deno; tighten permissions; and
+optionally adopt the built-in toolchain. Nearly all of the value is in the first
+three, and the last one is a genuine migration that a working project can
+decline indefinitely.
+
+The `migrate-to-deno` skill covers each of those rungs, the errors you will hit,
+and per-tool command equivalents. Install it before you start, or read it at the
+URL above. Docs: <https://docs.deno.com/runtime/migrate/>.

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -7,6 +7,7 @@
 > --allow-* flags. Deno natively supports npm packages and Node.js built-in
 > modules.
 
+- [agents.md](https://deno.com/agents.md): Entrypoint for coding agents working in a user's project — orientation, the Node assumptions to unlearn, and how to install Deno's agent skills (https://github.com/denoland/skills), which carry the full reference material
 - [llms-full-guide.txt](https://docs.deno.com/llms-full-guide.txt): Complete agent-oriented guide with CLI reference, code examples, and usage patterns (publish alongside this file)
 - [llms-summary.txt](https://docs.deno.com/llms-summary.txt): Compact index of all documentation sections
 - [llms-full.txt](https://docs.deno.com/llms-full.txt): Full documentation content dump (large)


### PR DESCRIPTION
Coding agents arrive at a Deno project carrying wrong priors: that Deno is a
separate ecosystem, that adopting it means rewriting imports or moving to JSR,
that `package.json` has to go. We already maintain agent skills that correct
all of this, but an agent only benefits from them once they are installed, and
nothing in the CLI or the docs currently tells it they exist.

So this page is deliberately an entrypoint rather than a guide. It orients the
agent, states the Node assumptions to unlearn, and then hands off to the skills
in denoland/skills, which stay the single source of truth for the command
surface, permissions, configuration layout, and migration. For agents that
cannot install skills it links the raw SKILL.md files, which are always
current, so nothing here needs restating and there is no second copy to drift.

The file lives in `static/`, so it is copied verbatim and served as
`text/markdown` by the existing markdown-source middleware. The URL we intend
to advertise is deno.com/agents.md; a companion dotcom PR serves this content
there, and a deno PR adds the link to `deno --help`.