### PR TITLE
fix(examples): repair broken run commands and execution flows

### DIFF
--- a/examples/scripts/child_process_ipc.ts
+++ b/examples/scripts/child_process_ipc.ts
@@ -2,7 +2,7 @@
  * @title Communicate with a child process over IPC
  * @difficulty intermediate
  * @tags cli
- * @run -A <url>
+ * @run -E --allow-run <url>
  * @resource {https://docs.deno.com/api/node/child_process/} Doc: node:child_process
  * @resource {https://docs.deno.com/examples/subprocess_tutorial/} Example: Subprocess spawning
  * @group System
@@ -28,7 +28,7 @@ if (process.send) {
   // In the parent, fork starts the child with an IPC channel attached.
   // Forking this same file keeps the example self-contained; normally the
   // child is its own module.
-  const child = fork(new URL(import.meta.url).pathname);
+  const child = fork(import.meta.url);
 
   // Messages from the child arrive on the message event. They are
   // structured values, not bytes, so no parsing is needed.

--- a/examples/scripts/data_processing.ts
+++ b/examples/scripts/data_processing.ts
@@ -3,7 +3,7 @@
  * @difficulty intermediate
  * @tags cli, deploy
  * @group Data Processing
- * @run -R data-processing.ts
+ * @run <url>
  *
  * Demonstrates using Deno's @std/collections library for processing user data.
  * This example uses pick, omit, and partition to manipulate data structures.

--- a/examples/scripts/deleting_files.ts
+++ b/examples/scripts/deleting_files.ts
@@ -3,6 +3,7 @@
  * @difficulty beginner
  * @tags cli
  * @resource {https://docs.deno.com/api/deno/~/Deno.remove} Doc: Deno.remove
+ * @run -W <url>
  * @group File System
  *
  * Removing files and directories is a common task. Deno has a number of
@@ -15,7 +16,8 @@
 await Deno.remove("example.txt");
 
 // There is also a sync version of the api available
-Deno.removeSync("example.txt");
+await Deno.writeTextFile("toBeRemoved.txt", "noop");
+Deno.removeSync("toBeRemoved.txt");
 
 // If we want to remove a directory, we could do exactly
 // what we did above. If the directory has contents, the

--- a/examples/scripts/deno_bundle.ts
+++ b/examples/scripts/deno_bundle.ts
@@ -2,7 +2,7 @@
  * @title Bundle code with Deno.bundle
  * @difficulty intermediate
  * @tags cli
- * @run --unstable-bundle --allow-read --allow-write --allow-env --allow-net <url>
+ * @run --unstable-bundle -R -W --allow-run <url>
  * @resource {https://docs.deno.com/api/deno/~/Deno.bundle} Doc: Deno.bundle
  * @resource {https://docs.deno.com/runtime/reference/bundling/} Bundling in the Deno manual
  * @group CLI

--- a/examples/scripts/kv_watch.ts
+++ b/examples/scripts/kv_watch.ts
@@ -2,12 +2,12 @@
  * @title Deno KV watch
  * @difficulty intermediate
  * @tags cli, deploy
- * @run --unstable-kv <url>
- * @resource {https://docs.deno.com/deploy/kv/manual} Deno KV user guide
+ * @run --unstable-kv -N <url>
+ * @resource {https://docs.deno.com/deploy/kv/} Deno KV user guide
  * @resource {https://docs.deno.com/api/deno/~/Deno.Kv} Deno KV Runtime API docs
  * @group Unstable APIs
  *
- * <strong>Warning: This is an unstable API that is subject to change or removal at anytime.</strong><br>Deno KV watch allows you to detect changes to your KV database, making
+ * <strong>Warning: This is an unstable API that is subject to change or removal at any time.</strong><br>Deno KV watch allows you to detect changes to your KV database, making
  * it easier to build real-time applications, newsfeeds, chat, and more.
  */
 
@@ -20,21 +20,8 @@ setInterval(() => {
   kv.atomic().sum(["counter"], 1n).commit();
 }, 1000);
 
-// Listen for changes to "counter" and log value.
-for await (const [entry] of kv.watch([["counter"]])) {
-  console.log(`Counter: ${entry.value}`);
-}
-
-// You can also create a stream reader from kv.watch, which returns
-// a ReadableStream.
-const stream = kv.watch([["counter"]]).getReader();
-while (true) {
-  const counter = await stream.read();
-  if (counter.done) {
-    break;
-  }
-  console.log(`Counter: ${counter.value[0].value}`);
-}
+// kv.watch([["counter"]]) also returns a ReadableStream you can consume
+// yourself; here the server below streams each change to clients.
 
 // To use server-sent events, let's create a server that
 // responds with a stream. Each time a change to "counter"

--- a/examples/scripts/tcp_echo_server.ts
+++ b/examples/scripts/tcp_echo_server.ts
@@ -2,7 +2,7 @@
  * @title TCP Echo Server
  * @difficulty beginner
  * @tags cli
- * @run -N echo_server.ts
+ * @run -N <url>
  * @resource {https://docs.deno.com/api/deno/~/Deno.listen} Deno listen API docs
  * @resource {https://docs.deno.com/api/deno/~/Deno.Conn#property_readable} Readable connection API docs
  * @resource {https://docs.deno.com/api/deno/~/Deno.Conn#property_writable} Writable connection docs

--- a/examples/scripts/top_level_await.ts
+++ b/examples/scripts/top_level_await.ts
@@ -3,7 +3,7 @@
  * @difficulty beginner
  * @tags cli
  * @resource {https://docs.deno.com/api/deno/~/Deno.readTextFile} Doc: Deno.readTextFile
- * @run <url>
+ * @run -R <url>
  * @group Basics
  *
  * Example of how top-level await can be used by default in Deno. This example would assist in migrating from NodeJS (CommonJS) to Deno.

--- a/examples/scripts/unix_cat.ts
+++ b/examples/scripts/unix_cat.ts
@@ -2,7 +2,7 @@
  * @title Unix cat
  * @difficulty beginner
  * @tags cli
- * @run -R cat.ts file1 file2
+ * @run -R <url> file1 file2
  * @resource {https://docs.deno.com/api/deno/~/Deno.args} Deno args API docs
  * @resource {https://docs.deno.com/api/deno/~/Deno.open} Deno open API docs
  * @resource {https://docs.deno.com/api/deno/~/Deno.stdout} Deno stdout API docs

--- a/examples/scripts/web_workers.ts
+++ b/examples/scripts/web_workers.ts
@@ -3,7 +3,7 @@
  * @difficulty intermediate
  * @tags cli, web
  * @resource {https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers} MDN: Web Workers
- * @resource {https://docs.deno.com/api/web/~/Worker/} Manual: Workers
+ * @resource {https://docs.deno.com/api/web/~/Worker/} API: Worker
  * @group Advanced
  *
  * Workers are the only way of running javascript off of the main thread.

--- a/examples/scripts/web_workers.ts
+++ b/examples/scripts/web_workers.ts
@@ -3,13 +3,15 @@
  * @difficulty intermediate
  * @tags cli, web
  * @resource {https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers} MDN: Web Workers
- * @resource {https://deno.land/manual@v1.30.0/runtime/workers} Manual: Workers
+ * @resource {https://docs.deno.com/api/web/~/Worker/} Manual: Workers
  * @group Advanced
  *
  * Workers are the only way of running javascript off of the main thread.
  * This can be useful for a wide variety of programs, especially those where
  * there is a lot of computation that needs to be done without blocking a
- * thread.
+ * thread. This example is not runnable on its own; the worker expects
+ * separate `worker.ts` and log files, so it is meant to be read rather than
+ * executed directly.
  */
 
 // File: ./worker.ts


### PR DESCRIPTION
- `tcp_echo_server` / `unix_cat` / `data_processing`: `@run` referenced nonexistent local files; use the `<url>` placeholder
- `deno_bundle`: add `--allow-run` (`Deno.spawnAndWait`) and trim flags to `-R -W`
- `kv_watch`: remove never-terminating watch loops so `Deno.serve` is reached; add `-N`; fix resource link
- `top_level_await`: add `-R`
- `child_process_ipc`: `fork(import.meta.url)` so the example runs from a remote URL; tighten `-A` to `-E --allow-run`
- `deleting_files`: fix duplicate-remove error; add `@run -W`
- `web_workers`: replace dead manual link

All changes pass `deno fmt`, `deno check`, and the examples test suite; `kv_watch` / `child_process_ipc` / `deleting_files` verified at runtime.