### PR TITLE
docs: add deno upgrade tip to getting started page

### DIFF
--- a/runtime/index.md
+++ b/runtime/index.md
@@ -1,5 +1,5 @@
 ---
-last_modified: 2026-07-29
+last_modified: 2026-08-21
 title: "Get started with Deno"
 description: "Install Deno and build your first project: why Deno, install, create, run, test, add a dependency, and use the built-in toolchain. No build step, no config."
 pagination_next: /runtime/getting_started/installation/

--- a/runtime/index.md
+++ b/runtime/index.md
@@ -85,6 +85,20 @@ deno --version
 See [Installation](/runtime/getting_started/installation/) for package managers,
 Docker, and other options.
 
+:::tip Keep Deno up to date
+
+Deno is constantly improving with new features and fixes. You can upgrade to the
+latest version at any time with:
+
+```sh
+deno upgrade
+```
+
+See [`deno upgrade`](/runtime/reference/cli/upgrade/) for channels (stable, LTS,
+canary), version pinning, and more.
+
+:::
+
 ## Create a project
 
 Scaffold a new project with [`deno init`](/runtime/reference/cli/init/):


### PR DESCRIPTION
Adds a visible tip about deno upgrade right after the install section on the main "Get started with Deno" page ([index.md](https://docs.deno.com/runtime/#install-deno)).

The upgrade reference page ([upgrade.md](https://docs.deno.com/runtime/reference/cli/upgrade/)) already existed with full details on channels, version pinning, and delta updates — but there was no mention of it on the landing page where most new users start. This makes the upgrade path discoverable earlier.

<img width="1914" height="965" alt="Screenshot 2026-08-21 at 00 29 19" src="https://github.com/user-attachments/assets/3a9d6af8-ae9f-417d-849e-f35e9d81b626" />

Addresses feedback from #3425 