### PR TITLE
docs: remove merch footer link, update node test viewer URLs

### DIFF
--- a/_components/Footer.tsx
+++ b/_components/Footer.tsx
@@ -146,10 +146,6 @@ const data = [
         href: "https://deno.com/blog",
       },
       {
-        label: "Merch",
-        href: "https://merch.deno.com/",
-      },
-      {
         label: "Privacy Policy",
         href: "/deploy/privacy_policy",
       },

--- a/api/node/index.md
+++ b/api/node/index.md
@@ -136,8 +136,8 @@ Node compatibility is an ongoing project. Most core Node.js APIs are supported
 with high fidelity. For detailed compatibility information:
 
 - View our [Node.js compatibility guide](/runtime/reference/node_apis/)
-- Check [Node.js test results](https://node-test-viewer.deno.dev/) for specific
-  test coverage
+- Check [Node.js test results](https://node-test-viewer.deno.deno.net/) for
+  specific test coverage
 - [Report compatibility issues](https://github.com/denoland/deno/issues) on
   GitHub
 

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -58,8 +58,8 @@ need a local `node_modules` directory, and a few tools assume npm's exact
 on-disk layout. The sections below cover each of those cases.
 
 You can track the current state at
-[node-test-viewer.deno.dev](https://node-test-viewer.deno.dev/) and browse the
-[list of supported Node.js APIs](/runtime/reference/node_apis/).
+[node-test-viewer.deno.deno.net](https://node-test-viewer.deno.deno.net/) and
+browse the [list of supported Node.js APIs](/runtime/reference/node_apis/).
 
 ## Using npm packages
 

--- a/runtime/fundamentals/node.md
+++ b/runtime/fundamentals/node.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-07-30
 title: "Node and npm Compatibility"
 description: "Guide to using Node.js modules and npm packages in Deno. Learn about compatibility features, importing npm packages, and differences between Node.js and Deno environments."
 oldUrl:

--- a/runtime/reference/node_apis.md
+++ b/runtime/reference/node_apis.md
@@ -181,4 +181,4 @@ db.setAuthorizer((_action, _table) => {
 
 If you're interested in a more detailed view of compatibility on a per-test-case
 basis, you can find a list of both passing and failing Node.js test cases on
-[this page](https://node-test-viewer.deno.dev/).
+[this page](https://node-test-viewer.deno.deno.net/).

--- a/runtime/reference/node_apis.md
+++ b/runtime/reference/node_apis.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-17
+last_modified: 2026-07-30
 title: Node APIs
 description: "A guide to Node.js compatibility in Deno. Learn about supported Node.js built-in modules, global objects, and how to use Node.js packages in Deno projects."
 templateEngine: [vto, md]


### PR DESCRIPTION
* merch.deno.com has been shut down; drop the footer entry
* node-test-viewer.deno.dev links updated to
  https://node-test-viewer.deno.deno.net/