### PR TITLE
fix(examples): register orphan examples in catalog

### DIFF
--- a/examples/_data.ts
+++ b/examples/_data.ts
@@ -377,6 +377,12 @@ export const items = [
     category: "File system",
   },
   {
+    title: "Checking for directory existence",
+    href: "/examples/checking_directory_existence/",
+    type: "example",
+    category: "File system",
+  },
+  {
     title: "Moving/Renaming files",
     href: "/examples/moving_renaming_files/",
     type: "example",
@@ -739,6 +745,12 @@ export const items = [
   {
     title: "AES Encryption and Decryption",
     href: "/examples/aes_encryption/",
+    type: "example",
+    category: "Cryptography",
+  },
+  {
+    title: "Shamir's Secret Sharing",
+    href: "/examples/sss/",
     type: "example",
     category: "Cryptography",
   },

--- a/examples/scripts/sss.ts
+++ b/examples/scripts/sss.ts
@@ -1,5 +1,5 @@
 /**
- * @title Shamir's Secret Sharing Implementation
+ * @title Shamir's Secret Sharing
  * @difficulty intermediate
  * @tags cli
  * @run <url>


### PR DESCRIPTION
Register `Shamir's Secret Sharing` and `Checking for directory existence` in the examples catalog so their pages appear in the sidebar/landing page. Also aligns `sss.ts` `@title` with its catalog label.