### PR TITLE
Rename working branch

### DIFF
--- a/runtime/desktop/index.md
+++ b/runtime/desktop/index.md
@@ -12,7 +12,9 @@ rendering engine into one bundle per platform.
 :::info Available in Deno 2.9
 
 `deno desktop` is available starting in Deno v2.9.0. If you're on an earlier
-version, [update Deno](/runtime/reference/cli/upgrade/) to use it. You'll also need to add `deno.desktop` to `compilerOptions.lib` in the `deno.json` configuration file.
+version, [update Deno](/runtime/reference/cli/upgrade/) to use it. You'll also
+need to add `deno.desktop` to `compilerOptions.lib` in the `deno.json`
+configuration file.
 
 :::
 

--- a/runtime/desktop/index.md
+++ b/runtime/desktop/index.md
@@ -12,7 +12,7 @@ rendering engine into one bundle per platform.
 :::info Available in Deno 2.9
 
 `deno desktop` is available starting in Deno v2.9.0. If you're on an earlier
-version, [update Deno](/runtime/reference/cli/upgrade/) to use it.
+version, [update Deno](/runtime/reference/cli/upgrade/) to use it. You'll also need to add `deno.desktop` to `compilerOptions.lib` in the `deno.json` configuration file.
 
 :::
 

--- a/runtime/desktop/index.md
+++ b/runtime/desktop/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-27
+last_modified: 2026-08-14
 title: "Desktop apps"
 description: "Build self-contained desktop applications from a Deno project, with framework auto-detection, hot reload, native windowing, auto-update, and cross-platform distribution."
 ---


### PR DESCRIPTION
This change renames working branch from patch-1 to docs/runtime/desktop