### PR TITLE
docs: add /go/desktop go link

### DIFF
--- a/go.json
+++ b/go.json
@@ -18,7 +18,7 @@
   "config": "/runtime/fundamentals/configuration/",
   "coverage": "/runtime/reference/cli/coverage/",
   "deploy": "/runtime/reference/cli/deploy",
-  "desktop": "/runtime/reference/cli/desktop/",
+  "desktop": "/runtime/desktop/",
   "doc": "/runtime/reference/cli/doc/",
   "env-vars": "/runtime/reference/env_variables",
   "eval": "/runtime/reference/cli/eval/",

--- a/go.json
+++ b/go.json
@@ -18,6 +18,7 @@
   "config": "/runtime/fundamentals/configuration/",
   "coverage": "/runtime/reference/cli/coverage/",
   "deploy": "/runtime/reference/cli/deploy",
+  "desktop": "/runtime/reference/cli/desktop/",
   "doc": "/runtime/reference/cli/doc/",
   "env-vars": "/runtime/reference/env_variables",
   "eval": "/runtime/reference/cli/eval/",


### PR DESCRIPTION
`deno desktop --help` ends with "Read more:
https://docs.deno.com/go/desktop", but that shortlink was never registered, so
it 404s. This adds it to `go.json`, pointing at the desktop apps guide at
`/runtime/desktop/` — the landing page for backends, bindings, auto-update,
DevTools, and distribution.

Fixes denoland/deno#36410