### PR TITLE
fix(examples): repair dead links and prose typos

### DIFF
--- a/examples/scripts/broadcast_channel.ts
+++ b/examples/scripts/broadcast_channel.ts
@@ -4,7 +4,7 @@
  * @tags cli, deploy, web
  * @run <url>
  * @resource {https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel} MDN: BroadcastChannel
- * @resource {https://docs.deno.com/deploy/api/runtime-broadcast-channel/} Deno Deploy: BroadcastChannel
+ * @resource {https://docs.deno.com/deploy/classic/api/runtime-broadcast-channel/} Deno Deploy: BroadcastChannel
  * @group Web Standard APIs
  *
  * BroadcastChannel is a named bus. Every channel opened with the same name

--- a/examples/scripts/cron.ts
+++ b/examples/scripts/cron.ts
@@ -3,11 +3,11 @@
  * @difficulty intermediate
  * @tags cli, deploy
  * @run --unstable-cron <url>
- * @resource {https://docs.deno.com/deploy/kv/manual/cron} Deno Cron user guide
+ * @resource {https://docs.deno.com/deploy/reference/cron/} Deno Cron user guide
  * @resource {https://docs.deno.com/api/deno/~/Deno.cron} Deno Cron Runtime API docs
  * @group Unstable APIs
  *
- * <strong>Warning: This is an unstable API that is subject to change or removal at anytime.</strong><br>Deno Cron is a cron task scheduler built into the Deno runtime and works with
+ * <strong>Warning: This is an unstable API that is subject to change or removal at any time.</strong><br>Deno Cron is a cron task scheduler built into the Deno runtime and works with
  * zero configuration on Deno Deploy. There's no overlapping cron executions and
  * has automatic handler retries on exceptions.
  */

--- a/examples/scripts/file_url_path.ts
+++ b/examples/scripts/file_url_path.ts
@@ -4,7 +4,7 @@
  * @tags cli
  * @run <url>
  * @resource {https://jsr.io/@std/path/doc/~/fromFileUrl} Doc: @std/path fromFileUrl
- * @resource {https://docs.deno.com/examples/module_metadata/} Example: Module Metadata
+ * @resource {https://docs.deno.com/examples/module_metadata_tutorial/} Example: Module Metadata
  * @group File System
  *
  * Modules are identified by URLs in Deno, while file system APIs take

--- a/examples/scripts/hello_world.ts
+++ b/examples/scripts/hello_world.ts
@@ -3,8 +3,8 @@
  * @difficulty beginner
  * @tags cli, deploy, web
  * @run <url>
- * @resource {https://docs.deno.com/runtime/manual/getting_started/installation} Deno: Installation
- * @resource {https://docs.deno.com/runtime/manual/getting_started/setup_your_environment} Manual: Set up your environment
+ * @resource {https://docs.deno.com/runtime/getting_started/installation/} Deno: Installation
+ * @resource {https://docs.deno.com/runtime/getting_started/setup_your_environment/} Manual: Set up your environment
  * @group Basics
  * @sortOrder 0
  * The one and only line in this program will print "Hello, World!" to the console. Run this file with the Deno CLI and the run command.

--- a/examples/scripts/hono.ts
+++ b/examples/scripts/hono.ts
@@ -7,7 +7,7 @@
  * @resource {https://hono.dev/docs} Hono documentation
  * @group Network
  *
- * An example of a HTTP server that uses the Hono framework.
+ * An example of an HTTP server that uses the Hono framework.
  */
 
 // Import the Hono framework

--- a/examples/scripts/http_requests.ts
+++ b/examples/scripts/http_requests.ts
@@ -7,7 +7,7 @@
  * @resource {https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream} MDN: ReadableStream
  * @group Network
  *
- * This example demonstrates how to make a HTTP request to a server.
+ * This example demonstrates how to make an HTTP request to a server.
  */
 
 // To make a request to a server, you use the `fetch` API.

--- a/examples/scripts/http_server.ts
+++ b/examples/scripts/http_server.ts
@@ -8,7 +8,7 @@
  * @playground https://dash.deno.com/playground/example-helloworld
  * @group Network
  *
- * An example of a HTTP server that serves a "Hello World" message.
+ * An example of an HTTP server that serves a "Hello World" message.
  */
 
 // HTTP servers need a handler function. This function is called for every

--- a/examples/scripts/http_server_file_upload.ts
+++ b/examples/scripts/http_server_file_upload.ts
@@ -3,9 +3,9 @@
  * @difficulty intermediate
  * @tags cli, deploy
  * @run -N <url>
- * @resource {https://fresh.deno.dev/docs/concepts/forms#-handling-file-uploads} Handling File Uploads in Fresh
- * @resource {/examples/writing-files} Writing files
- * @resource {/examples/http-server-routing} Example: HTTP server: Server routing
+ * @resource {https://usefresh.dev/docs/advanced/forms#handling-file-uploads} Handling File Uploads in Fresh
+ * @resource {/examples/writing_files} Writing files
+ * @resource {/examples/http_server_routing} Example: HTTP server: Server routing
  * @group Network
  *
  * An example HTTP server that provides sending and receiving of a file upload.<br><br>

--- a/examples/scripts/http_server_files.ts
+++ b/examples/scripts/http_server_files.ts
@@ -8,7 +8,7 @@
  * @resource {/examples/http_server} Example: HTTP Server: Hello World
  * @group Network
  *
- * An example of a HTTP server that serves files.
+ * An example of an HTTP server that serves files.
  */
 
 // Import utility methods for serving files with mime types.

--- a/examples/scripts/http_server_oak_crud_middleware_with_sqlite3_db.ts
+++ b/examples/scripts/http_server_oak_crud_middleware_with_sqlite3_db.ts
@@ -7,7 +7,7 @@
  * @resource {https://jsr.io/@db/sqlite} @db/sqlite on JSR
  * @group Network
  *
- * An example of a HTTP server for CRUD routes with oak middleware framework and SQLite3 database. It demonstrates the CRUD (Create, Read, Update and Delete) operations on file-based SQLite Database using HTTP methods (Get, Post, Put, Delete, Options)
+ * An example of an HTTP server for CRUD routes with oak middleware framework and SQLite3 database. It demonstrates the CRUD (Create, Read, Update and Delete) operations on file-based SQLite Database using HTTP methods (Get, Post, Put, Delete, Options)
  */
 import { Application, Router } from "jsr:@oak/oak";
 import { Database } from "jsr:@db/sqlite";

--- a/examples/scripts/http_server_routing.ts
+++ b/examples/scripts/http_server_routing.ts
@@ -8,7 +8,7 @@
  * @playground https://dash.deno.com/playground/example-routing
  * @group Network
  *
- * An example of a HTTP server that handles requests with different responses
+ * An example of an HTTP server that handles requests with different responses
  * based on the incoming URL.
  */
 

--- a/examples/scripts/http_server_tls.ts
+++ b/examples/scripts/http_server_tls.ts
@@ -3,7 +3,7 @@
  * @difficulty intermediate
  * @tags cli
  * @run -N -R <url>
- * @resource {https://docs.deno.com/api/deno/~/Deno.ServeTlsOptions} Doc: Deno.ServeTlsOptions
+ * @resource {https://docs.deno.com/api/deno/~/Deno.serve} Doc: Deno.serve
  * @resource {/examples/http_server} Example: HTTP Server: Hello world
  * @group Network
  *

--- a/examples/scripts/http_server_websocket.ts
+++ b/examples/scripts/http_server_websocket.ts
@@ -7,7 +7,7 @@
  * @resource {https://developer.mozilla.org/en-US/docs/Web/API/WebSocket} MDN: WebSocket
  * @group Network
  *
- * An example of a HTTP server that handles websocket requests.
+ * An example of an HTTP server that handles websocket requests.
  */
 
 // To start the server on the default port, call `Deno.serve` with the handler.

--- a/examples/scripts/import_export.ts
+++ b/examples/scripts/import_export.ts
@@ -2,8 +2,8 @@
  * @title Importing & exporting
  * @difficulty beginner
  * @tags cli, deploy
- * @resource {/examples/dependency-management} Example: Dependency Management
- * @resource {https://docs.deno.com/runtime/manual/basics/modules} Manual: Modules
+ * @resource {https://docs.deno.com/runtime/fundamentals/modules/} Example: Dependency Management
+ * @resource {https://docs.deno.com/runtime/fundamentals/modules/} Manual: Modules
  * @group Basics
  *
  * To build composable programs, it is necessary to be able to import and export
@@ -26,7 +26,7 @@ export const baz = "baz";
 
 // File: ./main.ts
 
-// To import things from files other files can use the import keyword.
+// To import things from other files, you can use the import keyword.
 import { sayHello } from "./util.ts";
 sayHello("World");
 

--- a/examples/scripts/import_export.ts
+++ b/examples/scripts/import_export.ts
@@ -2,8 +2,7 @@
  * @title Importing & exporting
  * @difficulty beginner
  * @tags cli, deploy
- * @resource {https://docs.deno.com/runtime/fundamentals/modules/} Example: Dependency Management
- * @resource {https://docs.deno.com/runtime/fundamentals/modules/} Manual: Modules
+ * @resource {https://docs.deno.com/runtime/fundamentals/modules/} Doc: Modules and dependencies
  * @group Basics
  *
  * To build composable programs, it is necessary to be able to import and export

--- a/examples/scripts/importing_text.ts
+++ b/examples/scripts/importing_text.ts
@@ -9,7 +9,7 @@
  * Text files can be imported in JS and TS files using the `import` keyword.
  * This makes including static data in a library much easier.
  *
- * Stable as of Deno 2.8 — no flag required. (Binary `bytes` imports are still
+ * Stable as of Deno 2.8: no flag required. (Binary `bytes` imports are still
  * experimental and require `--unstable-raw-imports`.)
  */
 
@@ -32,5 +32,5 @@ console.log(text2);
 2025-07-01 08:15:12 - Program started
 2025-07-01 08:16:45 - Uploading file: summary.xls
 2025-07-01 08:17:33 - Error: Invalid file format (xls)
-2025-07-01 08:18:01 - Uploadinf file failed: summary.xls
+2025-07-01 08:18:01 - Uploading file failed: summary.xls
 */

--- a/examples/scripts/kv.ts
+++ b/examples/scripts/kv.ts
@@ -3,11 +3,11 @@
  * @difficulty intermediate
  * @tags cli, deploy
  * @run --unstable-kv <url>
- * @resource {https://docs.deno.com/deploy/kv/manual} Deno KV user guide
+ * @resource {https://docs.deno.com/deploy/kv/} Deno KV user guide
  * @resource {https://docs.deno.com/api/deno/~/Deno.Kv} Deno KV Runtime API docs
  * @group Unstable APIs
  *
- * <strong>Warning: This is an unstable API that is subject to change or removal at anytime.</strong><br>Deno KV is a key/value database built in to the Deno runtime, and works with
+ * <strong>Warning: This is an unstable API that is subject to change or removal at any time.</strong><br>Deno KV is a key/value database built in to the Deno runtime, and works with
  * zero configuration on Deno Deploy. It's great for use cases that require fast
  * reads and don't require the query flexibility of a SQL database.
  */

--- a/examples/scripts/node_built_in.ts
+++ b/examples/scripts/node_built_in.ts
@@ -4,7 +4,7 @@
  * @tags cli, deploy
  * @run -E <url>
  * @resource {https://docs.deno.com/runtime/fundamentals/node} Node.js / npm support in Deno
- * @resource {https://docs.deno.com/runtime/fundamentals/node/#node_specifiers} node: specifiers
+ * @resource {https://docs.deno.com/runtime/fundamentals/node/#use-a-node-built-in-module} node: specifiers
  * @group Basics
  *
  * Deno supports most built-in Node.js modules natively - you can include them

--- a/examples/scripts/parsing_serializing_csv.ts
+++ b/examples/scripts/parsing_serializing_csv.ts
@@ -3,7 +3,7 @@
  * @difficulty beginner
  * @tags cli, deploy, web
  * @run -R <url>
- * @resource {/examples/import_export} Example: Importing & Exporting
+ * @resource {https://jsr.io/@std/csv} std/csv
  * @resource {https://datatracker.ietf.org/doc/html/rfc4180} Spec: CSV
  * @group Encoding
  *

--- a/examples/scripts/parsing_serializing_toml.ts
+++ b/examples/scripts/parsing_serializing_toml.ts
@@ -3,7 +3,7 @@
  * @difficulty beginner
  * @tags cli, deploy, web
  * @run <url>
- * @resource {/examples/import_export} Example: Importing & Exporting
+ * @resource {https://jsr.io/@std/toml} std/toml
  * @resource {https://toml.io} Spec: TOML
  * @group Encoding
  *
@@ -11,7 +11,7 @@
  */
 import { parse, stringify } from "jsr:@std/toml";
 
-// To parse a TOML string, you can use the the standard library's TOML
+// To parse a TOML string, you can use the standard library's TOML
 // parse function. The value is returned as a JavaScript object.
 const text = `
 int = 1_000_000

--- a/examples/scripts/parsing_serializing_yaml.ts
+++ b/examples/scripts/parsing_serializing_yaml.ts
@@ -3,7 +3,7 @@
  * @difficulty beginner
  * @tags cli, deploy, web
  * @run <url>
- * @resource {/examples/import_export} Example: Importing & Exporting
+ * @resource {https://jsr.io/@std/yaml} std/yaml
  * @resource {https://yaml.org} Spec: YAML
  * @group Encoding
  *
@@ -11,7 +11,7 @@
  */
 import { parse, stringify } from "jsr:@std/yaml";
 
-// To parse a YAML string, you can use the the standard library's YAML
+// To parse a YAML string, you can use the standard library's YAML
 // parse function. The value is returned as a JavaScript object.
 const text = `
 foo: bar
@@ -31,7 +31,7 @@ const obj = {
 };
 const yaml = stringify(obj);
 console.log(yaml);
-//- hello: word
+//- hello: world
 //- numbers:
 //-   - 1
 //-   - 2

--- a/examples/scripts/queues.ts
+++ b/examples/scripts/queues.ts
@@ -3,11 +3,11 @@
  * @difficulty intermediate
  * @tags cli, deploy
  * @run --unstable-kv <url>
- * @resource {https://docs.deno.com/deploy/class9c/queues/} Deno Queues user guide
+ * @resource {https://docs.deno.com/deploy/classic/queues/} Deno Queues user guide
  * @resource {https://docs.deno.com/api/deno/~/Deno.Kv} Deno Queues Runtime API docs
  * @group Unstable APIs
  *
- * <strong>Warning: This is an unstable API that is subject to change or removal at anytime.</strong><br>Deno Queues, built on Deno KV, allow you to offload parts of your application
+ * <strong>Warning: This is an unstable API that is subject to change or removal at any time.</strong><br>Deno Queues, built on Deno KV, allow you to offload parts of your application
  * or schedule work for the future to run asynchronously. It's an easy way to add
  * scalable background processing to your project.
  */

--- a/examples/scripts/quic.ts
+++ b/examples/scripts/quic.ts
@@ -7,7 +7,7 @@
  * @resource {https://docs.deno.com/api/deno/~/Deno.connectQuic} Doc: Deno.connectQuic
  * @group Network
  *
- * <strong>Warning: This is an unstable API that is subject to change or removal at anytime.</strong><br>QUIC is the transport protocol underneath HTTP/3. It runs over UDP,
+ * <strong>Warning: This is an unstable API that is subject to change or removal at any time.</strong><br>QUIC is the transport protocol underneath HTTP/3. It runs over UDP,
  * always encrypts with TLS, connects faster than TCP plus TLS, and one
  * connection carries many independent streams with no head-of-line
  * blocking. This example starts a QUIC server and client in one process

--- a/examples/scripts/sandbox_evaluating_javascript.ts
+++ b/examples/scripts/sandbox_evaluating_javascript.ts
@@ -9,8 +9,8 @@
  * You can evaluate JavaScript code in a sandbox using the `eval` function.
  *
  * Calling `sandbox.deno.eval()` lets you run arbitrary JavaScript snippets
- * directly inside the sandbox’s Deno runtime without writing files or shelling * out. This is useful when you want to prototype logic, run small
- * computations, or  inspect the sandbox environment itself quickly. Use it for
+ * directly inside the sandbox’s Deno runtime without writing files or shelling out. This is useful when you want to prototype logic, run small
+ * computations, or inspect the sandbox environment itself quickly. Use it for
  * dynamic scripts or exploratory debugging where creating a full module would
  * be overkill.
  */

--- a/examples/scripts/spy_functions.ts
+++ b/examples/scripts/spy_functions.ts
@@ -7,7 +7,7 @@
  * @resource {https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html} Typescript docs for `using` keyword
  * @group Testing
  *
- * A function spy allow us to assert that a function was called with the correct arguments and a specific number of times.
+ * A function spy allows us to assert that a function was called with the correct arguments and a specific number of times.
  * This snippet demonstrates how to spy on a function using a mock function.
  */
 

--- a/examples/scripts/timing_safe_comparison.ts
+++ b/examples/scripts/timing_safe_comparison.ts
@@ -4,7 +4,7 @@
  * @tags cli, deploy
  * @run <url>
  * @resource {https://jsr.io/@std/crypto/doc/timing-safe-equal} Doc: timingSafeEqual
- * @resource {https://codahale.com/a-lesson-in-timing-attacks/} A lesson in timing attacks
+ * @resource {https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html} OWASP: Authentication Cheat Sheet (timing attacks)
  * @group Cryptography
  *
  * An ordinary comparison like a === b returns as soon as the first byte

--- a/examples/scripts/udp_connector.ts
+++ b/examples/scripts/udp_connector.ts
@@ -7,7 +7,7 @@
  * @resource {/examples/udp_listener} Example: UDP Listener
  * @group Unstable APIs
  *
- * <strong>Warning: This is an unstable API that is subject to change or removal at anytime.</strong><br>An example of writing a 'ping' message to a UDP server on localhost.
+ * <strong>Warning: This is an unstable API that is subject to change or removal at any time.</strong><br>An example of writing a 'ping' message to a UDP server on localhost.
  */
 
 // Instantiate an instance of text encoder to write to the UDP stream.

--- a/examples/scripts/udp_listener.ts
+++ b/examples/scripts/udp_listener.ts
@@ -7,7 +7,7 @@
  * @resource {/examples/udp_connector} Example: UDP Connector
  * @group Unstable APIs
  *
- * <strong>Warning: This is an unstable API that is subject to change or removal at anytime.</strong><br>An example of a UDP listener on localhost that will log the message
+ * <strong>Warning: This is an unstable API that is subject to change or removal at any time.</strong><br>An example of a UDP listener on localhost that will log the message
  * if written to and close the connection if connected to.
  */
 

--- a/examples/scripts/web_transport.ts
+++ b/examples/scripts/web_transport.ts
@@ -7,7 +7,7 @@
  * @resource {https://docs.deno.com/api/deno/~/Deno.upgradeWebTransport} Doc: Deno.upgradeWebTransport
  * @group Network
  *
- * <strong>Warning: This is an unstable API that is subject to change or removal at anytime.</strong><br>WebTransport is the web platform's API for low-latency, multiplexed
+ * <strong>Warning: This is an unstable API that is subject to change or removal at any time.</strong><br>WebTransport is the web platform's API for low-latency, multiplexed
  * communication over HTTP/3. Browsers can use it where raw QUIC and TCP
  * sockets are unavailable, and unlike WebSockets it offers many independent
  * streams plus unreliable datagrams. Deno provides both the client API and,

--- a/examples/scripts/websocket_stream.ts
+++ b/examples/scripts/websocket_stream.ts
@@ -7,7 +7,7 @@
  * @resource {https://docs.deno.com/examples/websocket/} Example: Outbound WebSockets
  * @group Network
  *
- * <strong>Warning: This is an unstable API that is subject to change or removal at anytime.</strong><br>WebSocketStream is a promise-based alternative to the event-based
+ * <strong>Warning: This is an unstable API that is subject to change or removal at any time.</strong><br>WebSocketStream is a promise-based alternative to the event-based
  * WebSocket API. It exposes the connection as a pair of web streams, which
  * brings backpressure and async iteration to WebSocket code and composes
  * with everything else that speaks ReadableStream and WritableStream.

--- a/examples/scripts/write_benchmarks.ts
+++ b/examples/scripts/write_benchmarks.ts
@@ -3,7 +3,7 @@
  * @difficulty beginner
  * @tags cli
  * @run deno bench <url>
- * @resource {https://docs.deno.com/runtime/fundamentals/testing/#benchmarking} Doc: Benchmarking
+ * @resource {https://docs.deno.com/runtime/reference/cli/bench/} Doc: Benchmarking
  * @resource {https://docs.deno.com/api/deno/~/Deno.bench} Doc: Deno.bench
  * @group CLI
  *


### PR DESCRIPTION
- Fix 5 dead resource links: `class9c` typo, `module_metadata`, `Deno.ServeTlsOptions`, fresh.deno.dev, codahale.com
- Canonicalize stale doc URLs (`runtime/manual/...`, `deploy/kv/manual`, `/examples/*` kebab-case, etc.)
- Fix prose typos: `an HTTP`, `at any time`, `allows us`, `Uploading`, `use the`, YAML output example, em-dash -> colon

Replaced links verified live (HTTP 200); `deno fmt` and `deno check` pass.