### PR TITLE
docs: correct `deno compile` sloppy imports and pnpm workspace exclusion claims

### DIFF
--- a/runtime/migrate/migrate_from_pnpm.md
+++ b/runtime/migrate/migrate_from_pnpm.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrate from pnpm"
 description: "How to move a pnpm project to Deno: install dependencies from your existing package.json, keep your pinned versions, map pnpm CLI commands to Deno, and let Deno migrate pnpm-workspace.yaml workspaces and catalogs automatically."
-last_modified: 2026-06-25
+last_modified: 2026-08-01
 ---
 
 pnpm is a package manager, not a runtime, so most of what you are "migrating" is
@@ -113,15 +113,16 @@ packages:
 }
 ```
 
-A couple of differences are worth knowing when you read the migrated globs:
+A couple of notes are worth knowing when you read the migrated globs:
 
-- **Depth is explicit in Deno.** `packages/*` matches one level
-  (`packages/foo`), and `packages/*/*` matches two levels. There is no `**`
-  recursive glob; add a `/*` segment per level instead. See
+- **Depth follows the same rules.** `packages/*` matches one level
+  (`packages/foo`), `packages/*/*` matches two levels, and `packages/**` matches
+  every depth below `packages`. See
   [Workspace path patterns](/runtime/fundamentals/workspaces/#workspace-path-patterns).
-- **Exclusions are not supported.** pnpm's `!packages/excluded` negation has no
-  equivalent in the `workspace` field, so list the members you want explicitly
-  rather than excluding a few from a wildcard.
+- **Exclusions carry over.** pnpm's `!packages/excluded` negation means the same
+  thing in the `workspace` field: a `!` pattern drops directories that another
+  pattern would otherwise include. See
+  [Excluding members](/runtime/fundamentals/workspaces/#excluding-members).
 
 ### Catalogs
 

--- a/runtime/reference/cli/unstable_flags.md
+++ b/runtime/reference/cli/unstable_flags.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-02
+last_modified: 2026-08-01
 title: "Unstable feature flags"
 oldUrl:
   - /runtime/tools/unstable_flags/
@@ -111,8 +111,10 @@ Sloppy imports will allow (but print warnings for) the following:
 - Import a directory path, and automatically use `index.js` or `index.ts` as the
   import for that directory
 
-[`deno compile`](/runtime/reference/cli/compile/) does not support sloppy
-imports.
+[`deno compile`](/runtime/reference/cli/compile/) supports sloppy imports too.
+Enable the flag the same way you would for `deno run`, either on the command
+line or in the config file, and the resolved modules are embedded in the output
+binary.
 
 ## `--unstable-unsafe-proto`
 


### PR DESCRIPTION
Two pages state behavior that the current Deno CLI contradicts. Both statements
are the only place in the repo that makes the claim, so this is a prose-only fix
to those two spots.

## 1. `deno compile` does support sloppy imports

`runtime/reference/cli/unstable_flags.md` ends the `--unstable-sloppy-imports`
section with:

> `deno compile` does not support sloppy imports.

Support landed in denoland/deno#27944 (`feat(compile): support sloppy imports`,
merged 2025-02-03, shipped in Deno 2.2) and denoland/deno#34569 added further
test coverage in 2026. Verified against Deno 2.9.2 with the exact `foo.ts` /
`bar.ts` snippet already on that page:

```console
$ deno compile --unstable-sloppy-imports -o fooapp foo.ts
Check foo.ts
Compile foo.ts to fooapp

Embedded Files

fooapp
├── bar.ts (34B)
└── foo.ts (55B)

Files: 1.61KB
Metadata: 1.39KB
Remote modules: 12B

$ ./fooapp
Example
```

The same works through the config file (`{"unstable": ["sloppy-imports"]}`), and
without the flag the compile still fails, so the flag is doing the work. The
behavior predates the previous major release, so per AGENTS.md I did not add a
version marker.

## 2. pnpm workspace exclusions do have an equivalent

`runtime/migrate/migrate_from_pnpm.md` tells readers that Deno's `workspace`
field has no `**` glob and no exclusions:

> **Exclusions are not supported.** pnpm's `!packages/excluded` negation has no
> equivalent in the `workspace` field […]

This contradicts the reference page in this same repo, which documents both
[Recursive matching](https://docs.deno.com/runtime/fundamentals/workspaces/#recursive-matching)
and
[Excluding members](https://docs.deno.com/runtime/fundamentals/workspaces/#excluding-members).
The reference page is the correct one. Verified on Deno 2.9.2 with a scratch
workspace containing `packages/a`, `packages/b`, `packages/excluded`:

- With `"workspace": ["packages/*", "!packages/excluded"]`, importing
  `@acme/a` and `@acme/b` resolves and prints `a b`, while importing
  `@acme/excluded` errors with `Import "@acme/excluded" not a dependency and not
  in import map`.
- Dropping the `!` line makes `@acme/excluded` resolve again, so the negation is
  what excludes it rather than an unrelated failure.
- Listing the `!` pattern before the wildcard behaves identically, so the fixed
  prose does not claim an ordering requirement. (The reference section says "an
  earlier pattern"; observed behavior on 2.9.2 is order-independent, so the
  guide says "another pattern" — the looser reference wording may deserve its
  own follow-up.)
- `"workspace": ["packages/**"]` picks up `packages/foo/sub`, confirming the
  recursive glob works too.

Both bullets sit in the same two-item list, so I corrected them together and
pointed each at the reference section that enumerates the detail, following the
"guides teach, reference enumerates" rule in AGENTS.md.

Note: open PR #3383 touches `migrate_from_pnpm.md` too, but only a link on line
166 — no overlap with this hunk.

## Checks

Per AGENTS.md, run against this branch on macOS with Deno 2.9.2:

- `deno fmt` - clean (`Checked 885 files`, `deno fmt --check` passes)
- `deno test -A frontmatter_test.ts sidebar_test.ts` -
  `ok | 8 passed (646 steps) | 0 failed`
- `deno task check:freshness` -
  `Freshness check passed: all changed pages have a fresh 'last_modified'.`
- `deno task build:light` - `1109 files generated`, no broken links or invalid
  MDX; confirmed the new `#excluding-members` link resolves to a real anchor in
  the built `workspaces` page
- `deno lint` - reports 172 pre-existing problems in TypeScript files; identical
  count on unmodified `main`, and this PR touches only markdown

`last_modified` is bumped to 2026-08-01 on both pages.

## Disclosure

I prepared this change with an AI coding agent (Claude Code). The agent read the
two pages, ran every command quoted above against Deno 2.9.2 on my machine, and
wrote the prose. I have not independently audited the Deno source beyond the
linked upstream PRs and the CLI behavior reproduced above.
