### PR TITLE
docs: remove outdated @ts-types directives from Express examples

### DIFF
--- a/examples/scripts/npm.ts
+++ b/examples/scripts/npm.ts
@@ -9,13 +9,13 @@
  * @group Basics
  *
  * Use JavaScript modules from npm in your Deno programs with the "npm:"
- * specifier in your imports.
+ * specifier in your imports. As of Deno 2.2.1, TypeScript types for npm
+ * packages are resolved automatically.
  */
 
 // Import the express module from npm using an npm: prefix, and appending a
 // version number. Dependencies from npm can be configured in an import map
 // also.
-// @ts-types="npm:@types/express@4"
 import express, { type Request, type Response } from "npm:express@4.18.2";
 
 // Create an express server

--- a/examples/tutorials/express.md
+++ b/examples/tutorials/express.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2025-07-14
+last_modified: 2026-08-17
 title: "How to use Express with Deno"
 description: "Step-by-step guide to using Express.js with Deno. Learn how to set up an Express server, configure routes, handle middleware, and build REST APIs using Deno's Node.js compatibility features."
 url: /examples/express_tutorial/

--- a/examples/tutorials/express.md
+++ b/examples/tutorials/express.md
@@ -59,8 +59,11 @@ console.log(`Server is running on http://localhost:8000`);
 
 You may notice that your editor is complaining about the `req` and `res`
 parameters. This is because Deno does not have types for the `express` module.
-To fix this, you can import the Express types file directly from npm. Add the
-following comment to the top of your `main.ts` file:
+**If you're using Deno 2.2.1 or later**, Deno automatically resolves the types
+from `@types/express`—you don't need to add anything.
+
+**For earlier versions of Deno (pre-2.2.1)**, you needed to manually add a
+`@ts-types` comment:
 
 ```ts
 // @ts-types="npm:@types/express@4.17.15"


### PR DESCRIPTION
This PR removes outdated @ts-types directives from Express documentation,
as Deno 2.2.1+ automatically resolves types for npm packages.

Changes:
- examples/tutorials/express.md: Remove @ts-types comment, add note about automatic resolution
- examples/scripts/npm.ts: Remove @ts-types comment

Related: denoland/deno#28185