### PR TITLE
chore: format sveltekit tutorial for deno 2.9 fmt

### DIFF
--- a/examples/tutorials/sveltekit.md
+++ b/examples/tutorials/sveltekit.md
@@ -422,54 +422,54 @@ pagination and search inputs added to the UI!
 
 ```html
 <script lang="ts">
-	import { goto, invalidate, replaceState } from '$app/navigation';
-	import { page as sveltePage } from '$app/state';
+import { goto, invalidate, replaceState } from "$app/navigation";
+import { page as sveltePage } from "$app/state";
 
-	let { data } = $props();
+let { data } = $props();
 
-	// We have added a function to change the page number
-	// based on the search params and the value passed in.
-	function handlePageChange(page: number) {
-		const params = new URLSearchParams(sveltePage.url.searchParams);
+// We have added a function to change the page number
+// based on the search params and the value passed in.
+function handlePageChange(page: number) {
+  const params = new URLSearchParams(sveltePage.url.searchParams);
 
-		params.set('page', page.toString());
-		goto(`?${params.toString()}`, { keepFocus: true });
-	}
+  params.set("page", page.toString());
+  goto(`?${params.toString()}`, { keepFocus: true });
+}
 
-	// This function checks if there is a q in the form below
-	// and if so search by it or remove the search params
-	// and either way reset the current page.
-	function handleQueryChange(
-		event: SubmitEvent & {
-			currentTarget: EventTarget & HTMLFormElement;
-		}
-	) {
-		event.preventDefault();
-		const q = event.currentTarget.q.value;
-		const params = new URLSearchParams(sveltePage.url.searchParams);
+// This function checks if there is a q in the form below
+// and if so search by it or remove the search params
+// and either way reset the current page.
+function handleQueryChange(
+  event: SubmitEvent & {
+    currentTarget: EventTarget & HTMLFormElement;
+  },
+) {
+  event.preventDefault();
+  const q = event.currentTarget.q.value;
+  const params = new URLSearchParams(sveltePage.url.searchParams);
 
-		if (q) {
-			params.set('q', q);
-			params.set('page', '1');
-			goto(`?${params.toString()}`, { keepFocus: true });
-		} else {
-			params.delete('q');
-			params.delete('page');
-			goto(`?${params.toString()}`, { keepFocus: true });
-		}
-	}
+  if (q) {
+    params.set("q", q);
+    params.set("page", "1");
+    goto(`?${params.toString()}`, { keepFocus: true });
+  } else {
+    params.delete("q");
+    params.delete("page");
+    goto(`?${params.toString()}`, { keepFocus: true });
+  }
+}
 </script>
 
 <form onsubmit={handleQueryChange} class="mb-4">
-	<label class="mb-2 block text-sm font-bold" for="q">Search</label>
-	<input
-		class="focus:shadow-outline w-ful form-input appearance-none rounded border px-3 py-2 leading-tight text-gray-700 shadow focus:outline-none"
-		type="text"
-		id="q"
-		name="q"
-		placeholder="Search"
-		defaultValue={data.q ?? ''}
-	/>
+  <label class="mb-2 block text-sm font-bold" for="q">Search</label>
+  <input
+    class="focus:shadow-outline w-ful form-input appearance-none rounded border px-3 py-2 leading-tight text-gray-700 shadow focus:outline-none"
+    type="text"
+    id="q"
+    name="q"
+    placeholder="Search"
+    defaultValue={data.q ?? ''}
+  />
 </form>
 
 <section class="mb-4 grid max-h-96 grid-cols-2 gap-4 overflow-y-auto">
@@ -485,7 +485,7 @@ pagination and search inputs added to the UI!
 <!-- pagination -->
 {#if data.totalPages > 0}
 	<div class="mb-4 flex justify-center">
-		<div class="grid w-1/2 grid-flow-col gap-2">
+  <div class="grid w-1/2 grid-flow-col gap-2">
 			{@render pageButton(data.page - 1, data.page === 1, false, '←')}
 
 			{#each { length: data.totalPages }, page}
@@ -500,18 +500,18 @@ pagination and search inputs added to the UI!
 
 			{@render pageButton(data.page + 1, data.page === data.totalPages, false, '→')}
 		</div>
-	</div>
+</div>
 {/if}
 
 {#snippet pageButton(page: number, disabled: boolean, active: boolean, child: string | number)}
 	<button
-		class="rounded border p-4"
-		class:disabled
-		{disabled}
-		class:active
-		type="button"
-		onclick={() => handlePageChange(page)}
-	>
+  class="rounded border p-4"
+  class:disabled
+  {disabled}
+  class:active
+  type="button"
+  onclick={() => handlePageChange(page)}
+>
 		{child}
 	</button>
 {/snippet}

--- a/examples/tutorials/sveltekit.md
+++ b/examples/tutorials/sveltekit.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-06-25
+last_modified: 2026-08-17
 title: "Building a SvelteKit app with sv and Deno"
 url: /examples/sveltekit_tutorial/
 ---


### PR DESCRIPTION
The `lint and link check` CI job fails on main: deno v2.9.5's `deno fmt` reformats a code block in `examples/tutorials/sveltekit.md` (tab indentation and quote style), but the file hasn't been updated since the rule change. Formatting-only change; fixes the pre-existing CI failure that blocks every PR.