### PR TITLE
fix(examples): remove broken /main suffix from multi-file URLs

### DIFF
--- a/examples/_components/ExamplePage.tsx
+++ b/examples/_components/ExamplePage.tsx
@@ -9,12 +9,8 @@ export default function ExamplePage({ example }: Props) {
     file.snippets.map((snippet) => snippet.code).join("\n")
   ).join("\n");
   const url =
-    `https://github.com/denoland/docs/blob/main/examples/scripts/${example.name}${
-      example.parsed.files.length > 1 ? "/main" : ""
-    }`;
-  const rawUrl = `https://docs.deno.com/examples/scripts/${example.name}${
-    example.parsed.files.length > 1 ? "/main" : ""
-  }`;
+    `https://github.com/denoland/docs/blob/main/examples/scripts/${example.name}`;
+  const rawUrl = `https://docs.deno.com/examples/scripts/${example.name}`;
 
   return (
     <div data-content="example">


### PR DESCRIPTION
Appending `/main` to the GitHub Edit link and raw source URL for the 7 multi-file examples produced 404s on all 14 URLs. Drops the suffix so the links resolve.

Follow-up (separate PR): the displayed `deno run <url>` command for multi-file examples still can't resolve embedded companion files; that model needs a redesign.